### PR TITLE
lsp: parse qualified parenthesized operators

### DIFF
--- a/util/lsp/bs-parser/src/Language/Bluespec/Parser.hs
+++ b/util/lsp/bs-parser/src/Language/Bluespec/Parser.hs
@@ -2011,7 +2011,8 @@ pBitSelect = do
 -- Includes do/if/case/let/lambda so they can be function arguments.
 pAExpr' :: Parser LExpr
 pAExpr' = choice
-  [ pVar
+  [ try pQualifiedParenOp
+  , pVar
   , pCon
   , pLitExpr
   , pValueOf
@@ -2039,6 +2040,25 @@ pCon :: Parser LExpr
 pCon = do
   c <- qualConId
   pure $ Located (locSpan c) (ECon c)
+
+-- | Parse a qualified parenthesized operator used as a value.
+-- Handles: Module.(op), e.g. Vector.(!!)
+pQualifiedParenOp :: Parser LExpr
+pQualifiedParenOp = do
+  m <- conId
+  void $ punct Lex.PunctDot
+  void $ punct Lex.PunctLParen
+  op <- MP.token test expected
+  end <- punct Lex.PunctRParen
+  let qid = Located (mergeSpans (locSpan m) (spanOf end)) $
+        QualIdent (Just $ ModuleId $ identText $ locVal m) (locVal op)
+  pure $ Located (locSpan qid) (EVar qid)
+  where
+    test t = case Lex.tokKind t of
+      Lex.TokVarSym op -> Just $ Located (Lex.tokSpan t) (VarId op)
+      Lex.TokConSym op -> Just $ Located (Lex.tokSpan t) (ConId op)
+      _ -> Nothing
+    expected = Set.singleton $ Label $ NE.fromList "operator"
 
 -- | Parse a literal.
 pLitExpr :: Parser LExpr

--- a/util/lsp/bs-parser/src/Language/Bluespec/Pretty.hs
+++ b/util/lsp/bs-parser/src/Language/Bluespec/Pretty.hs
@@ -624,8 +624,13 @@ prettyQualIdent qid = case qualModule qid of
 -- wrap it in parentheses to make it a valid expression.
 prettyQualIdentAsExpr :: QualIdent -> Doc ann
 prettyQualIdentAsExpr qid
-  | isOperatorIdent (qualIdent qid) = parens (prettyQualIdent qid)
+  | isOperatorIdent ident =
+      case qualModule qid of
+        Nothing -> parens (prettyIdent ident)
+        Just m -> prettyModuleId m <> ".(" <> prettyIdent ident <> ")"
   | otherwise = prettyQualIdent qid
+  where
+    ident = qualIdent qid
 
 -- | Check if an identifier is an operator (starts with an operator character).
 isOperatorIdent :: Ident -> Bool

--- a/util/lsp/bs-parser/test/Spec.hs
+++ b/util/lsp/bs-parser/test/Spec.hs
@@ -208,6 +208,24 @@ main = do
           Left err -> expectationFailure $ show err
           Right _ -> pure ()
 
+      it "parses qualified parenthesized symbolic operators" $ do
+        let inputs =
+              [ "Vector.(!!) v i"
+              , "M.(+) x y"
+              , "M.(<=) x y"
+              , "M.(++) xs ys"
+              ]
+        mapM_ (\input -> case parseExpr "<test>" input of
+          Left err -> expectationFailure $ show err
+          Right _ -> pure ()) inputs
+
+      it "pretty-prints qualified parenthesized symbolic operators" $ do
+        case parseExpr "<test>" "Vector.(!!) v i" of
+          Left err -> expectationFailure $ show err
+          Right expr ->
+            renderPretty 80 (prettyExpr (locVal expr))
+              `shouldBe` "Vector.(!!) v i"
+
     describe "BSV parser — unit tests" $ do
       it "parses empty package" $ do
         parseBSV "package Foo;\nendpackage" `shouldSucceed`


### PR DESCRIPTION
Fixes #5.

Adds Classic parser support for qualified parenthesized symbolic operators such as `Vector.(!!)` and preserves that spelling when pretty-printing.