### PR TITLE
Minimal change to suppress -Wformat-truncation

### DIFF
--- a/src/bluesim/bs_prim_mod_reg.h
+++ b/src/bluesim/bs_prim_mod_reg.h
@@ -1004,15 +1004,15 @@ class MOD_CReg : public Module
     vcd_write_scope_start(sim_hdl, inst_name);
     for (unsigned int i = 0; i < ports; i++) {
       // start with Q_OUT, so that the alias' number is reused
-      snprintf(buf, 8, "Q_OUT_%u", i);
+      snprintf(buf, 8, "Q_OUT_%c", '0'+i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, bits);
 
-      snprintf(buf, 8, "EN_%u", i);
+      snprintf(buf, 8, "EN_%c", '0'+i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, 1);
 
-      snprintf(buf, 8, "D_IN_%u", i);
+      snprintf(buf, 8, "D_IN_%c", '0'+i);
       vcd_set_clock(sim_hdl, num, __clk_handle_0);
       vcd_write_def(sim_hdl, num++, buf, bits);
     }


### PR DESCRIPTION
The compilers are smart enough to see that this might be a problem but
not to know that the range of the value is limited.

Bluesim/bs_prim_mod_reg.h: In member function 'unsigned int MOD_mkValidVectorTest_Dut::dump_VCD_defs(unsigned int)':
Bluesim/bs_prim_mod_reg.h:1007:31: warning: '%u' directive output may be truncated writing between 1 and 10 bytes into a region of size 2 [-Wformat-truncation=]
 1007 |       snprintf(buf, 8, "Q_OUT_%u", i);
      |                               ^~
In member function 'unsigned int MOD_CReg<T>::dump_VCD_defs(unsigned int) [with T = unsigned char]',
    inlined from 'unsigned int MOD_mkValidVectorTest_Dut::dump_VCD_defs(unsigned int)' at bazel-out/k8-opt/bin/rtl/lib/test/mkValidVectorTest_Dut.cxx:193:39:
Bluesim/bs_prim_mod_reg.h:1007:24: note: directive argument in the range [0, 4294967294]
 1007 |       snprintf(buf, 8, "Q_OUT_%u", i);
      |                        ^~~~~~~~~~
Bluesim/bs_prim_mod_reg.h:1007:15: note: 'snprintf' output between 8 and 17 bytes into a destination of size 8
 1007 |       snprintf(buf, 8, "Q_OUT_%u", i);
      |       ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~

A much better fix would be to switch to real C++, but it's a battle
for another day.
