### PR TITLE
typecheck: establish synonym-expansion at pred construction

### DIFF
--- a/doc/perf/rc8-regression-fix-plan.md
+++ b/doc/perf/rc8-regression-fix-plan.md
@@ -257,3 +257,42 @@ that specific change.
 | WS7.5 gated deepseq | `rtl.controller.TAControllerScalarUnit` (crosses most phases); guard: residency must not rise on `ComparePostSrbInstr` | total CPU; peak residency A/B |
 | WS7.8 IExpr interning/eqE | `rtl.tile.belts.vpu.test.VpuBkwdBeltTest` (transform 389s); `rtl.controller.test.TAInstrAssemblerCosimTest` (transform 151s) | transform phase |
 | WS8 elab/codegen split | full `//rtl/...` build critical path (bazel --profile); per-action: `rtl.bs_sv_validation.ComparePostSrbInstr` (verilog+writeVerilog ≈179s leaves critical path); grid chain `rtl.tile.TileGrid` → `emulation.gate_count.tile.TileGrid_16x32` | bazel critical path length; byte-identity of .v |
+
+## Implementation status (2026-07-16, branch claude/bsc-18772-perf-regressions-9vi622)
+
+Landed (bsc, this branch — one commit per item):
+- WS2a/2b verilog SYB gating; WS3.1 O(1) interned-IType rnf; WS1 scheduler
+  (ctx-tuple memo + unconditional-use shortcut, Yices+STP); WS3.2 LiftDicts
+  pre-conversion pool; WS3.3 fixup redirect hoist; WS4 (findCls hoist, fewer
+  ATF tyvars, VPred fv cache for split_rs, sharing-preserving Type apSubM,
+  lazy PredAncestor forcing); WS5 leaf-scoped instance comparisons; WS7.5
+  gated phase-boundary deepseq; WS7.1 RTS defaults (-A64m -n4m -I0);
+  WS8 verilog-codegen-stage merge + new -elab-only flag.
+
+Landed (matx, same branch name): +RTS -n4m -I0 on bsc actions;
+--//rtl/bluespec:split_codegen (default off) splitting BscV into
+BscVElab/BscVCodegen.
+
+Measured on the #19126 2000-register repro vs stock build-20260715-1:
+verilog phase notrip 0.37s -> 0.14s, trip 1.03s -> 0.57s (G0132 renames
+intact); typecheck at parity (45s); split flow .v byte-identical modulo
+timestamp comment.  Scheduler micro-bench (150 rules, shared register,
+distinct predicates): schedule 0.54s -> 0.32s.
+
+Learned the hard way (do not re-attempt without new evidence):
+- The Types [a] instance must stay LAZY: eager whole-list changed-detection
+  doubled typecheck on long assumption lists.
+- substDomainDisjoint must probe per-variable; Map.keysSet per call is
+  O(subst size) and also doubled typecheck.
+- apSub on a Pred doubles as an expandSyn normalization pass: skipping the
+  rebuild when the substitution changed nothing broke instance resolution
+  (T0031 in bsc.typechecker/PrintfATS.bs).  Whole-pred sharing therefore
+  requires first making construction sites expandSyn-normalized — future
+  work; per-element type sharing is kept.
+
+Remaining backlog (in priority order): WS7.3/7.4 Builder-based .v/.bo
+output; WS4 Tier-2 ATF constraint-synthesis memo; WS5 Tier-2 symtab
+trie/overlap reuse across rebuilds; WS7.6/7.8 IExpr fv-cache/interning;
+full 2131-action A/B via tools/bench_bs_master.sh on real build hosts
+(publish a prerelease with .github/workflows/matx-prerelease.yml), then the
+matx pin bump, memory_multiplier 8->4 revert, and split_codegen default-on.

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -1152,7 +1152,9 @@ getCls errh mi src_pkg iks r incoh ps ik vs fds ats ifs msort qts =
           Class {
             name = CTypeclass qi,
             csig = tvs,
-            super = [ (c', IsIn (mustFindClass r c') (map conv ts)) | CPred c' ts <- ps ],
+            -- superclass preds are synonym-expanded for the same reason
+            -- as instance heads (see mkInst)
+            super = [ (c', IsIn (mustFindClass r c') (map (expandSyn . conv) ts)) | CPred c' ts <- ps ],
             genInsts  = genInsts',
             getInsts  = getInsts',
             tyConOf = TyCon qi (Just k)

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -185,14 +185,13 @@ instance PVPrint Pred where
 
 instance Types Pred where
     apSub s p = fromMaybe p (apSubM s p)
-    -- expandSyn re-normalizes only when the substitution actually
-    -- introduced new structure; an untouched pred is already expanded
-    -- (preds are synonym-expanded at construction)
+    -- apSub on a Pred doubles as a synonym-expansion pass (callers rely
+    -- on it normalizing types the substitution did not touch), so a
+    -- rebuild always runs expandSyn over every argument; the sharing
+    -- win here is per-element, via each type's own apSubM.
     apSubM s (IsIn c ts) =
         let mts = map (apSubM s) ts
-        in  if all isNothing mts
-            then Nothing
-            else Just (IsIn c (expandSyn <$> zipWith fromMaybe ts mts))
+        in  Just (IsIn c (expandSyn <$> zipWith fromMaybe ts mts))
     tv      (IsIn c ts) = tv ts
 
 instance NFData Pred where

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -5,7 +5,7 @@ module Pred(
             removePredPositions, getPredPositions, addPredPositions, mkPredWithPositions,
             PredAncestor(..),
             getPredAncestors, mkPredAncestor, addPredAncestors,
-            expandSyn, predToType, qualToType, mkInst,
+            expandSyn, expandSynPred, predToType, qualToType, mkInst,
             Instantiate(..),
             predToCPred, qualTypeToCQType,
             pureInputPositions,
@@ -289,7 +289,17 @@ instance NFData Inst where
     rnf (Inst x1 x2 x3 x4) = rnf4 x1 x2 x3 x4
 
 mkInst :: CExpr -> Qual Pred -> Maybe Id -> Inst
-mkInst e i pkg = Inst e (tv i) i pkg
+-- The instance HEAD is synonym-expanded at construction: instance
+-- matching is structural, so a synonym in the head would never match
+-- an expanded solver predicate.  (Previously this was masked by apSub
+-- incidentally re-expanding every pred it touched.)  Context preds
+-- need no expansion here -- subgoals are minted through mkVPred*,
+-- which normalizes.
+mkInst e (ps :=> p) pkg = let i' = ps :=> expandSynPred p
+                          in  Inst e (tv i') i' pkg
+
+expandSynPred :: Pred -> Pred
+expandSynPred (IsIn c ts) = IsIn c (map expandSyn ts)
 
 instance Types Inst where
     apSub s (Inst e _ i pkg) = Inst (apSub s e) [] (apSub s i) pkg

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -66,6 +66,24 @@ useLegacyInstIndex = elem "-legacy-inst-index" progArgs
 legacyDeferInstances :: Bool
 legacyDeferInstances = elem "-legacy-defer-instances" progArgs
 
+-- Debug-only invariant check: every predicate entering the satisfy
+-- loop must be synonym-expanded at construction (see mkVPredFromPred).
+-- Enable with -hack-check-pred-expanded (also via BSC_OPTIONS) to make
+-- a violation an internal error naming the offending predicate.
+checkPredExpanded :: Bool
+checkPredExpanded = elem "-hack-check-pred-expanded" progArgs
+
+assertPredsExpanded :: String -> [VPred] -> a -> a
+assertPredsExpanded tag vps x
+  | not checkPredExpanded = x
+  | otherwise =
+      case [ p | vp@(VPred _ pwp) <- vps
+               , let p@(IsIn _ ts) = removePredPositions pwp
+               , map expandSyn ts /= ts ] of
+        [] -> x
+        (p:_) -> internalError (tag ++ ": unexpanded pred reached the " ++
+                                "solver: " ++ ppReadable p)
+
 doRTrace :: Bool
 doRTrace = elem "-trace-type" progArgs
 rtrace :: String -> a -> a
@@ -178,7 +196,7 @@ satisfyX dvs es ps = do
 
 satisfyXStream :: DVS -> [EPred] -> [VPred] -> TI ([VPred], SolvedBinds)
 satisfyXStream _   es [] = return ([], emptySBs)
-satisfyXStream dvs es ps = do
+satisfyXStream dvs es ps = assertPredsExpanded "satisfyXStream" ps $ do
         -- satTraceM ("satisfy enter: " ++ ppString (dvs, ps))
 -- it is not clear if applying the substitution here wins or not
         s0 <- getSubst
@@ -1621,7 +1639,12 @@ mkVPredNoNewPos p = do
 mkVPredFromPred :: [Position] -> Pred -> TI VPred
 mkVPredFromPred poss p = do
   v <- newDict
-  return (VPred v $ mkPredWithPositions poss p)
+  -- expandSynVPred upholds the solver invariant that every predicate
+  -- is synonym-expanded at construction (the other mkVPred* producers
+  -- already do this); resolution matches instance heads structurally,
+  -- so an unexpanded synonym (e.g. Action for ActionValue ()) would
+  -- fail to match
+  return (expandSynVPred (VPred v $ mkPredWithPositions poss p))
 
 toPredWithPositions :: VPred -> PredWithPositions
 toPredWithPositions (VPred _ p) = p

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -377,8 +377,12 @@ addNumDecided proven refuted = modify (\ s ->
         tsNumRefuted = foldr S.insert (tsNumRefuted s) refuted })
 
 mkEPred :: Pred -> TI EPred
+-- expandSynPred: givens must satisfy the same construction-time
+-- normalization invariant as goals (lookfor matches structurally, so
+-- an unexpanded synonym in a given would never match an expanded
+-- solver predicate).
 mkEPred p = do i <- newDict
-               return $ EPred (CVar i) p
+               return $ EPred (CVar i) (expandSynPred p)
 
 clearSubst :: TI ()
 clearSubst = modify (transSubst (const nullSubst))

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -487,12 +487,15 @@ instance Show VPred where
         showString " " . showsPrec 11 p
 
 instance Types VPred where
+    -- No substitution-disjointness shortcut here: apSub on a Pred
+    -- doubles as a synonym-expansion pass (see the Pred instance), so
+    -- an "untouched" skip is not behavior-preserving.  The cached fv
+    -- set serves split_rs, which only needs membership.
     apSub s vp = fromMaybe vp (apSubM s vp)
-    apSubM s vp@(VPred_ i p fvs)
-      | substDomainDisjoint s fvs = Nothing
-      | otherwise = case apSubM s p of
-                      Nothing -> Nothing
-                      Just p' -> Just (VPred i p')
+    apSubM s (VPred_ i p _) =
+        case apSubM s p of
+          Nothing -> Nothing
+          Just p' -> Just (VPred i p')
     tv (VPred_ _ p _) = tv p
 
 instance PPrint VPred where


