### PR TITLE
verilator 3/6: polymorphic import "BDPI" over the DPI path (-use-dpi)

### DIFF
--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -273,16 +273,21 @@ aVerilog errh flags pps aspack ffmap =
 
         -- The main module
         -- XXX note, no special port grouping/commenting for bit blasted mod
+        -- DPI imports are emitted at module scope (as body items), so that
+        -- multiple modules using the same foreign function don't collide at
+        -- Verilator's shared $unit scope; they go in the module that contains
+        -- the foreign-function calls (the main module).
+        dpi_items = map VMDPI dpi_decls
         mainMod =
             if doBitBlast
             then VModule { vm_name = modnameBB,
                            vm_comments = [],
                            vm_ports = [(bargs,[])],
-                           vm_body = bbItems }
+                           vm_body = dpi_items ++ bbItems }
             else VModule { vm_name = modnameUB,
                            vm_comments = [],
                            vm_ports = (groupPorts signal_info args),
-                           vm_body = ubItems }
+                           vm_body = dpi_items ++ ubItems }
 
         -- The un-blasted wrapper, when bit-blasting
         -- It has the unblasted name, the unblasted ports,

--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -39,7 +39,7 @@ import VPrims(vPriEnc,vMux,vPriMux,verilogInstancePrefix)
 import AVerilogUtil
 import InlineReg
 import BackendNamingConventions(isRegInst, isClockCrossingRegInst, isInoutConnect)
-import ForeignFunctions(ForeignFuncMap, mkDPIDeclarations, getForeignFunctions)
+import ForeignFunctions(ForeignFuncMap, mkDPIDeclarations, getDPIInstantiations)
 import qualified GraphWrapper as G
 
 --import Debug.Trace
@@ -131,7 +131,13 @@ aVerilog errh flags pps aspack ffmap =
                     [ (pos, WSVReservedIdent name) | (name, pos) <- sv_clashes ]
          return vprog
   where
-        vco = flagsToVco flags
+        -- vco carries the foreign-function map and def widths so that DPI call
+        -- sites can be monomorphized (name-mangled by concrete width)
+        vco = (flagsToVco flags)
+                { vco_ffmap = ffmap
+                , vco_def_widths =
+                    M.fromList [ (i, aSize t) | ADef i t _ _ <- aspkg_values aspack ]
+                }
         -- look for pass-through comments, taking care of \n
         -- XXX should these attach to the main module instead of the
         -- XXX entire file (attached to file in case of multiple modules)
@@ -312,7 +318,7 @@ aVerilog errh flags pps aspack ffmap =
     -- create import-DPI statements, if using DPI
 
         dpi_decls = if (useDPI flags)
-                    then mkDPIDeclarations $ getForeignFunctions ffmap aspack
+                    then mkDPIDeclarations $ getDPIInstantiations ffmap aspack
                     else []
 
     -- ----------

--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -87,8 +87,8 @@ aVerilog errh flags pps aspack ffmap =
        -- G0131 despite never being printed.)
        let suspect_str s = isVReservedWord s || isSVStdPackageIdent s
            suspect_vid (VId s _ _) = suspect_str s
