### PR TITLE
Add an install-extra target for the tools the testsuite needs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,9 @@ help:
 	@echo
 	@echo '    make  install-src  Build and install just the tools'
 	@echo '    make  install-doc  Build and install just the documentation'
+	@echo '    make  install-extra'
+	@echo '                       install-src plus the extra tools that parts of'
+	@echo '                       the testsuite need (showrules, fstscopes, ...)'
 	@echo
 	@echo '    make  check-smoke  Run a quick smoke test'
 	@echo '    make  check-suite  Run the test suite (this will take time!)'
@@ -41,6 +44,18 @@ rem_build:
 .PHONY: install-src
 install-src:
 	$(MAKE)  -C src  PREFIX=$(PREFIX)  install
+
+# showrules, fstscopes, fstcheck, vcdcheck, dumpba -- the tools some
+# testsuite directories need.  Without them bsc.showrules and
+# bsc.bluetcl/fst_correlation report "unsupported" and silently skip 61
+# tests, so a green run quietly covers less than the last one.
+# Depends on install-src because these link against the same build;
+# src/Makefile forwards only install/clean/full_clean and the target
+# lives in comp, so go direct, with -j1 as comp's targets share one
+# workspace.
+.PHONY: install-extra
+install-extra: install-src
+	$(MAKE)  -C src/comp  -j1  PREFIX=$(PREFIX)  install-extra
 
 .PHONY: install-doc
 install-doc:


### PR DESCRIPTION
`showrules`, `fstscopes`, `fstcheck`, `vcdcheck` and `dumpba` are built by
`src/comp`'s `install-extra`, but nothing above it reaches that target —
`src/Makefile` forwards only `install`, `clean` and `full_clean`.

So a normal `make install-src` leaves them out, and the testsuite then
reports `bsc.showrules` and `bsc.bluetcl/fst_correlation` as **unsupported**
and skips them. That is **61 tests that never run**, with no failure to
notice — a green run quietly covering less than the previous one.

This adds a top-level target that depends on `install-src` and then invokes
`comp`'s `install-extra` directly (`-j1`, as `comp`'s targets share one
workspace), plus a line in `make help`. `install-src` is untouched, so this
costs nothing unless asked for.

Verified: with the tools present, `bsc.showrules` goes from 1 unsupported to
**60 passes** and `fst_correlation` from unsupported to passing.

One footgun worth knowing, since the dependency only runs one way: rebuilding
with `make install-src` after this leaves the extra tools at the previous
compiler's version, and `showrules` then fails with
`(S0005) Binary version mismatch in '<module>.ba'. Recompile!` — which blames
the freshly generated `.ba` when the stale thing is the tool reading it.
Building with `make install-extra` avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDMYHhdhVaV3K7hif8zE7x