### PR TITLE
verilator 1/6: -system-verilog-output flag; SystemVerilog string parameters

### DIFF
--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -24,7 +24,8 @@ import Util
 import FileNameUtil(hasSuf)
 import PFPrint
 import Error(internalError, ErrorHandle)
-import Flags(Flags, removeReg, removeCross, removeInoutConnect, removeUnusedMods,
+import Flags(Flags, systemVerilogOutput,
+             removeReg, removeCross, removeInoutConnect, removeUnusedMods,
              useDPI, verilogDeclareAllFirst)
 import Id
 import Pragma(PProp(..))
@@ -322,15 +323,19 @@ aVerilog errh flags pps aspack ffmap =
         -- XXX might be good to allow the user to specify a default
 
         args :: [VArg]
-        args =        [ VAParameter (vId i) r v
+        args =        [ VAParameter (vId i) r v isStr
                      | (i, t) <- ps,
-                       let (r, v) = case t of
+                       let (r, v, isStr) = case t of
                                       ATBit sz -> (Just (VEConst (sz-1),
                                                          VEConst 0),
-                                             VEWConst (mkVId "0") sz 2 0)
-                                      ATString _ -> (Nothing, VEString "")
-                                      ATReal -> (Nothing, VEReal 0.0)
-                                      _ -> (Nothing, VEConst 0) ] ++
+                                             VEWConst (mkVId "0") sz 2 0, False)
+                                      -- under -system-verilog-output, emit a SV
+                                      -- `string` parameter so $display treats it
+                                      -- as a string, not a packed bit-vector
+                                      ATString _ -> (Nothing, VEString "",
+                                                     systemVerilogOutput flags)
+                                      ATReal -> (Nothing, VEReal 0.0, False)
+                                      _ -> (Nothing, VEConst 0, False) ] ++
                 [ VAInput (vId i) (vSize t)
                      | (i, t) <- is ] ++
                 filterSharedInout

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -37,7 +37,7 @@ import Data.Maybe
 
 import FStringCompat(FString, getFString)
 import ErrorUtil
-import Flags(Flags, readableMux, unSpecTo, v95, systemVerilogTasks, useDPI)
+import Flags(Flags, readableMux, unSpecTo, v95, systemVerilogOutput, useDPI)
 import PPrint
 import IntLit
 import Id