-           dpi_name_vids = [ n | VDPI n _ _ <- dpi_decls ] ++
-                           [ a | VDPI _ _ args <- dpi_decls,
+           dpi_name_vids = [ n | VDPI n _ _ _ _ <- dpi_decls ] ++
+                           [ a | VDPI _ _ _ _ args <- dpi_decls,
                                  (a, _, _) <- args ]
            has_suspects = any suspect_vid dpi_name_vids ||
                           any (suspect_str . fst) foreign_func_names ||
@@ -2056,15 +2056,15 @@ instance VUse VExpr where
 renameSVStdIdents :: [(String, Position)] -> VProgram
                   -> (VProgram, [(String, String, Position)], [(String, Position)])
 renameSVStdIdents foreign_funcs (VProgram vmods dpis comments) =
-    let dpi_names = S.fromList ([ s | VDPI (VId s _ _) _ _ <- dpis ] ++
-                                [ s | VDPI _ _ args <- dpis,
+    let dpi_names = S.fromList ([ s | VDPI (VId s _ _) _ _ _ _ <- dpis ] ++
+                                [ s | VDPI _ _ _ _ args <- dpis,
                                       (VId s _ _, _, _) <- args ])
         -- foreign Verilog function/task calls name a definition in the
         -- user's own Verilog code, so, like DPI names, they must never
         -- be renamed (the call would no longer match its definition)
         extern_names = dpi_names `S.union` S.fromList (map fst foreign_funcs)
         dpi_clashes = [ (s, getPosition i)
-                      | VDPI (VId s i _) _ _ <- dpis,
+                      | VDPI (VId s i _) _ _ _ _ <- dpis,
                         isSVStdPackageIdent s ]
         foreign_clashes = [ (s, pos) | (s, pos) <- foreign_funcs,
                                        isSVStdPackageIdent s ]
@@ -2210,6 +2210,7 @@ vModuleDeclVIds vmod =
     go (VMRegGroup i _ _ it) = i : go it
     go (VMGroup _ itss)      = concatMap (concatMap go) itss
     go (VMFunction (VFunction n _ decls _)) = n : concatMap declVIds decls
+    go (VMDPI (VDPI n _ _ _ args)) = n : [ a | (a, _, _) <- args ]
     declVIds :: VVDecl -> [VId]
     declVIds (VVDecl _ _ vs) = map vvName vs
     declVIds (VVDWire _ v _) = [vvName v]

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -54,7 +54,8 @@ import VPrims(verilogInstancePrefix, viWidth)
 import BackendNamingConventions(createVerilogNameMapForAVInst,
                                 xLateFStringUsingFStringMap)
 import ForeignFunctions(ForeignFunction(..), ForeignFuncMap,
-                        isPoly, isWide, isMappedAVId)
+                        isPoly, isWide, isMappedAVId,
+                        isPolyFF, mkDPIMonoName, dpiPolyWidths)
 
 import Util
 import IntegerUtil
@@ -75,7 +76,11 @@ data VConvtOpts = VConvtOpts {
                               vco_v95_tasks   :: [String],
                               vco_readableMux :: Bool,
                               vco_sv_tasks    :: Bool,
-                              vco_use_dpi     :: Bool
+                              vco_use_dpi     :: Bool,
+                              -- foreign-function map and def widths, for
+                              -- monomorphizing polymorphic DPI call names
+                              vco_ffmap       :: ForeignFuncMap,
+                              vco_def_widths  :: M.Map AId Integer
                               }
 
 
@@ -86,7 +91,9 @@ flagsToVco flags = VConvtOpts {
                                vco_v95_tasks = ["$signed", "$unsigned"],
                                vco_readableMux = readableMux flags,
                                vco_sv_tasks = systemVerilogOutput flags,
-                               vco_use_dpi = useDPI flags
+                               vco_use_dpi = useDPI flags,
+                               vco_ffmap = M.empty,
+                               vco_def_widths = M.empty
                               }
 
 -- This has been abolished from the compiler everywhere but the Verilog backend
@@ -215,7 +222,14 @@ vForeignCall vco f@(AForeignCall aid taskid (c:es) ids resets) ffmap =
   if aid==idSVA then fcall es
                   else foldr (Vif . mkNotEqualsReset . vExpr vco) fcall_body resets
   where
-    vtaskid = VId (vCommentTaskName vco taskid) aid Nothing
+    -- monomorphize the DPI call name by the concrete polymorphic-operand widths
+    dpiName = if vco_use_dpi vco
+              then dpiMonoCallName vco taskid retW (map (aSize . aType) es)
+              else taskid
+    retW = case ids of
+             (w:_) -> M.lookup w (vco_def_widths vco)
+             []    -> Nothing
+    vtaskid = VId (vCommentTaskName vco dpiName) aid Nothing
     (ids',es') = let lv = headOrErr "vForeignCall: missing return value" ids
                  in case isAForeignCallWithRetAsArg vco ffmap f of
                      (Just ty) -> ([], (ASDef ty lv) : es)
@@ -591,7 +605,12 @@ vDefMpd vco (ADef i_t t_t@(ATBit _) fn@(AFunCall {}) _) ffmap
     [ VMDecl $ VVDecl VDReg (vSize t_t) [VVar (vId i_t)]
     , VMStmt { vi_translate_off = True, vi_body = body }
     ]
-  where name = vCommentTaskName vco (vNameToTask (vco_use_dpi vco) (ae_funname fn))
+  where name = vCommentTaskName vco foreignNm
+        foreignNm = if vco_use_dpi vco
+                    then dpiMonoCallName vco (ae_funname fn)
+                                         (Just (aSize t_t))
+                                         (map (aSize . aType) (ae_args fn))
+                    else vNameToTask False (ae_funname fn)
         vtaskid = VId name (ae_objid fn) Nothing
         sensitivityList = nub (concatMap aIds (ae_args fn))
         ev = foldr1 VEEOr (map (VEE . VEVar) sensitivityList)
@@ -764,8 +783,11 @@ vExpr vco (APrim aid t p es) = VEOp (idToVId aid) (vExpr vco (APrim aid t p (ini
 -- vExpr vco (AMethCall t i m []) = VEVar (vMethId i m 1 MethodResult M.Empty)
 -- vExpr vco (AMethCall t i m _) = internalError "AVerilog.vExpr: AMethCall with args"
 -- vExpr vco (AMethValue t i m) = VEVar (vMethId i m 1 MethodResult M.Empty)
-vExpr vco (AFunCall _ _ n isC es) =
-  let name = vCommentTaskName vco (if isC then vNameToTask (vco_use_dpi vco) n else n)
+vExpr vco (AFunCall t _ n isC es) =
+  let foreignName = if vco_use_dpi vco
+                    then dpiMonoCallName vco n (Just (aSize t)) (map (aSize . aType) es)
+                    else vNameToTask False n
+      name = vCommentTaskName vco (if isC then foreignName else n)
   in VEFctCall (mkVId name) (map (vExpr vco) es)
 vExpr vco (ASInt idt (ATBit w) (IntLit _ b i))  = VEWConst (idToVId idt) w b i
 vExpr vco (ASReal _ _ r)                        = VEReal r
@@ -1209,10 +1231,20 @@ vCommentTaskName vco s | vco_v95 vco && elem s (vco_v95_tasks vco) = " /*" ++ s 
                        | otherwise = s
 
 -- create a Verilog DPI/VPI task name from a foreign function name
--- XXX When using DPI, if any types are poly, use the wrapper name
 vNameToTask :: Bool -> String -> String
 vNameToTask True  s = s
 vNameToTask False s = "$imported_" ++ s
+
+-- Monomorphize a DPI foreign-call name by the concrete widths of its
+-- polymorphic operands, matching ForeignFunctions.mkDPIDeclarations.  For a
+-- monomorphic function (or one not found), the base name is returned unchanged.
+-- 'mretW' is the concrete return width (used only when the return is
+-- polymorphic); 'argWs' are the concrete argument widths (aligned to ff_args).
+dpiMonoCallName :: VConvtOpts -> String -> Maybe Integer -> [Integer] -> String
+dpiMonoCallName vco base mretW argWs =
+  case M.lookup base (vco_ffmap vco) of
+    Just ff | isPolyFF ff -> mkDPIMonoName base (dpiPolyWidths ff mretW argWs)
+    _                     -> base
 
 
 -- ==============================

--- a/src/comp/DPIWrappers.hs
+++ b/src/comp/DPIWrappers.hs
@@ -1,30 +1,134 @@
 module DPIWrappers ( genDPIWrappers ) where
 
-import ForeignFunctions(ForeignFunction(..), isPoly)
-import CCSyntax(CCFragment)
-import Position(getPosition)
-import Error(ErrorHandle, bsError, ErrMsg(EGeneric))
-import Flags(Flags(..))
+import Verilog(VDPI(..), VDPIType(..))
+import CCSyntax
+import Error(ErrorHandle)
+import Flags(Flags(..), quiet)
+import FileNameUtil(mkDPICName, getRelativeFilePath, dropSuf)
+import FileIOUtil(writeFileCatch)
+import PPrint(ppReadable)
+import TopUtils(putStrLnF, commentC)
+
+import Control.Monad(unless)
+import Data.List(nub)
+
+-- ---------------------------------------------------------------------------
+-- DPI wrappers for polymorphic foreign functions
+--
+-- A monomorphic foreign function needs no wrapper: its DPI-C import names the
+-- user's C function directly (mkDPIDeclarations emits no c_identifier alias).
+--
+-- A polymorphic function is monomorphized into one fixed-width DPI import per
+-- concrete width used (see ForeignFunctions.getDPIInstantiations).  Each such
+-- import has a mangled SystemVerilog name and links, via a "c_identifier ="
+-- alias, to a generated wrapper.  A fixed-width packed operand ("bit [W-1:0]")
+-- is passed on the C side as the word-canonical 'svBitVecVal *' for every W,
+-- which matches the polymorphic C function's word-pointer ABI, so the wrapper
+-- just casts and forwards to the single real C function:
+--
+--   void poly_add_w7_bs_dpi_wrapper(svBitVecVal* res, const svBitVecVal* a,
+--                                   const svBitVecVal* b, unsigned int size) {
+--     poly_add((unsigned int*)res, (unsigned int*)a, (unsigned int*)b, size);
+--   }
+--
+-- All wrappers for one function are written to a single "dpi_wrapper_<fn>.c"
+-- (so the link step finds them by the function's base name), one wrapper per
+-- distinct width used.
+-- ---------------------------------------------------------------------------
+
+-- Info for one wrapper: (c_identifier/wrapper name, return type, arg types).
+type WrapInfo = (String, VDPIType, [VDPIType])
 
 genDPIWrappers :: ErrorHandle ->
-                  Flags -> String -> [String] -> [ForeignFunction] ->
+                  Flags -> String -> [String] -> [VDPI] ->
                   IO [CCFragment]
-genDPIWrappers errh flags prefix blurb ffs =
-  do files <- mapM (writeWrapper errh flags prefix blurb) ffs
+genDPIWrappers errh flags prefix blurb vdpis =
+  do -- collect the imports that need a wrapper (those with a c_identifier alias
+     -- and an underlying C function), keyed by the real C function name
+     let wrapped = [ (cfn, (wname, ret, map thd args))
+                   | VDPI _ (Just wname) (Just cfn) ret args <- vdpis ]
+         cfns = nub (map fst wrapped)
+         groups = [ (cfn, [ wi | (c, wi) <- wrapped, c == cfn ]) | cfn <- cfns ]
+     files <- mapM (writeWrapperFile errh flags prefix blurb) groups
      return $ concat files
+  where thd (_,_,t) = t
 
-writeWrapper :: ErrorHandle ->
-                Flags -> String -> [String] -> ForeignFunction ->
-                IO [CCFragment]
-writeWrapper errh flags prefix blurb (FF name rt arg_types) =
-  if (isPoly rt || any isPoly arg_types)
-  then do
-    -- Polymorphic types require a wrapper
-    -- XXX When we implement wrapper generation,
-    -- XXX remember to add it to 'getGenFs' in 'Depend.hs'.
-    let pos = getPosition name
-        msg = "Polymorphic types are not yet supported with DPI"
-    bsError errh [(pos, EGeneric msg)]
-  else do
-    -- If there are no polymorphic types, then no wrapper is needed
-    return []
+writeWrapperFile :: ErrorHandle -> Flags -> String -> [String] ->
+                    (String, [WrapInfo]) -> IO [CCFragment]
+writeWrapperFile errh flags prefix blurb (cfn, wraps) =
+  do let c_filename = mkDPICName (vdir flags) prefix cfn
+         c_filename_rel = getRelativeFilePath c_filename
+
+         -- all wrappers for one function share the underlying C signature;
+         -- derive its declaration from the first
+         (_, ret0, args0) = head wraps
+         real_decl = externC [ mkRealDecl cfn ret0 args0 ]
+         wrapper_defs = externC [ define (mkWrapperType wi) (mkWrapperBody cfn wi)
+                                | wi <- wraps ]
+
+         c_segments = [ cpp_system_include "svdpi.h"
+                      , comment "the underlying polymorphic C function"
+                                real_decl
+                      , comment "fixed-width DPI wrappers (one per width used)"
+                                wrapper_defs
+                      ]
+         c_contents = commentC blurb ++ ppReadable (program c_segments)
+
+     writeFileCatch errh c_filename c_contents
+     unless (quiet flags) $ putStrLnF $ "DPI wrapper file created: " ++
+                                        (dropSuf c_filename_rel) ++ ".c"
+     return c_segments
+
+-- The prototype of the underlying (real) C function, whose ABI passes wide and
+-- polymorphic values as 'unsigned int *' and scalars by value.
+mkRealDecl :: String -> VDPIType -> [VDPIType] -> CCFragment
+mkRealDecl cfn ret args =
+  decl $ function (retCType ret) (mkVar cfn)
+                  [ decl $ (realCType t) (mkVar "") | t <- args ]
+
+mkWrapperType :: WrapInfo -> CCFragment
+mkWrapperType (wname, rett, args) =
+  function (retCType rett) (mkVar wname)
+           [ decl $ (dpiCType t) (mkVar (argName i)) | (i,t) <- zip [(0::Int)..] args ]
+
+mkWrapperBody :: String -> WrapInfo -> CCFragment
+mkWrapperBody cfn (_, rett, args) =
+  let call = (var cfn) `cCall` [ fwd t (argName i) | (i,t) <- zip [(0::Int)..] args ]
+  in block [ if rett == VDT_void then stmt call else ret (Just call) ]
+
+argName :: Int -> String
+argName i = "a" ++ show i
+
+-- The C type of an operand as seen by the wrapper (the DPI ABI): fixed-width
+-- packed operands are 'svBitVecVal *'; scalars are by value.
+dpiCType :: VDPIType -> (CCFragment -> CCFragment)
+dpiCType VDT_void       = void
+dpiCType VDT_byte       = unsigned . char
+dpiCType VDT_int        = unsigned . int
+dpiCType VDT_longint    = unsigned . long . long
+dpiCType (VDT_wide _)   = ptr . userType "svBitVecVal"
+dpiCType VDT_string     = ptr . char
+dpiCType VDT_poly       = ptr . userType "svBitVecVal"
+
+-- The C type of an operand as seen by the real function.
+realCType :: VDPIType -> (CCFragment -> CCFragment)
+realCType VDT_void      = void
+realCType VDT_byte      = unsigned . char
+realCType VDT_int       = unsigned . int
+realCType VDT_longint   = unsigned . long . long
+realCType (VDT_wide _)  = ptr . unsigned . int
+realCType VDT_string    = ptr . char
+realCType VDT_poly      = ptr . unsigned . int
+
+-- The C type of the return value (scalars; wide/poly returns go via an output
+-- argument, so the actual return is void in that case).
+retCType :: VDPIType -> (CCFragment -> CCFragment)
+retCType = realCType
+
+-- Forward a wrapper operand to the real C function, casting packed operands
+-- from svBitVecVal* to unsigned int* and strings to char*.
+fwd :: VDPIType -> String -> CCExpr
+fwd (VDT_wide _) nm = cCast (ptrType (classType "unsigned int")) (var nm)
+fwd VDT_poly     nm = cCast (ptrType (classType "unsigned int")) (var nm)
+fwd VDT_string   nm = cCast (ptrType (classType "char")) (var nm)
+fwd _            nm = var nm

--- a/src/comp/Depend.hs
+++ b/src/comp/Depend.hs
@@ -236,6 +236,15 @@ getGenFs flags pi =
             in  foreign_abin_files ++ mod_abin_files
          Just Verilog ->
             let mod_ver_files = map mkVerFileName (gens pi)
+                -- With DPI, only *polymorphic* foreign imports produce a
+                -- generated file (a "dpi_wrapper_<name>.c"); monomorphic ones
+                -- are called directly with no wrapper.  PkgInfo only records
+                -- the foreign import's Id (from the pragma), not its type, so
+                -- we can't tell here which imports are polymorphic -- and
+                -- listing a wrapper file that wasn't generated would force a
+                -- spurious rebuild every run (getModTime of a missing file).
+                -- So DPI wrapper files are not tracked for incremental rebuild;
+                -- they are regenerated whenever the package itself is compiled.
                 foreign_vpi_files = if (useDPI flags)
                                     then []
                                     else concatMap mkVPIFileNames (foreigns pi)

--- a/src/comp/FileNameUtil.hs
+++ b/src/comp/FileNameUtil.hs
@@ -84,6 +84,10 @@ mkVPIHName m pre s = mkPre m pre ++ "vpi_wrapper_" ++ s ++ "." ++ hSuffix
 mkVPIArrayCName :: Maybe String -> String -> String
 mkVPIArrayCName m pre = mkPre m pre ++ "vpi_startup_array" ++ "." ++ cSuffix
 
+-- DPI wrapper C file (for polymorphic imports over the DPI path)
+mkDPICName :: Maybe String -> String -> String -> String
+mkDPICName m pre s = mkPre m pre ++ "dpi_wrapper_" ++ s ++ "." ++ cSuffix
+
 -- add prefix but no suffix
 mkNameWithoutSuffix :: Maybe String -> String -> String -> String
 mkNameWithoutSuffix m pre s = mkPre m pre ++ s

--- a/src/comp/ForeignFunctions.hs
+++ b/src/comp/ForeignFunctions.hs
@@ -8,7 +8,10 @@ module ForeignFunctions ( ForeignType(..)
                         , mkForeignFunction
                         , mkImportDeclarations
                         , mkDPIDeclarations
-                        , getForeignFunctions
+                        , mkDPIMonoName
+                        , dpiPolyWidths
+                        , isPolyFF
+                        , getDPIInstantiations
                         , mkFFDecl
                         , encodeArgs
                         , argExpr
@@ -49,7 +52,7 @@ import Util(tailOrErr, itos)
 import PPrint hiding (char, int)
 import Eval
 
-import Data.List(intercalate, isPrefixOf, nub)
+import Data.List(intercalate, isPrefixOf, nub, nubBy)
 import Data.Maybe(mapMaybe, maybeToList)
 import PreIds
 import ListMap as LM
@@ -529,12 +532,98 @@ mkImportDeclarations ff_map =
 -- Make the SystemVerilog DPI-C declarations for all foreign functions in
 -- the ForeignFuncMap.
 
-mkDPIDeclarations :: [ForeignFunction] -> [VDPI]
-mkDPIDeclarations ffuncs = map mkDPIDecl ffuncs
+-- ---------------------------------------------------------------------------
+-- Monomorphic DPI instantiations
+--
+-- SystemVerilog DPI-C imports require concrete widths, so a polymorphic
+-- foreign function cannot be a single import.  Instead, for each distinct
+-- concrete width at which it is used, we emit one fixed-width import.  A
+-- fixed-width packed operand ("bit [W-1:0]") maps to the word-canonical
+-- 'svBitVecVal *' on the C side for every W, which matches the polymorphic C
+-- function's word-pointer ABI -- so a tiny wrapper just casts and forwards.
+-- (This avoids DPI open arrays entirely, whose C runtime is unreliable in
+-- Verilator: svGetArrayPtr can return NULL for reg-backed values.)
+--
+-- The import's SystemVerilog name is mangled with the widths ('mkDPIMonoName');
+-- it links, via a "c_identifier =" alias, to a generated wrapper
+-- ('mkDPIWrapperName') that calls the one real C function.
+-- ---------------------------------------------------------------------------
+
+-- A concrete instantiation of a foreign function actually used in the design.
+-- For a monomorphic function this is just the function itself (dpii_widths=[]);
+-- for a polymorphic one there is one DPIInst per distinct set of concrete
+-- polymorphic-operand widths, with 'Polymorphic' replaced by 'Wide w'.
+data DPIInst = DPIInst { dpii_cname  :: String        -- real underlying C fn
+                       , dpii_ret    :: ForeignType    -- concrete return type
+                       , dpii_args   :: [ForeignType]  -- concrete argument types
+                       , dpii_widths :: [Integer]      -- poly-operand widths ([] if mono)
+                       }
+  deriving (Eq, Show)
+
+-- The (mangled) SystemVerilog import/call name for an instantiation.
+mkDPIMonoName :: String -> [Integer] -> String
+mkDPIMonoName base []     = base
+mkDPIMonoName base widths = base ++ concatMap (("_w" ++) . show) widths
+
+-- The C linkage name of the generated wrapper (and the "c_identifier =" alias).
+-- Derived from the already-unique mangled SV name.
+mkDPIWrapperName :: String -> String
+mkDPIWrapperName svname = svname ++ "_bs_dpi_wrapper"
+
+-- The concrete widths of the polymorphic operands, in signature order
+-- (return first if polymorphic, then arguments).  Used both to name an
+-- instantiation and to name a call site, so the two agree.
+dpiPolyWidths :: ForeignFunction -> Maybe Integer -> [Integer] -> [Integer]
+dpiPolyWidths (FF _ rt args) mretW argWs =
+  (if isPoly rt then maybeToList mretW else []) ++
+  [ w | (t, w) <- zip args argWs, isPoly t ]
+
+-- Does this foreign function have any polymorphic operand (so it needs a
+-- monomorphized, wrapped DPI import)?
+isPolyFF :: ForeignFunction -> Bool
+isPolyFF (FF _ rt args) = isPoly rt || any isPoly args
+
+-- Build the DPIInst for one use of a foreign function.
+mkDPIInst :: ForeignFunction -> Maybe Integer -> [Integer] -> DPIInst
+mkDPIInst ff@(FF nm rt args) mretW argWs =
+  DPIInst { dpii_cname  = getIdString nm
+          , dpii_ret    = concretize rt mretW
+          , dpii_args   = zipWith concretize args (map Just argWs)
+          , dpii_widths = dpiPolyWidths ff mretW argWs
+          }
+  where concretize Polymorphic (Just w) = Wide w   -- render "bit [w-1:0]"
+        concretize t          _         = t
+
+-- Scan the package for every foreign-function use and return the distinct
+-- concrete instantiations needed.
+getDPIInstantiations :: ForeignFuncMap -> ASPackage -> [DPIInst]
+getDPIInstantiations ffmap aspkg =
+  let defW = M.fromList [ (i, aSize t) | ADef i t _ _ <- aspkg_values aspkg ]
+
+      exprUses = [ mkDPIInst ff (Just (aSize (aType e))) (map (aSize . aType) (ae_args e))
+                 | e@(AFunCall { ae_funname = nm, ae_isC = True })
+                     <- findAExprs exprForeignCalls aspkg
+                 , Just ff <- [M.lookup nm ffmap] ]
+
+      actUses  = [ mkDPIInst ff mret (map (aSize . aType) (drop 1 (afc_args fc)))
+                 | fc <- concatMap snd (aspkg_foreign_calls aspkg)
+                 , Just ff <- [M.lookup (afc_fun fc) ffmap]
+                 , let mret = case afc_writes fc of
+                                (w:_) -> M.lookup w defW
+                                []    -> Nothing ]
+
+      eqInst a b = dpii_cname a == dpii_cname b && dpii_widths a == dpii_widths b
+  in  nubBy eqInst (exprUses ++ actUses)
+
+mkDPIDeclarations :: [DPIInst] -> [VDPI]
+mkDPIDeclarations insts = map mkDPIDecl insts
   where
-    mkDPIDecl :: ForeignFunction -> VDPI
-    mkDPIDecl (FF name rt arg_types) =
+    mkDPIDecl :: DPIInst -> VDPI
+    mkDPIDecl inst =
       let
+          rt        = dpii_ret inst
+          arg_types = dpii_args inst
+
           mkResName = mkVId "res"
           mkArgName n = mkVId ("arg" ++ show (n :: Integer))
 
@@ -542,12 +631,18 @@ mkDPIDeclarations ffuncs = map mkDPIDecl ffuncs
           mkIn n t = (mkArgName n, True, toVDPIType t)
           mkIns ts = zipWith mkIn [0..] ts
 
+          -- Wide/poly-derived returns are returned via a leading output arg
           (vdpi_ret, vdpi_args) =
-            if isWide rt || isPoly rt
+            if isWide rt
             then (VDT_void, (mkOut rt : mkIns arg_types))
             else (toVDPIType rt, mkIns arg_types)
+
+          svname   = mkDPIMonoName (dpii_cname inst) (dpii_widths inst)
+          needsWrap = not (null (dpii_widths inst))
+          mclink   = if needsWrap then Just (mkDPIWrapperName svname) else Nothing
+          vdpi_cfn = if needsWrap then Just (dpii_cname inst) else Nothing
       in
-         VDPI (idToVId name) vdpi_ret vdpi_args
+         VDPI (mkVId svname) mclink vdpi_cfn vdpi_ret vdpi_args
 
     toVDPIType :: ForeignType -> VDPIType
     toVDPIType Void = VDT_void
@@ -558,22 +653,6 @@ mkDPIDeclarations ffuncs = map mkDPIDecl ffuncs
     toVDPIType (Wide n)    = VDT_wide n
     toVDPIType StringPtr   = VDT_string
     toVDPIType Polymorphic = VDT_poly
-
-getForeignFunctions :: ForeignFuncMap -> ASPackage -> [ForeignFunction]
-getForeignFunctions ffmap aspkg =
-  let
-      expr_ff_uses = findAExprs exprForeignCalls aspkg
-      expr_ff_names =
-        [ i | (AFunCall { ae_funname = i, ae_isC = True }) <- expr_ff_uses ]
-
-      act_ff_uses = concatMap snd (aspkg_foreign_calls aspkg)
-      act_ff_names = map afc_fun act_ff_uses
-
-      ff_names = nub (expr_ff_names ++ act_ff_names)
-
-      findFF name = M.lookup name ffmap
-  in
-      mapMaybe findFF ff_names
 
 -- #############################################################################
 -- # Map to and from real Verilog foreign funcs and the BSV AV version.

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -836,6 +836,7 @@ instance Bin VMItem where
                                          toBin m
     writeBytes (VMGroup a body)     = do putI 6; toBin a; toBin body
     writeBytes (VMFunction f)       = do putI 7; toBin f
+    writeBytes (VMDPI dpi)          = do putI 8; toBin dpi
     readBytes = do
       i <- getI
       case i of
@@ -849,6 +850,7 @@ instance Bin VMItem where
                 return (VMRegGroup i s c m)
         6 -> do a <- fromBin; body <- fromBin; return (VMGroup a body)
         7 -> do f <- fromBin; return (VMFunction f)
+        8 -> do dpi <- fromBin; return (VMDPI dpi)
         n -> internalError $ "GenABin(VMItem).readBytes: " ++ show n
 
 instance Bin VVDecl where

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -725,10 +725,11 @@ instance Bin VModule where
                    body <-fromBin; return (VModule name c ports body)
 
 instance Bin VDPI where
-    writeBytes (VDPI name ret args) =
-        do toBin name; toBin ret; toBin args
-    readBytes = do name <- fromBin; ret <- fromBin; args <- fromBin;
-                   return (VDPI name ret args)
+    writeBytes (VDPI name mclink cfn ret args) =
+        do toBin name; toBin mclink; toBin cfn; toBin ret; toBin args
+    readBytes = do name <- fromBin; mclink <- fromBin; cfn <- fromBin;
+                   ret <- fromBin; args <- fromBin;
+                   return (VDPI name mclink cfn ret args)
 
 instance Bin VDPIType where
     writeBytes (VDT_void)    = do putI 0

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -135,26 +135,36 @@ ppComment cs =
 
 
 -- VDPI
---    * The function name
+--    * The function name (the SystemVerilog function name)
+--    * An optional C linkage name (the "c_identifier =" alias); when present,
+--      the SV function links to this generated wrapper C symbol instead of a
+--      C function of the same name.  Used for monomorphized polymorphic imports.
+--    * An optional "real" C function name that the wrapper forwards to (present
+--      exactly when the c_identifier alias is).  Carried so the wrapper can be
+--      generated directly from the VDPI.
 --    * The return type
 --    * The arguments (name, whether it's an input, type)
-data VDPI = VDPI VId VDPIType [(VId, Bool, VDPIType)]
+data VDPI = VDPI VId (Maybe String) (Maybe String) VDPIType [(VId, Bool, VDPIType)]
         deriving (Eq, Show, Generic.Data, Generic.Typeable)
 
 instance PPrint VDPI where
-  pPrint d p (VDPI name ret args) =
+  pPrint d p (VDPI name mclink _cfn ret args) =
     let
         mkDir False = text "output"
         mkDir True  = text "input"
         ppArg (i, dir, t) = mkDir dir <+> pPrint d 0 t <+> pPrint d 0 i
+        clink = case mclink of
+                  Nothing -> empty
+                  Just s  -> text s <+> text "="
     in
-        text "import \"DPI-C\" function" <+>
+        text "import \"DPI-C\"" <+> clink <+> text "function" <+>
         pPrint d 0 ret <+> pPrint d 0 name <+> text "(" <>
         sepList (map ppArg args) (text ",") <>
         text ");"
 
 instance NFData VDPI where
-    rnf (VDPI name ret args) = rnf3 name ret args
+    rnf (VDPI name mclink cfn ret args) =
+        rnf name `seq` rnf mclink `seq` rnf cfn `seq` rnf ret `seq` rnf args
 
 data VDPIType = VDT_void
               | VDT_byte
@@ -172,6 +182,10 @@ instance PPrint VDPIType where
   pPrint _ _ VDT_longint = text "longint unsigned"
   pPrint _ _ (VDT_wide n) = text $ "bit [" ++ itos (n-1) ++ ":0]"
   pPrint _ _ VDT_string  = text "string"
+  -- VDT_poly is not emitted in DPI import declarations: polymorphic operands
+  -- are monomorphized to a concrete "bit [W-1:0]" (VDT_wide W) per use width
+  -- (see ForeignFunctions.mkDPIDeclarations).  This rendering is a harmless
+  -- placeholder should it ever be printed.
   pPrint _ _ VDT_poly    = text "bit []"
 
 instance NFData VDPIType where

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -89,11 +89,14 @@ data VProgram = VProgram [VModule] [VDPI] VComment
         deriving (Eq, Show, Generic.Data, Generic.Typeable)
 
 instance PPrint VProgram where
-    pPrint d p (VProgram ms dpis cs) =
+    -- Note: DPI import declarations (dpis) are carried on the VProgram for the
+    -- wrapper generator, but are printed at *module* scope (as VMDPI items in
+    -- each module's body), not here at file/$unit scope -- see AVerilog and the
+    -- VMDPI note in VMItem.
+    pPrint d p (VProgram ms _dpis cs) =
         ppComment cs $+$
         assignment_delay_macro $+$
         reset_level_macro $+$
-        dpi_decls $+$
         vsepEmptyLine (map (pPrint d 0) ms) $+$
         text ""
       where -- define BSV_ASSIGNMENT_DELAY when the user does not override it
@@ -113,9 +116,6 @@ instance PPrint VProgram where
           text "  `define BSV_RESET_EDGE negedge" $+$
           text "`endif" $+$
           text ""
-        dpi_decls =
-          vsep (map (pPrint d 0) dpis) $+$
-          if (not (null dpis)) then text "" else empty
 
 instance NFData VProgram where
     rnf (VProgram mods dpis cmt) = rnf3 mods dpis cmt
@@ -340,6 +340,11 @@ data VMItem
         --          if no spaces needed, use a list of one list.
         | VMGroup { vg_translate_off :: Bool, vg_body :: [[VMItem]]}
         | VMFunction VFunction
+        -- an import "DPI-C" declaration, emitted at *module* scope (rather
+        -- than file/$unit scope) so that multiple modules using the same
+        -- foreign function don't produce duplicate $unit declarations that
+        -- Verilator rejects when they are compiled together.
+        | VMDPI VDPI
         deriving (Eq, Show, Generic.Data, Generic.Typeable)
 
 instance Ord VMItem where
@@ -411,6 +416,7 @@ instance PPrint VMItem where
                 | otherwise = vsepEmptyLine (map (ppLines d) stmtss)
 
         pPrint d p (VMFunction f) = pPrint d p f
+        pPrint d p (VMDPI dpi) = pPrint d p dpi
         pPrint d p (VMRegGroup inst_id def_name cs stmt) =
             text "// register" <+>
             pPrint d 0 inst_id $+$
@@ -426,6 +432,7 @@ instance NFData VMItem where
     rnf (VMRegGroup vid s cmt item) = rnf4 vid s cmt item
     rnf (VMGroup toff body) = rnf2 toff body
     rnf (VMFunction vfun) = rnf vfun
+    rnf (VMDPI dpi) = rnf dpi
 
 pv95params :: PDetail -> (Maybe String, VExpr) -> Doc
 pv95params d (Nothing,x)  =  pPrint d 0 x

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -359,6 +359,12 @@ instance Ord VMItem where
          compare (VMRegGroup _ _ _ x) y                    = compare x y
          compare x                    (VMRegGroup _ _ _ y) = compare x y
 
+         -- DPI imports are declared at module scope ahead of
+         -- everything else, so they sort first
+         compare (VMDPI _) (VMDPI _)                = EQ
+         compare (VMDPI _) _                        = LT
+         compare _         (VMDPI _)                = GT
+
          compare (VMDecl dl) (VMDecl dr)            = compare dl dr
          compare (VMDecl  _) _                      = LT
 

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -36,7 +36,7 @@ import ParseOp
 import PFPrint
 import Util(headOrErr, fromJustOrErr, joinByFst, quote, fst3)
 import FileNameUtil(baseName, hasDotSuf, dropSuf, dirName, mangleFileName,
-                    mkAName, mkVName, mkVPICName,
+                    mkAName, mkVName, mkVPICName, mkDPICName,
                     mkNameWithoutSuffix,
                     mkSoName, mkObjName, mkMakeName,
                     bscSrcSuffix, binSuffix,
@@ -131,7 +131,7 @@ import ABinUtil(readAndCheckABin, readAndCheckABinPathCatch, getABIHierarchy,
                 assertNoSchedErr)
 import GenABin(genABinFile)
 import ForeignFunctions(ForeignFunction(..), ForeignFuncMap,
-                        mkImportDeclarations)
+                        mkImportDeclarations, isPoly)
 import VPIWrappers(genVPIWrappers, genVPIRegistrationArray)
 import DPIWrappers(genDPIWrappers)
 import SimCCBlock
@@ -442,10 +442,12 @@ compilePackage
     start flags DFgenVPI
     blurb <- mkGenFileHeader flags
     let ffuncs = map snd foreign_func_info
+    -- Note: with DPI, wrapper generation happens later (in genModuleVerilog),
+    -- once the concrete widths of polymorphic imports are known; see there.
     vpi_wrappers <- if (backend flags /= Just Verilog)
                     then return []
                     else if (useDPI flags)
-                         then genDPIWrappers errh flags prefix blurb ffuncs
+                         then return []
                          else genVPIWrappers errh flags prefix blurb ffuncs
     t <- dump errh flags t DFgenVPI dumpnames vpi_wrappers
 
@@ -1194,6 +1196,16 @@ genModuleVerilog errh pprops flags dumpnames time0 prefix moduleName
                    then (removeDollarsFromVerilog vprog0)
                    else vprog0
        t <- dump errh flags t DFverilogDollar dumpnames vprog
+
+       -- Generate DPI wrapper C files for any polymorphic imports.  This is
+       -- done here (not in the early foreign-function pass) because the set of
+       -- concrete widths, and hence the monomorphized wrappers, is only known
+       -- from the generated Verilog's DPI import declarations.
+       when (useDPI flags) $ do
+           let VProgram _ vdpis _ = vprog
+           ff_blurb <- mkGenFileHeader flags
+           _ <- genDPIWrappers errh flags prefix ff_blurb vdpis
+           return ()
 
        -- Write the Verilog files
        start flags DFwriteVerilog
@@ -2109,7 +2121,30 @@ vGenFFuncs errh flags t prefix cfilenames_unique ffuncs = do
       t <- timestampStr flags "compile user-provided C files" t
 
       (t, ofiles3) <-
-        if (useDPI flags) then return (t, [])
+        if (useDPI flags)
+        then do
+          -- Polymorphic imports have a generated DPI wrapper file
+          -- ("dpi_wrapper_<name>.c") which must be linked.  We do NOT
+          -- pre-compile it here: it includes svdpi.h, which lives in the
+          -- simulator's (Verilator's) include path, so we hand the source
+          -- file to the link step and let Verilator compile it.
+          let isPolyFFunc ff = isPoly (ff_ret ff) || any isPoly (ff_args ff)
+              poly_ffuncs = filter isPolyFFunc ffuncs
+          if (null poly_ffuncs)
+            then return (t, [])
+            else do
+              let findDPIWrapperFile ffunc = do
+                    let ffunc_name = getIdString (ff_name ffunc)
+                        dpiwrapper_filename = mkDPICName Nothing "" ffunc_name
+                    mfile <- readFilePath errh noPosition False
+                                          dpiwrapper_filename (vPath flags)
+                    case mfile of
+                      Nothing -> bsError errh [(noPosition,
+                                    EMissingVPIWrapperFile dpiwrapper_filename False)]
+                      Just (_, filename) -> return filename
+              dpiwrapper_filenames <- mapM findDPIWrapperFile poly_ffuncs
+              t <- timestampStr flags "locate DPI wrapper files" t
+              return (t, dpiwrapper_filenames)
         else do
           -- compile all necessary vpi wrapper files
 

--- a/src/exec/bsc_build_vsim_verilator
+++ b/src/exec/bsc_build_vsim_verilator
@@ -79,6 +79,12 @@ while [ $# -gt 0 ]; do
     BSC_VERILOG_FILES="$BSC_VERILOG_FILES $1"
   elif [ "${1%%.o}" != "$1" ]; then
     BSC_VPI_FILES="$BSC_VPI_FILES $1"
+  elif [ "${1%%.c}" != "$1" ] || [ "${1%%.cc}" != "$1" ] || \
+       [ "${1%%.cpp}" != "$1" ] || [ "${1%%.cxx}" != "$1" ]; then
+    # C/C++ source files (e.g. generated DPI wrappers) are handed to
+    # Verilator, which compiles them with its own include path (so svdpi.h
+    # is found) and links the result.
+    BSC_VPI_FILES="$BSC_VPI_FILES $1"
   elif [ "$1" = "-L" ]; then
     shift 1
     BSC_C_LIB_PATH="$BSC_C_LIB_PATH -L$1"


### PR DESCRIPTION
Layer 3/6, stacked on `verilator/2-sv-identifiers`.

Supports polymorphic `import "BDPI"` functions over the DPI path (`-use-dpi`) and emits DPI-C imports at module scope rather than file scope. The third commit is the composition seam: it covers VMDPI in layer 2's identifier scans and the VMItem ordering. Mirrors upstream PR B-Lang-org/bsc#999.

---
Full testsuite gate on the composed 6-layer stack tip: **20,323 PASS / 0 FAIL / 134 XFAIL / 0 ERROR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
