### PR TITLE
typecheck: sharing-preserving substitution, VPred fv cache, ATF trims

### DIFF
--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -16,6 +16,7 @@ import Prelude hiding ((<>))
 #endif
 
 import Data.List(union, genericSplitAt, genericLength)
+import Data.Maybe(fromMaybe, isNothing)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -53,7 +54,15 @@ instance PVPrint t => PVPrint (Qual t) where
     pvPrint d p (ps :=> t) = pvparen (p>0) $ pvPrint d 0 t <+> pvPreds d (map removePredPositions ps)
 
 instance Types t => Types (Qual t) where
-    apSub s (ps :=> t) = apSub s ps :=> apSub s t
+    apSub s q = fromMaybe q (apSubM s q)
+    -- local changed-detection: contexts are short, so forcing the
+    -- element results here is cheap and buys whole-value sharing
+    apSubM s (ps :=> t) =
+        let mps = map (apSubM s) ps
+            mt  = apSubM s t
+        in  if all isNothing mps && isNothing mt
+            then Nothing
+            else Just (zipWith fromMaybe ps mps :=> fromMaybe t mt)
     tv      (ps :=> t) = tv ps `union` tv t
 
 instance (NFData a) => NFData (Qual a) where
@@ -148,11 +157,19 @@ instance PVPrint PredWithPositions where
 
 instance Types PredWithPositions where
     -- the ancestors are deliberately not substituted (see above)
-    apSub s (PredWithPositions p poss anc) = PredWithPositions (apSub s p) poss anc
+    apSub s pwp = fromMaybe pwp (apSubM s pwp)
+    apSubM s (PredWithPositions p poss anc) =
+        case apSubM s p of
+          Nothing -> Nothing
+          Just p' -> Just (PredWithPositions p' poss anc)
     tv      (PredWithPositions p poss anc) = tv p
 
 instance NFData PredWithPositions where
-    rnf (PredWithPositions p poss anc) = rnf3 p poss anc
+    -- ancestors are diagnostic-only (consumed by ContextErrors on the
+    -- error path) and are excluded from substitution and comparison;
+    -- excluding them from forcing too keeps phase-boundary deepseqs
+    -- from walking every residual predicate's reduction chain
+    rnf (PredWithPositions p poss _) = rnf2 p poss
 
 -----
 
@@ -167,7 +184,15 @@ instance PVPrint Pred where
     pvPrint d p (IsIn c ts) = pvparen (p>0) $ pvpId d (typeclassId $ name c) <> pvParameterTypes d ts
 
 instance Types Pred where
-    apSub s (IsIn c ts) = IsIn c $ expandSyn <$> apSub s ts
+    apSub s p = fromMaybe p (apSubM s p)
+    -- expandSyn re-normalizes only when the substitution actually
+    -- introduced new structure; an untouched pred is already expanded
+    -- (preds are synonym-expanded at construction)
+    apSubM s (IsIn c ts) =
+        let mts = map (apSubM s) ts
+        in  if all isNothing mts
+            then Nothing
+            else Just (IsIn c (expandSyn <$> zipWith fromMaybe ts mts))
     tv      (IsIn c ts) = tv ts
 
 instance NFData Pred where

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -8,6 +8,7 @@ module Subst(
              {- removeFromSubst, -}
              apSubstToSubst,
              getSubstDomain, getSubstRange, sizeSubst,
+             substDomainDisjoint,
              chkSubstOrder
              ) where
 
@@ -16,6 +17,7 @@ import CType
 import Type
 import Util(fromJustOrErr)
 import Data.List(nub,union)
+import Data.Maybe(fromMaybe, isNothing)
 import Position
 
 import qualified Data.Set as Set
@@ -198,31 +200,56 @@ mergeAgreements s1 s2 = fj $ merge diff1 diff2
 
 class Types t where
   apSub :: Subst -> t -> t
+  apSub s t = fromMaybe t (apSubM s t)
+  -- Change-tracking substitution: Nothing means the substitution
+  -- provably left the value untouched, so the caller keeps the
+  -- original object (preserving sharing and skipping any rebuild or
+  -- re-normalization).  Instances without a hand-written apSubM get
+  -- the conservative "always changed" default; new hot-path consumers
+  -- should define apSubM and derive apSub from it.
+  apSubM :: Subst -> t -> Maybe t
+  apSubM s t = Just (apSub s t)
   tv    :: t -> [TyVar]
+  {-# MINIMAL (apSub | apSubM), tv #-}
 
 instance Types Type where
-  apSub (S seo _) v@(TVar u) =
+  apSub s t = fromMaybe t (apSubM s t)
+  apSubM s _ | isNullSubst s = Nothing
+  apSubM (S seo _) t0 = go t0
+    where
+      go v@(TVar u) =
         case slookup u seo of
         Just t  ->
             case t of
-            (TGen _ _) -> t -- (kind (TGen _ _)) errors out -- don't check kind
+            (TGen _ _) -> Just t -- (kind (TGen _ _)) errors out -- don't check kind
             _ -> if isKVar (kind v) || kind t == kind v
-                 then t
+                 then Just t
                  else internalError ("Subst.Type.apSub: bad kind: " ++
                                      ppString t ++ "::" ++ ppString (kind t) ++
                                      "@" ++ ppString (getPosition t) ++
                                      " / " ++ ppString v ++ "::" ++
                                      ppString (kind v) ++ "@" ++
                                      ppString (getPosition v))
-        Nothing -> v
-  apSub s (TAp l r) = normTAp (apSub s l) (apSub s r)
-  apSub s t         = t
+        Nothing -> Nothing
+      go (TAp l r) =
+        case (go l, go r) of
+          (Nothing, Nothing) -> Nothing
+          (ml, mr) -> Just (normTAp (fromMaybe l ml) (fromMaybe r mr))
+      go _ = Nothing
 
   tv (TVar u)  = [u]
   tv (TAp l r) = tv l `union` tv r
   tv t         = []
 
 instance Types a => Types [a] where
+  -- NB deliberately lazy (and spine-rebuilding): consumers routinely
+  -- apply substitutions to long lists (assumption environments,
+  -- residual predicate sets) and force only part of the result, so an
+  -- eager changed-detection over the whole list here is a large
+  -- pessimization.  Element-level sharing still comes from each
+  -- element's own apSub.  Short-list containers that want whole-value
+  -- sharing (Pred's class args, Qual's context) do their own local
+  -- detection.
   apSub s ts = map (apSub s) ts
   tv ts      = nub (concatMap tv ts)
 
@@ -239,6 +266,16 @@ sizeSubst (S eo _) = (Map.size eo)
 
 getSubstDomain :: Subst -> [TyVar]
 getSubstDomain (S eo _) = (Map.keys eo)
+
+-- True when the substitution touches none of the given variables --
+-- the test behind the "return the value unchanged" fast paths.
+-- Probed per variable: the argument sets (predicate free vars) are
+-- tiny, while the substitution can hold thousands of entries, so
+-- materializing its key set (O(size) per call) must be avoided.
+substDomainDisjoint :: Subst -> Set.Set TyVar -> Bool
+substDomainDisjoint (S eo _) fvs
+  | Map.null eo = True
+  | otherwise   = not (any (`Map.member` eo) (Set.toAscList fvs))
 
 getSubstRange :: Subst -> [TyVar]
 getSubstRange (S eo _ ) = concat (map tv (Map.elems eo))

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -195,9 +195,7 @@ split_rs s' rs  = partition affected_pred rs
           -- should only be a few since classes are small
           -- and the substitution comes from a single reducePred
           -- or joinCtx (at the end)
-    where changed_tv = getSubstDomain s'
-          affected_var v = v `elem` changed_tv
-          affected_pred r = any affected_var (tv r)
+    where affected_pred r = not (substDomainDisjoint s' (vpredFVs r))
 
 satisfy' :: DVS -> [EPred] -> [VPred] -> TI SolveResult
 satisfy' dvs es ps = do
@@ -283,20 +281,20 @@ expTConPred (VPred e (PredWithPositions (IsIn c ts) pos anc)) = do
         return (VPred e (PredWithPositions (IsIn c ts') pos anc): concat vss)
 
 -- Build a class predicate from a fully-applied ATF.  Given the ATF's
--- class, param indices, target index, the ATF arguments, and the type
--- to place at the target position, fills in fresh vars for any class
--- params not covered by the ATF.
-mkATFClassPred :: String -> Type -> Id -> [Int] -> Int -> [Type] -> Type
+-- class (already looked up by the caller), param indices, target
+-- index, the ATF arguments, and the type to place at the target
+-- position, fills in fresh vars for any class params not covered by
+-- the ATF.  Fresh vars are minted only for the uncovered positions.
+mkATFClassPred :: String -> Type -> Class -> [Int] -> Int -> [Type] -> Type
                -> TI (Class, [Type])
-mkATFClassPred tag posType clsId pIdxs tIdx atfArgs targetType = do
-    cls <- findCls (CTypeclass clsId)
+mkATFClassPred tag posType cls pIdxs tIdx atfArgs targetType = do
     let nParams = length (csig cls)
-    freshVars <- mapM (\tv -> newTVar tag (kind tv) posType) (csig cls)
-    let classArgs = [ if idx == tIdx then targetType
-                      else case elemIndex idx pIdxs of
-                            Just j  -> atfArgs !! j
-                            Nothing -> freshVars !! idx
-                    | idx <- [0..nParams-1] ]
+        mkArg idx | idx == tIdx = return targetType
+                  | otherwise =
+            case elemIndex idx pIdxs of
+              Just j  -> return (atfArgs !! j)
+              Nothing -> newTVar tag (kind (csig cls !! idx)) posType
+    classArgs <- mapM mkArg [0..nParams-1]
     return (cls, classArgs)
 
 -- Compute the transitive incoherence closure on a fully-merged SolvedBinds,
@@ -345,7 +343,7 @@ expTFun t0
     length as == length pIdxs = do
         cls <- findCls (CTypeclass clsId)
         v <- newTVar "expTFun" (kind (csig cls !! tIdx)) t0
-        (_, classArgs) <- mkATFClassPred "expTFun" t0 clsId pIdxs tIdx as v
+        (_, classArgs) <- mkATFClassPred "expTFun" t0 cls pIdxs tIdx as v
         vps <- mkVPred (getPosition t0) $ mkPredWithPositions [] (IsIn cls classArgs)
         return (vps, v)
 -- eliminate the identity type constructor.
@@ -1416,8 +1414,9 @@ tryATFClassPred atfType targetType = do
       TCon (TyCon _ _ (TIatf { atf_class_id = clsId, atf_param_idxs = pIdxs
                               , atf_target_idx = tIdx }))
         | length atfArgs == length pIdxs -> do
+        cls0 <- findCls (CTypeclass clsId)
         (cls, classArgs) <- mkATFClassPred "tryATFClassPred" atfType
-                              clsId pIdxs tIdx atfArgs targetType
+                              cls0 pIdxs tIdx atfArgs targetType
         return $ Just (IsIn cls classArgs)
       _ -> return Nothing
 
@@ -2042,7 +2041,7 @@ expandTCons (orig_qs :=> orig_t) =
                 cls <- findCls (CTypeclass clsId)
                 v <- newTVar "expandTCons" (kind (csig cls !! tIdx)) t0
                 (_, classArgs) <- mkATFClassPred "expandTCons" t0
-                                    clsId pIdxs tIdx as v
+                                    cls pIdxs tIdx as v
                 let p = PredWithPositions (IsIn cls classArgs) [] []
                 return ([p], v)
       exp (TAp t1 t2) = do (ps1, t1') <- exp t1

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -507,8 +507,9 @@ tiExpr as td (CHasType (CAny {}) qt@(CQType [_] nt)) | nt == noType = do
     case qual_type of
       [PredWithPositions p poss _] :=> _ -> do
           -- poss is probably a list of only one position
-          VPred i pwp <- mkVPredFromPred poss p
-          let pwp' = addPredPositions pwp poss
+          vp <- mkVPredFromPred poss p
+          let VPred i pwp = vp
+              pwp' = addPredPositions pwp poss
           return ([VPred i pwp'], CVar i)
       _ -> internalError ("tiExpr: unexpected mkQualType result")
 

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 module TIMonad(
         TI,
         apSubTI,
@@ -9,7 +10,7 @@ module TIMonad(
         getSubst, clearSubst, extSubst, updSubst,
         newTVar, newTVarId, isNewTVar, newDict, newVar,
         freshInst,
-        VPred(..), getVPredPositions, expandSynVPred,
+        VPred(VPred), vpredFVs, getVPredPositions, expandSynVPred,
         EPred(..), Infer2, CheckT, TaskCheckT,
         getBoundTVs, getTopBoundTVs, addBoundTVs, popBoundTVs,
         getExplPreds, getTopExplPreds, addExplPreds, popExplPreds, mkEPred,
@@ -52,6 +53,7 @@ import Control.Monad.State(State, StateT, runState, runStateT,
                            lift, gets, get, put, modify)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.Maybe(fromMaybe)
 import Util(headOrErr)
 
 -------
@@ -459,12 +461,39 @@ freshInst msg x (Forall ks qt@(_ :=> t)) = do
 ------
 
 -- VPred is an unsolved predicate (at least in satisfy, satMany, sat...)
-data VPred = VPred Id PredWithPositions
-    deriving (Show)
+--
+-- The extra (lazy) field caches the predicate's free type variables as
+-- a set, so the solver's substitution application can skip untouched
+-- predicates with one set-disjointness test instead of walking the
+-- predicate (and split_rs can test "affected by substitution" the same
+-- way).  The bidirectional pattern synonym keeps every existing
+-- construction and match site source-compatible; the cache is rebuilt
+-- automatically whenever a new VPred is constructed.  Order-sensitive
+-- consumers keep using tv (traversal order); the set is only ever used
+-- for membership tests.
+data VPred = VPred_ Id PredWithPositions (S.Set TyVar)
+
+pattern VPred :: Id -> PredWithPositions -> VPred
+pattern VPred i p <- VPred_ i p _
+  where VPred i p = VPred_ i p (S.fromList (tv p))
+{-# COMPLETE VPred #-}
+
+vpredFVs :: VPred -> S.Set TyVar
+vpredFVs (VPred_ _ _ fvs) = fvs
+
+instance Show VPred where
+    showsPrec d (VPred_ i p _) = showParen (d > 10) $
+        showString "VPred " . showsPrec 11 i .
+        showString " " . showsPrec 11 p
 
 instance Types VPred where
-    apSub s (VPred i p) = VPred i (apSub s p)
-    tv (VPred _ p) = tv p
+    apSub s vp = fromMaybe vp (apSubM s vp)
+    apSubM s vp@(VPred_ i p fvs)
+      | substDomainDisjoint s fvs = Nothing
+      | otherwise = case apSubM s p of
+                      Nothing -> Nothing
+                      Just p' -> Just (VPred i p')
+    tv (VPred_ _ p _) = tv p
 
 instance PPrint VPred where
 -- note that the colon (:) that gets printed here is NOT a list cons!


### PR DESCRIPTION
Fix 6/11 of the rc8 performance-regression series (stacked on #31).

## What regressed
The associated-type-function and coherent-commit typechecker work (`add2e991`/`925b29be` lineage) — the report's `typecheck`/`wrapper_typecheck` CPU+memory regressions on proviso-heavy targets.

## Fix
Maybe-based sharing-preserving substitution on `Type` (untouched values returned as-is), a free-variable set cache on `VPred` so `split_rs` probes without walking predicates, and ATF resolution trims.

## Benchmark row (proviso-heavy shape: 1200 registers of depth-5 Vector nests; 3 interleaved pairs, medians)
- typecheck **71.4 → 44.0s (0.62×)**; total −38%; **alloc −25%**; residency flat.
- The largest single row in the series' matrix. Output gate: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT)_