### PR TITLE
Fix docgen highlighting for unbased literals

### DIFF
--- a/util/docgen/src/Language/Bluespec/DocGen/Highlight.hs
+++ b/util/docgen/src/Language/Bluespec/DocGen/Highlight.hs
@@ -70,6 +70,7 @@ classify = \case
   TokPragmaContent t -> (Just "cm",  t)
   -- Literals: source text not stored in token; use a generic label
   TokInteger _ _     -> (Just "lit", "0")
+  TokUnbasedUnsized b -> (Just "lit", if b then "'1" else "'0")
   TokFloat _         -> (Just "lit", "0.0")
   TokChar _          -> (Just "lit", "'?'")
 


### PR DESCRIPTION
Adds docgen highlighting support for bare unbased unsized bit literals (`'0` / `'1`) so the broader `bbt` build handles the new parser token.