### PR TITLE
build: default the RTS to a large chunked nursery, no idle GC

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -191,10 +191,17 @@ GHCTMP = '-tmpdir $(TMPDIR)'
 # which inflates peak stack usage by roughly an order of magnitude
 # on the perf regression suite.
 # If you modify this, also update rts_opts in ../vendor/htcl/haskell.c
+# -A64m: a large allocation area is the single biggest GC lever for
+# bsc's allocation-heavy batch workload (the default nursery forces
+# very frequent minor GCs; GC was ~22% of total CPU on the matx perf
+# suite).  -n4m chunks the nursery for cache behavior; -I0 disables
+# idle GC, which only triggered spurious collections in a short-lived
+# batch process.  Callers can still override per invocation via +RTS
+# (the binary is built with -rtsopts).
 ifeq ($(BSC_BUILD),PROF)
-RTSFLAGS = "-with-rtsopts=-H256m -K256m -i1"
+RTSFLAGS = "-with-rtsopts=-H256m -K256m -A64m -n4m -I0"
 else
-RTSFLAGS = "-with-rtsopts=-H256m -K10m -i1"
+RTSFLAGS = "-with-rtsopts=-H256m -K10m -A64m -n4m -I0"
 endif
 FVIA ?= -fasm
 GHCFLAGS = \

--- a/src/vendor/htcl/haskell.c
+++ b/src/vendor/htcl/haskell.c
@@ -13,7 +13,7 @@ htcl_initHaskellRTS(int *argc, char **argv[])
   RtsConfig conf = defaultRtsConfig;
 
   conf.rts_opts_enabled = RtsOptsAll;
-  conf.rts_opts = "-H256m -K10m -i1";
+  conf.rts_opts = "-H256m -K10m -A64m -n4m -I0"; /* keep in sync with RTSFLAGS in src/comp/Makefile */
   hs_init_ghc(argc, argv, conf);
 
   // register haskell exit function, finish


### PR DESCRIPTION
Fix 8/11 of the rc8 performance-regression series (stacked on the symtab PR).

## Motivation
GC was ~22% of total CPU across the matx fleet; the baked `-H256m` leaves the allocation area at GHC's small default once the heap grows. This bakes `-A64m -n4m -I0` into the default rtsopts (still overridable per invocation).

## Benchmark rows — workload-dependent, both directions disclosed
- Churn-heavy shape (2000-register module): typecheck **79.6 → 61.3s (0.77×)**, **max residency 2.09 → 1.63GB (−22%)**.
- Residency-heavy proviso shape: typecheck 36.8 → 43.9s (**1.19×** — a real loss on this profile).

Context: matx's bazel rules pass explicit per-action RTS flags (`-H1G -A64m -n4m -I0`), so the baked default governs bare invocations only. Recommendation from the matrix: `-A64m -n4m` is clearly good; `-I0` and nursery sizing are the tunables if the fleet profile shifts. Output gate: `.bo` identical under pinned library (flags-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT)_