@@ -85,7 +85,7 @@ flagsToVco flags = VConvtOpts {
                                vco_v95    = v95 flags,
                                vco_v95_tasks = ["$signed", "$unsigned"],
                                vco_readableMux = readableMux flags,
-                               vco_sv_tasks = systemVerilogTasks flags,
+                               vco_sv_tasks = systemVerilogOutput flags,
                                vco_use_dpi = useDPI flags
                               }
 

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -129,7 +129,7 @@ data Flags = Flags {
         strictMethodSched :: Bool,
         suppressWarnings :: MsgListFlag,
         synthesize :: Bool,
-        systemVerilogTasks :: Bool,
+        systemVerilogOutput :: Bool,
         tclShowHidden :: Bool,
         timeStamps :: Bool,
         showVersion :: Bool,

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -629,7 +629,7 @@ defaultFlags bluespecdir = Flags {
         strictMethodSched = True,
         suppressWarnings = SomeMsgs [],
         synthesize = False,
-        systemVerilogTasks = False,
+        systemVerilogOutput = False,
         tclShowHidden = False,
         testAssert = False,
         timeStamps = True,
@@ -1452,9 +1452,15 @@ externalFlags = [
           "check that rule names are unique (when disabled unique numbers are assigned)", Hidden)),
 
 
+        ("system-verilog-output",
+         (Toggle (\f x -> f {systemVerilogOutput=x}) (showIfTrue systemVerilogOutput),
+         "emit SystemVerilog output (SV tasks like $error, string parameters)", Hidden)),
+
+        -- old, backward-compatible spelling of -system-verilog-output
         ("system-verilog-tasks",
-         (Toggle (\f x -> f {systemVerilogTasks=x}) (showIfTrue systemVerilogTasks),
-         "preserve SystemVerilog tasks (e.g. $error) in output code", Hidden)),
+         (Toggle (\f x -> f {systemVerilogOutput=x}) (showIfTrue systemVerilogOutput),
+         "deprecated spelling of -system-verilog-output",
+         Deprecated "Use -system-verilog-output instead.")),
 
         ("sched-conditions",
          (Toggle (\f x -> f {schedConds=x}) (showIfTrue schedConds),
@@ -1931,7 +1937,7 @@ showFlagsRaw flags =
           ("strictMethodSched", show (strictMethodSched flags)),
           ("suppressWarnings", show (suppressWarnings flags)),
           ("synthesize", show (synthesize flags)),
-          ("systemVerilogTasks", show (systemVerilogTasks flags)),
+          ("systemVerilogOutput", show (systemVerilogOutput flags)),
           ("tclShowHidden", show (tclShowHidden flags)),
           ("testAssert", show (testAssert flags)),
           ("timeStamps", show (timeStamps flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -759,7 +759,7 @@ instance Bin VArg where
     writeBytes (VAInput i r)       = do putI 0; toBin i; toBin r
     writeBytes (VAInout i i' r)    = do putI 1; toBin i; toBin i'; toBin r
     writeBytes (VAOutput i r)      = do putI 2; toBin i; toBin r
-    writeBytes (VAParameter i r d) = do putI 3; toBin i; toBin r; toBin d
+    writeBytes (VAParameter i r d b) = do putI 3; toBin i; toBin r; toBin d; toBin b
     readBytes = do
       i <- getI
       case i of
@@ -767,8 +767,8 @@ instance Bin VArg where
         1 -> do i <- fromBin; i' <- fromBin; r <- fromBin;
                 return (VAInout i i' r)
         2 -> do i <- fromBin; r <- fromBin; return (VAOutput i r)
-        3 -> do i <- fromBin; r <- fromBin; d <- fromBin;
-                return (VAParameter i r d)
+        3 -> do i <- fromBin; r <- fromBin; d <- fromBin; b <- fromBin;
+                return (VAParameter i r d b)
         n -> internalError $ "GenABin(VArg).readBytes: " ++ show n
 
 instance Bin VExpr where

--- a/src/comp/VPrims.hs
+++ b/src/comp/VPrims.hs
@@ -25,7 +25,7 @@ vMuxP parallel n = VModule { vm_name = (mkVId ("Mux_" ++ itos n)),
   where
         comments = [] -- XXX room to add comments
         args = param : out : iss
-        param = VAParameter viWidth Nothing (VEConst 1)
+        param = VAParameter viWidth Nothing (VEConst 1) False
         out = VAOutput viOut rng
         iss = concatMap (\ n -> [VAInput (i n) rng, VAInput (s n) Nothing]) ns
         hi = mkVEOp w VSub one

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -247,7 +247,9 @@ data VArg
         -- If the type is Nothing, then do not print a declaration
         | VAInout VId (Maybe VId) (Maybe (Maybe VRange))
         | VAOutput VId (Maybe VRange)
-        | VAParameter VId (Maybe VRange) VExpr
+        -- final Bool: when True, emit as a SystemVerilog `string` parameter
+        -- (`parameter string id = val`) instead of an untyped bit-vector parameter
+        | VAParameter VId (Maybe VRange) VExpr Bool
         deriving (Eq, Show, Generic.Data, Generic.Typeable)
 
 -- only use this for debugging
@@ -263,14 +265,15 @@ instance PPrint VArg where
         (case mmr of { Just mr -> ppMRange d mr; Nothing -> empty })
     pPrint d p (VAOutput i mr) =
         text "VAOutput" <+> pPrint d 0 i <+> ppMRange d mr
-    pPrint d p (VAParameter i mr e) =
-        text "VAParameter" <+> pPrint d 0 i <+> ppMRange d mr <+> pPrint d 0 e
+    pPrint d p (VAParameter i mr e isStr) =
+        text "VAParameter" <+> pPrint d 0 i <+> ppMRange d mr <+> pPrint d 0 e <+>
+        pPrint d 0 isStr
 
 instance NFData VArg where
     rnf (VAInput vid mr) = rnf2 vid mr
     rnf (VAInout vid mvid mmr) = rnf3 vid mvid mmr
     rnf (VAOutput vid mr) = rnf2 vid mr
-    rnf (VAParameter vid mr expr) = rnf3 vid mr expr
+    rnf (VAParameter vid mr expr isStr) = rnf4 vid mr expr isStr
 
 ppVArgPort :: PDetail -> VArg -> Doc
 ppVArgPort d (VAInput i _) = pPrint d 0 i
@@ -287,15 +290,15 @@ ppVArgDecl d (VAInout vi mvi' (Just mr)) =
     in  pPrint d 0 (VVDecl VDInout mr [VVar i])
 ppVArgDecl d (VAInout vi mvi' Nothing) = empty
 ppVArgDecl d (VAOutput vi mr) = pPrint d 0 (VVDecl VDOutput mr [VVar vi])
-ppVArgDecl d (VAParameter i mr e) =
-    text "parameter" <+> ppMRange d mr <+> pPrint d 0 i <+>
-    text "=" <+> pPrint d 0 e <> text ";"
+ppVArgDecl d (VAParameter i mr e isStr) =
+    text "parameter" <+> (if isStr then text "string" else ppMRange d mr) <+>
+    pPrint d 0 i <+> text "=" <+> pPrint d 0 e <> text ";"
 
 vargName :: VArg -> VId
 vargName (VAInput i _) = i
 vargName (VAInout i _ _) = i
 vargName (VAOutput i _) = i
-vargName (VAParameter i _ _) = i
+vargName (VAParameter i _ _ _) = i
 
 data VMItem
         = VMDecl VVDecl

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -109,7 +109,7 @@ Flags {
 	strictMethodSched = True,
 	suppressWarnings = SomeMsgs [],
 	synthesize = False,
-	systemVerilogTasks = False,
+	systemVerilogOutput = False,
 	tclShowHidden = False,
 	testAssert = False,
 	timeStamps = True,


### PR DESCRIPTION
Layer 1/6 of the verilator stack (base: `upstream-main` = B-Lang-org main @ 941eecfe).

Adds the `-system-verilog-output` flag and emits SystemVerilog `parameter string` declarations so string-valued module parameters survive verilator. Mirrors upstream PR B-Lang-org/bsc#997.

---
Full testsuite gate on the composed 6-layer stack tip: **20,323 PASS / 0 FAIL / 134 XFAIL / 0 ERROR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