### PR DESCRIPTION
Fix 10/11 of the rc8 performance-regression series (stacked on the codegen-stage PR). Two commits: the earlier band-aid ("apSub on a Pred must keep its expandSyn normalization") and the principled version that supersedes it.

## Problem
`apSub` on a `Pred` doubled as a synonym-normalization pass (`IsIn c $ expandSyn <$> apSub s ts`): every substitution re-expanded every element, and any producer emitting an unexpanded pred was silently laundered by the next substitution. That coupling forbids sharing-preserving substitution ("untouched" does not imply "normalized") and masked real bugs — instance heads from `mkInst` carried unexpanded synonyms (the T0031 failure on PrintfATS when substitution first tried to skip untouched preds).

## Fix
Establish the invariant at construction: `mkInst` expands instance heads, `mkVPred*` normalizes via `expandSynVPred`, `mkEPred` expands givens, `MakeSymTab` expands superclass preds. A development checker (`-hack-check-pred-expanded`, usable via `BSC_OPTIONS`) makes an unexpanded pred reaching the satisfy loop an internal error.

## Validation
Full `bsc.typechecker` suite green (1523 expected passes / 24 expected failures / 0 unexpected) both normally and with the checker enforced — no producer violates the invariant anywhere in the suite.

## Benchmark row (proviso-heavy shape)
typecheck 45.8 → 47.3s (1.03×), alloc/residency flat. The value is soundness and enabling the next PR, not standalone speed; `.bo` content changes as intended (expanded forms serialized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHQHaZajYgygHRSxdVH8YT)_