### PR TITLE
Support BH unary minus and unbased literals in LSP

### DIFF
--- a/util/lsp/bs-lsp/cabal.project
+++ b/util/lsp/bs-lsp/cabal.project
@@ -5,3 +5,6 @@ packages: .
 allow-newer:
   lsp:*,
   lsp-types:*
+
+constraints:
+  some < 1.1

--- a/util/lsp/bs-lsp/src/Language/Bluespec/LSP/Diagnostics.hs
+++ b/util/lsp/bs-lsp/src/Language/Bluespec/LSP/Diagnostics.hs
@@ -130,6 +130,7 @@ formatToken tok = case Lex.tokKind tok of
   Lex.TokQVarSym m s -> "'" <> m <> "." <> s <> "'"
   Lex.TokQConSym m s -> "'" <> m <> "." <> s <> "'"
   Lex.TokInteger n _ -> T.pack (show n)
+  Lex.TokUnbasedUnsized b -> if b then "'1" else "'0"
   Lex.TokFloat f -> T.pack (show f)
   Lex.TokChar c -> "'" <> T.singleton c <> "'"
   Lex.TokString s -> "\"" <> s <> "\""

--- a/util/lsp/bs-parser/src/Language/Bluespec/BSV/Parser.hs
+++ b/util/lsp/bs-parser/src/Language/Bluespec/BSV/Parser.hs
@@ -234,6 +234,7 @@ namedOp name = void $ tok $ \case
 intLit :: Parser (Located Literal)
 intLit = tok $ \case
   Lex.TokInteger n mfmt -> Just $ LitInt n (fmap (\(w,f) -> (w, cvtFmt f)) mfmt)
+  Lex.TokUnbasedUnsized b -> Just $ LitInt (if b then 1 else 0) Nothing
   _ -> Nothing
   where
     cvtFmt Lex.IntDec' = IntDec

--- a/util/lsp/bs-parser/src/Language/Bluespec/Lexer.hs
+++ b/util/lsp/bs-parser/src/Language/Bluespec/Lexer.hs
@@ -65,6 +65,7 @@ data TokenKind
 
   -- Literals
   | TokInteger !Integer !(Maybe (Int, IntFormat'))  -- ^ Integer literal
+  | TokUnbasedUnsized !Bool                         -- ^ '0 / '1 unbased unsized bit literal
   | TokFloat !Double                                -- ^ Float literal
   | TokChar !Char                                   -- ^ Character literal
   | TokString !Text                                 -- ^ String literal
@@ -446,7 +447,7 @@ operator = do
 
 -- | Lex a numeric literal.
 numericLit :: Lexer TokenKind
-numericLit = sized <|> tickPrefixed <|> unsized
+numericLit = sized <|> tickPrefixed <|> unbasedUnsized <|> unsized
   where
     -- Sized bit literals: 8'hFF, 4'b1010
     sized = try $ do
@@ -464,6 +465,14 @@ numericLit = sized <|> tickPrefixed <|> unsized
         , (char 'o' <|> char 'O') *> (TokInteger <$> octNum <*> pure (Just (0, IntOct')))
         , (char 'd' <|> char 'D') *> (TokInteger <$> L.decimal <*> pure (Just (0, IntDec')))
         ]
+
+    -- Unbased unsized bit literals: '0 (all zeros) and '1 (all ones).
+    -- Do not consume character literals like '0' and '1'.
+    unbasedUnsized = try $ do
+      void $ char '\''
+      bit <- oneOf ("01" :: String)
+      notFollowedBy $ char '\''
+      pure $ TokUnbasedUnsized (bit == '1')
 
     sizedFormat =
           (char 'h' *> ((,IntHex') <$> hexNum))

--- a/util/lsp/bs-parser/src/Language/Bluespec/Parser.hs
+++ b/util/lsp/bs-parser/src/Language/Bluespec/Parser.hs
@@ -246,6 +246,7 @@ intLit = MP.token test expected
   where
     test t = case Lex.tokKind t of
       Lex.TokInteger n mFmt -> Just $ Located (Lex.tokSpan t) (LitInt n (cvtFmt <$> mFmt))
+      Lex.TokUnbasedUnsized b -> Just $ Located (Lex.tokSpan t) (LitInt (if b then 1 else 0) Nothing)
       _ -> Nothing
     cvtFmt (w, Lex.IntDec') = (w, IntDec)
     cvtFmt (w, Lex.IntHex') = (w, IntHex)
@@ -579,6 +580,7 @@ pPragmaContent = do
       Lex.TokConSym s -> s
       Lex.TokString s -> "\"" <> s <> "\""
       Lex.TokInteger n _ -> T.pack (show n)
+      Lex.TokUnbasedUnsized b -> if b then "'1" else "'0"
       Lex.TokKeyword kw -> T.pack (show kw)
       Lex.TokPunct p -> punctToText p
       _ -> ""
@@ -1358,12 +1360,33 @@ pExpr = do
 -- | Parse expression with operators.
 pExprOps :: Parser LExpr
 pExprOps = do
-  e <- pLExpr
+  e <- pUnaryExpr
   ops <- many $ do
     op <- anyOp
-    e2 <- pLExpr
+    e2 <- pUnaryExpr
     pure (op, e2)
   pure $ resolveOps bluespecFixities e ops
+
+-- | Parse Classic/BH prefix unary operators.
+pUnaryExpr :: Parser LExpr
+pUnaryExpr = choice
+  [ pfx "-" ENeg
+  , pLExpr
+  ]
+  where
+    pfx nm f = do
+      op <- varSymNamed nm
+      e <- pUnaryExpr
+      pure $ Located (mergeSpans (locSpan op) (locSpan e)) (f e)
+
+-- | Match a specific variable operator symbol.
+varSymNamed :: Text -> Parser (Located Text)
+varSymNamed name = MP.token test expected
+  where
+    test t = case Lex.tokKind t of
+      Lex.TokVarSym op | op == name -> Just $ Located (Lex.tokSpan t) op
+      _ -> Nothing
+    expected = Set.singleton $ Label $ NE.fromList $ T.unpack name
 
 -- | Parse a left-hand expression (lambda, let, if, case, etc.).
 pLExpr :: Parser LExpr

--- a/util/lsp/bs-parser/test/Spec.hs
+++ b/util/lsp/bs-parser/test/Spec.hs
@@ -109,6 +109,15 @@ main = do
         let Right toks = tokenize "<test>" "42 0xFF 8'b10101010"
         length (filter (not . isEof) toks) `shouldBe` 3
 
+      it "lexes unbased unsized literals without stealing character literals" $ do
+        let Right toks = tokenize "<test>" "'0 '1 '0' '1'"
+        map tokKind (filter (not . isEof) toks) `shouldBe`
+          [ TokUnbasedUnsized False
+          , TokUnbasedUnsized True
+          , TokChar '0'
+          , TokChar '1'
+          ]
+
       it "lexes string literals" $ do
         let Right toks = tokenize "<test>" "\"hello\" 'a'"
         length (filter (not . isEof) toks) `shouldBe` 2
@@ -225,6 +234,34 @@ main = do
           Right expr ->
             renderPretty 80 (prettyExpr (locVal expr))
               `shouldBe` "Vector.(!!) v i"
+
+      it "parses Classic unary minus expressions" $ do
+        let inputs =
+              [ "foo = -x"
+              , "foo = -1"
+              , "foo = -(x + y)"
+              , "foo = 5 - (-2)"
+              ]
+        mapM_ (\body -> case parsePackage "<test>" ("package Foo where\n" <> body <> "\n") of
+          Left err -> expectationFailure $ show err
+          Right pkg -> length (pkgDefns pkg) `shouldBe` 1) inputs
+
+      it "parses Classic unbased unsized literals" $ do
+        let inputs =
+              [ "foo = '0"
+              , "foo = '1"
+              , "foo '0 = '1"
+              , "foo = case x of\n  '0 -> False\n  '1 -> True\n"
+              ]
+        mapM_ (\body -> case parsePackage "<test>" ("package Foo where\n" <> body <> "\n") of
+          Left err -> expectationFailure $ show err
+          Right pkg -> length (pkgDefns pkg) `shouldBe` 1) inputs
+
+      it "continues to parse tick-prefixed and character literals" $ do
+        let inputs = ["foo = 'hFF", "foo = 'b1010", "foo = 'o77", "foo = 'd42", "foo = '0'"]
+        mapM_ (\body -> case parsePackage "<test>" ("package Foo where\n" <> body <> "\n") of
+          Left err -> expectationFailure $ show err
+          Right pkg -> length (pkgDefns pkg) `shouldBe` 1) inputs
 
     describe "BSV parser — unit tests" $ do
       it "parses empty package" $ do


### PR DESCRIPTION
Adds LSP parser support for Classic/BH unary minus and bare unbased unsized bit literals (`'0` / `'1`).

Pins the LSP build to a compatible `some` dependency version so `lsp-types-2.4.0.0` builds reliably.