### PR TITLE
verilator 4/6: -dump-formats — waveform format selection at link time

### DIFF
--- a/src/Verilator/sim_main.cpp
+++ b/src/Verilator/sim_main.cpp
@@ -20,9 +20,25 @@
 
 #include QUOTE(mkV(TOP).h)
 
-// If "verilator --trace" is used, include the tracing class
+// Tracing: verilator compiles in exactly one format -- VCD (--trace) or FST
+// (--trace-fst), which are mutually exclusive and signalled by VM_TRACE_FST.
+// Select the matching writer class and the plusarg/filename for it.  With
+// -dump-formats none (no --trace) VM_TRACE is 0 and nothing below is compiled.
 #if VM_TRACE
-# include <verilated_vcd_c.h>
+# if defined(VM_TRACE_FST) && VM_TRACE_FST
+#  include <verilated_fst_c.h>
+typedef VerilatedFstC BscTraceC;
+#  define BSC_DUMP_FILE "dump.fst"
+#  define BSC_DUMP_ARG  "bscfst"
+#  define BSC_OTHER_ARG "bscvcd"
+# else
+#  include <verilated_vcd_c.h>
+typedef VerilatedVcdC BscTraceC;
+#  define BSC_DUMP_FILE "dump.vcd"
+#  define BSC_DUMP_ARG  "bscvcd"
+#  define BSC_OTHER_ARG "bscfst"
+# endif
+static BscTraceC* tfp = NULL;    // harness trace file (guarded by VM_TRACE)
 #endif
 
 vluint64_t main_time = 0;    // Current simulation time
@@ -31,7 +47,7 @@ double sc_time_stamp () {    // Called by $time in Verilog
     return main_time;
 }
 
-inline void step (mkV(TOP)* TOP, VerilatedVcdC* tfp, vluint64_t incr)
+inline void step (mkV(TOP)* TOP, vluint64_t incr)
 {
 #if VM_TRACE
     if (tfp)
@@ -47,33 +63,47 @@ int main (int argc, char **argv, char **env) {
     // Use a hierarchical name that matches 'main.v'
     mkV(TOP)* TOP = new mkV(TOP)("main");    // create instance of model
 
-    VerilatedVcdC* tfp = NULL;    // pointer for tracing
-
 #if VM_TRACE
-    // If verilator was invoked with --trace argument,
-    // and if at run time passed the +bscvcd argument, turn on tracing
-    const char* flag = Verilated::commandArgsPlusMatch("bscvcd");
-    if (flag && 0==strcmp(flag, "+bscvcd")) {
+    // +bscvcd / +bscfst: open the harness dump in whichever format this binary
+    // was built for (BSC_DUMP_ARG).  The format is fixed at build time
+    // (--trace vs --trace-fst), so passing the *other* format's plusarg errors.
+    const char* flag = Verilated::commandArgsPlusMatch(BSC_DUMP_ARG);
+    if (flag && 0==strcmp(flag, "+" BSC_DUMP_ARG)) {
         Verilated::traceEverOn(true);  // Verilator must compute traced signals
-        VL_PRINTF("Enabling waves into dump.vcd...\n");
-        tfp = new VerilatedVcdC;
+        VL_PRINTF("Enabling waves into %s...\n", BSC_DUMP_FILE);
+        tfp = new BscTraceC;
         TOP->trace(tfp, 99);  // Trace 99 levels of hierarchy
-        tfp->open("dump.vcd");  // Open the dump file
+        tfp->open(BSC_DUMP_FILE);  // Open the dump file
+    }
+    const char* other = Verilated::commandArgsPlusMatch(BSC_OTHER_ARG);
+    if (other && 0==strcmp(other, "+" BSC_OTHER_ARG)) {
+        VL_PRINTF("%%Error: this model was built for %s, not +%s "
+                  "(rebuild with a different -dump-formats)\n",
+                  BSC_DUMP_FILE, BSC_OTHER_ARG);
+    }
+#else
+    // Built with -dump-formats none (no --trace): no dumping is compiled in.
+    // Fail loudly if a dump was requested rather than silently doing nothing.
+    const char* nov = Verilated::commandArgsPlusMatch("bscvcd");
+    const char* nof = Verilated::commandArgsPlusMatch("bscfst");
+    if ((nov && 0==strcmp(nov, "+bscvcd")) || (nof && 0==strcmp(nof, "+bscfst"))) {
+        VL_PRINTF("%%Error: this model was built with -dump-formats none; "
+                  "no waveform dumping is available\n");
     }
 #endif
 
     // initial conditions
     TOP->BSV_RESET_NAME = BSV_RESET_VALUE;
     TOP->CLK = 0;
-    step(TOP, tfp, 1);
+    step(TOP, 1);
 
     // First CLK edge to time 1
     TOP->CLK = 1;
-    step(TOP, tfp, 1);
+    step(TOP, 1);
 
     // De-assert RST at time 2
     TOP->BSV_RESET_NAME = 1 - BSV_RESET_VALUE;
-    step(TOP, tfp, 3);
+    step(TOP, 3);
 
     // now resume normal CLK cycle
     // negedge on 5, posedge on 10
@@ -81,11 +111,11 @@ int main (int argc, char **argv, char **env) {
     while (! Verilated::gotFinish ()) {
 
 	TOP->CLK = 0;
-	step(TOP, tfp, 5);
+	step(TOP, 5);
 	if (Verilated::gotFinish ()) break;
 
 	TOP->CLK = 1;
-	step(TOP, tfp, 5);
+	step(TOP, 5);
     }
 
     TOP->final ();    // Done simulating

--- a/src/Verilog/main.v
+++ b/src/Verilog/main.v
@@ -52,7 +52,9 @@ module main();
  `define BSV_DUMP_TOP main
 `endif
 
-   reg [8*256:1] filename;
+   reg [8*256:1] filename;        // VCD dump file
+   reg [8*256:1] fst_filename;    // FST dump file
+   reg [8*256:1] fsdb_filename;   // FSDB dump file
 
    initial begin
       // CLK_GATE = 1'b1;
@@ -70,29 +72,39 @@ module main();
       else if (do_vcd)
 	filename = "dump.vcd";
 
-      if ($value$plusargs("bscfsdb=%s", filename))
+      if ($value$plusargs("bscfst=%s", fst_filename))
+	do_fst = 1;
+      else if (do_fst)
+	fst_filename = "dump.fst";
+
+      if ($value$plusargs("bscfsdb=%s", fsdb_filename))
 	do_fsdb = 1; // avoids bug in cvc
       else if (do_fsdb)
-	filename = "dump.fsdb";
+	fsdb_filename = "dump.fsdb";
 
+      // FSDB uses its own system tasks, available only when the Verdi PLI was
+      // linked (BSC_FSDB defined); it can coexist with a VCD/FST dump below.
 `ifdef BSC_FSDB
       if (do_fsdb) begin
-         $fsdbDumpfile(filename);
+         $fsdbDumpfile(fsdb_filename);
          $fsdbDumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
       end
 `else
+      if (do_fsdb)
+	$display("ERROR: %m was not built with FSDB support (rebuild with -dump-formats fsdb)");
+`endif
 
-//      if (do_fst && ! do_vcd) begin
-//         $dumpfile("|vcd2fst -F -f dump.fst -");
-//         $dumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
-//      end
-
-      if (do_vcd) begin
+      // VCD and FST share $dumpfile/$dumpvars; the on-disk format for FST is
+      // selected by the simulator at run time (e.g. iverilog: vvp -fst), so a
+      // build runs at most one of them -- FST takes precedence if both are asked.
+      if (do_fst) begin
+         $dumpfile(fst_filename);
+         $dumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
+      end
+      else if (do_vcd) begin
          $dumpfile(filename);
          $dumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
       end
-
-`endif
 
       #0
       RST = `BSV_RESET_VALUE;

--- a/src/Verilog/main.v
+++ b/src/Verilog/main.v
@@ -97,6 +97,12 @@ module main();
       // VCD and FST share $dumpfile/$dumpvars; the on-disk format for FST is
       // selected by the simulator at run time (e.g. iverilog: vvp -fst), so a
       // build runs at most one of them -- FST takes precedence if both are asked.
+      // With -dump-formats none the build script defines BSC_NO_DUMP: the dump
+      // trigger is compiled out and a request errors loudly instead of dumping.
+`ifdef BSC_NO_DUMP
+      if (do_fst || do_vcd)
+	$display("ERROR: %m was built with -dump-formats none; no waveform dumping is available");
+`else
       if (do_fst) begin
          $dumpfile(fst_filename);
          $dumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
@@ -105,6 +111,7 @@ module main();
          $dumpfile(filename);
          $dumpvars(`BSV_DUMP_LEVEL, `BSV_DUMP_TOP);
       end
+`endif
 
       #0
       RST = `BSV_RESET_VALUE;

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -43,6 +43,8 @@ data Flags = Flags {
         passThroughAssertions :: Bool,
         doICheck :: Bool,
         dumpAll :: Maybe (Maybe FilePath), -- maybe dump to file or stdout
+        dumpFormats :: [String], -- waveform dump formats compiled into the sim
+                                 -- (subset of vcd/fst/fsdb; [] means none)
         dumps :: [(DumpFlag, Maybe FilePath)], -- dump to file or stdout
         enablePoisonPills :: Bool,
         entry :: Maybe String,

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -535,6 +535,7 @@ defaultFlags bluespecdir = Flags {
         passThroughAssertions = False,
         doICheck = True,
         dumpAll = Nothing,
+        dumpFormats = ["vcd"],
         dumps = [],
         enablePoisonPills = False,
         entry = Nothing,
@@ -1697,6 +1698,23 @@ externalFlags = [
          (Arg "path" (\f s -> Left (f {vPathRaw = splitPath' f s vPathRaw})) (showPath vPathRaw),
           "search path (`:' sep.) for Verilog files", Visible)),
 
+        ("dump-formats",
+         let valids = ["none", "vcd", "fst", "fsdb"]
+             setFn f s =
+               let toks = filter (not . null) (splitWhen (== ',') s)
+               in case filter (`notElem` valids) toks of
+                    (bad:_) -> Right (cmdPosition, EBadArgFlag "-dump-formats" bad valids)
+                    []      -> Left $ f { dumpFormats =
+                                           if "none" `elem` toks
+                                           then []
+                                           else nub (filter (/= "none") toks) }
+             getFn = FRTString (\f -> case dumpFormats f of
+                                        [] -> "none"
+                                        fs -> intercalate "," fs)
+         in  (Arg "formats" setFn (Just getFn),
+              "waveform formats to compile into the simulation " ++
+              "(comma-separated subset of vcd,fst,fsdb; or none)", Visible)),
+
         ("vsim",
          let setFn f s = case setBackend f Verilog of
                            Left f' -> Left $ f' {vsim = Just s}
@@ -1847,6 +1865,7 @@ showFlagsRaw flags =
           ("disableAssertions", show (disableAssertions flags)),
           ("doICheck", show (doICheck flags)),
           ("dumpAll", show (dumpAll flags)),
+          ("dumpFormats", show (dumpFormats flags)),
           ("dumps", show (dumps flags)),
           ("enablePoisonPills", show (enablePoisonPills flags)),
           ("entry", show (entry flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260712-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260715-1"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -550,7 +550,7 @@ instance Bin Flags where
     writeBytes (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
-                a_020 a_021 a_022 a_023 a_024 a_025 a_026 a_027 a_028 a_029
+                a_020 a_021 a_dumpFormats a_022 a_023 a_024 a_025 a_026 a_027 a_028 a_029
                 a_030 a_031 a_032 a_033 a_034 a_035 a_036 a_037 a_038 a_039
                 a_040 a_041 a_042 a_043 a_044 a_045 a_046 a_047 a_048 a_049
                 a_050 a_051 a_052 a_053 a_054 a_055 a_056 a_057 a_058 a_059
@@ -576,7 +576,7 @@ instance Bin Flags where
         {-# NOINLINE wr_chunk1 #-}
         wr_chunk1 =
           do toBin a_015; toBin a_016; toBin a_017; toBin a_018; toBin a_019;
-             toBin a_020; toBin a_021; toBin a_022; toBin a_023; toBin a_024;
+             toBin a_020; toBin a_021; toBin a_dumpFormats; toBin a_022; toBin a_023; toBin a_024;
              toBin a_025; toBin a_026; toBin a_027; toBin a_028; toBin a_029
         {-# NOINLINE wr_chunk2 #-}
         wr_chunk2 =
@@ -616,7 +616,7 @@ instance Bin Flags where
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
-          (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
+          (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_dumpFormats, a_022,
            a_023, a_024, a_025, a_026, a_027, a_028, a_029) <- rd_chunk1
           (a_030, a_031, a_032, a_033, a_034, a_035, a_036, a_037,
            a_038, a_039, a_040, a_041, a_042, a_043, a_044) <- rd_chunk2
@@ -635,7 +635,7 @@ instance Bin Flags where
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
-                a_020 a_021 a_022 a_023 a_024 a_025 a_026 a_027 a_028 a_029
+                a_020 a_021 a_dumpFormats a_022 a_023 a_024 a_025 a_026 a_027 a_028 a_029
                 a_030 a_031 a_032 a_033 a_034 a_035 a_036 a_037 a_038 a_039
                 a_040 a_041 a_042 a_043 a_044 a_045 a_046 a_047 a_048 a_049
                 a_050 a_051 a_052 a_053 a_054 a_055 a_056 a_057 a_058 a_059
@@ -658,9 +658,9 @@ instance Bin Flags where
         {-# NOINLINE rd_chunk1 #-}
         rd_chunk1 =
           do a_015 <- fromBin; a_016 <- fromBin; a_017 <- fromBin; a_018 <- fromBin; a_019 <- fromBin;
-             a_020 <- fromBin; a_021 <- fromBin; a_022 <- fromBin; a_023 <- fromBin; a_024 <- fromBin;
+             a_020 <- fromBin; a_021 <- fromBin; a_dumpFormats <- fromBin; a_022 <- fromBin; a_023 <- fromBin; a_024 <- fromBin;
              a_025 <- fromBin; a_026 <- fromBin; a_027 <- fromBin; a_028 <- fromBin; a_029 <- fromBin
-             return (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_022,
+             return (a_015, a_016, a_017, a_018, a_019, a_020, a_021, a_dumpFormats, a_022,
                      a_023, a_024, a_025, a_026, a_027, a_028, a_029)
         {-# NOINLINE rd_chunk2 #-}
         rd_chunk2 =

--- a/src/comp/SimBlocksToC.hs
+++ b/src/comp/SimBlocksToC.hs
@@ -514,22 +514,34 @@ convertSchedules flags creation_time top_id def_clk def_rst sb_map ff_map
         dump_methods  = [ comment "State dumping function" state_dump_def ]
 
         -- function for dumping VCDs
+        -- with -dump-formats none the per-signal dump code was not generated,
+        -- so instead of silently writing an empty VCD, report an error when
+        -- dumping is requested (dump_VCD_defs runs once, at VCD-header time)
+        genVCD         = "vcd" `elem` dumpFormats flags
+        no_vcd_msg     = "Error: this model was built with -dump-formats none; "
+                         ++ "no waveform dumping is available\n"
+        no_vcd_err     = stmt $ (var "fprintf") `cCall`
+                                  [ var "stderr", mkStr no_vcd_msg ]
         top_backing    = [mkBacking top_blk]
         dump_type      = (userType "tVCDDumpType") (mkVar "dt")
         vcd_depth      = (var "vcd_depth") `cCall` [ var "sim_hdl" ]
         vcd_hdr_proto  = function void (mkScopedVar "dump_VCD_defs") []
         vcd_hdr_def    = define vcd_hdr_proto
-                                (block [ mkDumpCall top_blk "dump_VCD_defs"
-                                                    [ vcd_depth ]])
+                                (if genVCD
+                                 then block [ mkDumpCall top_blk "dump_VCD_defs"
+                                                         [ vcd_depth ]]
+                                 else block [ no_vcd_err ])
         backing_fn sb  = (var ((sb_name sb) ++ "_backing")) `cCall` [ var "sim_hdl" ]
         vcd_proto      = function void (mkScopedVar "dump_VCD") [ dump_type ]
         vcd_def        = define vcd_proto
-                                (block [ mkDumpCall top_blk "dump_VCD"
-                                                    [ var "dt"
-                                                    , vcd_depth
-                                                    , backing_fn top_blk
-                                                    ]
-                                       ])
+                                (if genVCD
+                                 then block [ mkDumpCall top_blk "dump_VCD"
+                                                         [ var "dt"
+                                                         , vcd_depth
+                                                         , backing_fn top_blk
+                                                         ]
+                                            ]
+                                 else block [])
         vcd_methods = [ comment "VCD dumping functions" (blankLines 0) ] ++
                       top_backing ++ [ vcd_hdr_def, vcd_def ]
 

--- a/src/comp/SimBlocksToC.hs
+++ b/src/comp/SimBlocksToC.hs
@@ -187,12 +187,17 @@ convertModuleBlock flags sb_map ff_map clk_map wdef_mod_map reused top_blk write
         -- list of subblocks that need to be included
         include_ids = nub (map (\(id,_,_)->id) (sb_state sb))
 
+        -- whether to emit the per-signal VCD dumping code (-dump-formats vcd);
+        -- with -dump-formats none it is stubbed out, dropping a lot of
+        -- generated code in large/replicated designs.
+        genVCD = "vcd" `elem` dumpFormats flags
+
         -- class declaration (for the H file)
-        class_decl = simCCBlockToClassDeclaration sb_map sb
+        class_decl = simCCBlockToClassDeclaration genVCD sb_map sb
 
         -- method definitions (for the CXX file)
         (method_defs, state) =
-            runState (simCCBlockToClassDefinition sb_map dom_map sb)
+            runState (simCCBlockToClassDefinition genVCD sb_map dom_map sb)
                      (initialState ff_map wdef_inst_map (unSpecTo flags))
         lit_defs = mkLiteralDecls (nub (literals state))
         str_defs = mkStringDecls (M.toList (str_map state))

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -1595,8 +1595,8 @@ isOkId i = not ((isInternal i) || (isBadId i) || (isFromRHSId i))
 -- Generate a class declaration for the SimCCBlock.
 -- The declaration will include all of the state elements and local
 -- defs, along with rule and method declarations.
-simCCBlockToClassDeclaration :: SBMap -> SimCCBlock -> CCFragment
-simCCBlockToClassDeclaration sb_map sb =
+simCCBlockToClassDeclaration :: Bool -> SBMap -> SimCCBlock -> CCFragment
+simCCBlockToClassDeclaration genVCD sb_map sb =
   let clks        = [ decl $ clockType (mkVar (mkClkDefName dom))
                     | dom <- sb_domains sb]
       clk_defs    = [comment "Clock handles" (private clks)]
@@ -1665,14 +1665,16 @@ simCCBlockToClassDeclaration sb_map sb =
       vcd_hdr     = decl $ vcdHdrFnProto Nothing
       is_string_type (ATString _) = True
       is_string_type _            = False
-      has_members = any (not . null) [ sb_resetDefs sb
+      -- with -dump-formats none (genVCD False) no VCD helper functions are
+      -- emitted, so their prototypes must not be declared either
+      has_members = genVCD && any (not . null) [ sb_resetDefs sb
                                      , [ (t,i)
                                        | (t,i) <- ((sb_privateDefs sb) ++ (sb_publicDefs sb))
                                        , not (is_string_type t)
                                        ]
                                      ]
-      has_prims = or [ isPrimBlock sub | (sub,_,_) <- sb_state sb ]
-      has_submodules = or [ not (isPrimBlock sub) | (sub,_,_) <- sb_state sb ]
+      has_prims = genVCD && or [ isPrimBlock sub | (sub,_,_) <- sb_state sb ]
+      has_submodules = genVCD && or [ not (isPrimBlock sub) | (sub,_,_) <- sb_state sb ]
       vcd_changes = [ decl $ vcdFnProto sb Nothing ]
                     ++
                     (if has_members
@@ -1763,9 +1765,9 @@ symOrd (str1,sym1) (str2,sym2) =
                       GT -> GT
               GT -> GT
 
-simCCBlockToClassDefinition :: SBMap -> M.Map (Bool,AId) ClockDomain ->
+simCCBlockToClassDefinition :: Bool -> SBMap -> M.Map (Bool,AId) ClockDomain ->
                                SimCCBlock -> StmtsConv
-simCCBlockToClassDefinition sb_map sch_map sb =
+simCCBlockToClassDefinition genVCD sb_map sch_map sb =
   do let scope = Just (pfxMod ++ (sb_name sb))
          state_defs = map (addSBArgs sb_map) (sb_state sb)
          task_id_set = S.fromList (sb_taskDefs sb)
@@ -1917,12 +1919,15 @@ simCCBlockToClassDefinition sb_map sch_map sb =
                          ]
          meth_map = M.fromList [ (i,d) | (d,is) <- ids_by_clock', i <- is ]
          clk_map = M.unions [ rl_map, meth_map, sch_map ]
-         prims = sortBy cmpIdByName
+         -- with -dump-formats none (genVCD False) these are emptied, which (via
+         -- the null-checks below) collapses the per-signal VCD defs, the value-
+         -- dumping helpers, and the submodule recursion to empty method stubs
+         prims = if not genVCD then [] else sortBy cmpIdByName
                         (catMaybes [ if isPrimBlock sub
                                      then Just inst
                                      else Nothing
                                    | (sub,inst,_) <- sb_state sb ])
-         sub_modules = sortBy cmpIdByName
+         sub_modules = if not genVCD then [] else sortBy cmpIdByName
                               (catMaybes [ if isPrimBlock sub
                                            then Nothing
                                            else Just inst
@@ -1930,7 +1935,7 @@ simCCBlockToClassDefinition sb_map sch_map sb =
          cmp_def (_,i1,_) (_,i2,_) = i1 `cmpIdByName` i2
          is_string_type (ATString _) = True
          is_string_type _            = False
-         members = sortBy cmp_def $
+         members = if not genVCD then [] else sortBy cmp_def $
                           [ (t,i,True)
                           | (t,i) <- (sb_resetDefs sb)
                           ] ++
@@ -1939,7 +1944,7 @@ simCCBlockToClassDefinition sb_map sch_map sb =
                                       (sb_publicDefs sb))
                           , not (is_string_type t)
                           ]
-         ports = sortBy cmp_def
+         ports = if not genVCD then [] else sortBy cmp_def
                         [ (t,vName_to_id vn,True)
                         | (t,_,vn) <- sb_methodPorts sb ]
          num_ids = (length members) + (length ports) + (length prims)

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -2029,7 +2029,13 @@ vSimLink errh flags toplevel prefix vfiles ofiles = do
                 veriFiles bsdir ++
                 (map vfnString vfiles) ++
                 ofiles)
-        cmd = unwords (build_script : args)
+        -- pass the requested waveform dump formats to the build script, which
+        -- translates them to the simulator's mechanism (or errors if unsupported)
+        dumpFmts = case dumpFormats flags of
+                     [] -> "none"
+                     fs -> intercalate "," fs
+        cmd = "BSC_VSIM_TRACE_FORMATS=" ++ dumpFmts ++ " " ++
+              unwords (build_script : args)
     when (verbose flags) $ putStrLnF ("exec: " ++ cmd)
     rc <- system cmd
     case rc of

--- a/src/exec/bsc_build_vsim_iverilog
+++ b/src/exec/bsc_build_vsim_iverilog
@@ -194,14 +194,34 @@ fi
 # path to Verilog files
 VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 
+# -dump-formats handling.  iverilog emits VCD natively and FST via the vvp
+# "-fst" runtime flag, so vcd/fst need nothing at build time; fsdb is not an
+# iverilog format.  With "none", define BSC_NO_DUMP so the main.v dump trigger
+# is compiled out (a +bscvcd/+bscfst request then errors instead of dumping).
+DUMP_DEFS=""
+if [ -n "$BSC_VSIM_TRACE_FORMATS" ]; then
+    want_dump=no
+    OLDIFS=$IFS; IFS=','
+    for fmt in $BSC_VSIM_TRACE_FORMATS; do
+        case "$fmt" in
+            none) ;;
+            vcd|fst) want_dump=yes ;;
+            *) echo "ERROR: iverilog does not support waveform dump format '$fmt' (supported: vcd, fst)" >&2
+               IFS=$OLDIFS; exit 1 ;;
+        esac
+    done
+    IFS=$OLDIFS
+    if [ "$want_dump" = no ]; then DUMP_DEFS="-DBSC_NO_DUMP"; fi
+fi
+
 # compile Verilog files
 if [ "$VERBOSE" = "yes" ]; then
   IV_VERBOSE="-v"
-  echo "exec: iverilog -v -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
+  echo "exec: iverilog -v -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS $DUMP_DEFS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
 else
   IV_VERBOSE=""
 fi
-iverilog $IV_VERBOSE -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
+iverilog $IV_VERBOSE -o $BSC_SIM_EXECUTABLE -Wall $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS $DUMP_DEFS -DTOP=$BSC_TOPLEVEL_MODULE $VPI_LIBPATH $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
 status=$?
 if [ "$status" != "0" ]; then
   echo "ERROR: cannot compile Verilog files" >&2

--- a/src/exec/bsc_build_vsim_vcs
+++ b/src/exec/bsc_build_vsim_vcs
@@ -178,14 +178,32 @@ fi
 # path to Verilog files
 VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 
+# -dump-formats handling.  VCS emits VCD natively ($dumpvars); FSDB is enabled
+# with -kdb (modern VCS bundles the Verdi FSDB writer, so no external Verdi PLI
+# is needed) plus +define+BSC_FSDB so the harness calls $fsdbDumpvars.  VCS does
+# not produce FST.
+DUMP_FLAGS=""
+if [ -n "$BSC_VSIM_TRACE_FORMATS" ]; then
+    OLDIFS=$IFS; IFS=','
+    for fmt in $BSC_VSIM_TRACE_FORMATS; do
+        case "$fmt" in
+            none|vcd) ;;
+            fsdb) DUMP_FLAGS="$DUMP_FLAGS -kdb -debug_access+all +define+BSC_FSDB" ;;
+            *) echo "ERROR: vcs does not support waveform dump format '$fmt' (supported: vcd, fsdb)" >&2
+               IFS=$OLDIFS; exit 1 ;;
+        esac
+    done
+    IFS=$OLDIFS
+fi
+
 # compile Verilog files
 if [ "$VERBOSE" = "yes" ]; then
     VCS_VERBOSE="-V"
-    echo "exec: vcs -V -o $BSC_SIM_EXECUTABLE +v2k +libext+.v $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS +define+TOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
+    echo "exec: vcs -V -o $BSC_SIM_EXECUTABLE +v2k +libext+.v $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS $DUMP_FLAGS +define+TOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES"
 else
     VCS_VERBOSE=""
 fi
-vcs $VCS_VERBOSE -o $BSC_SIM_EXECUTABLE +v2k +libext+.v $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS +define+TOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
+vcs $VCS_VERBOSE -o $BSC_SIM_EXECUTABLE +v2k +libext+.v $VSIM_PATH_FLAGS $BSC_VSIM_FLAGS $DUMP_FLAGS +define+TOP=$BSC_TOPLEVEL_MODULE $BSC_VERILOG_DEFS $BSC_VERILOG_OPTS $VPI_LINK $BSC_VERILOG_FILES
 status=$?
 if [ "$status" != "0" ]; then
     echo "ERROR: cannot compile Verilog files" >&2

--- a/src/exec/bsc_build_vsim_vcs
+++ b/src/exec/bsc_build_vsim_vcs
@@ -184,16 +184,23 @@ VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 # not produce FST.
 DUMP_FLAGS=""
 if [ -n "$BSC_VSIM_TRACE_FORMATS" ]; then
+    want_dump=no
     OLDIFS=$IFS; IFS=','
     for fmt in $BSC_VSIM_TRACE_FORMATS; do
         case "$fmt" in
-            none|vcd) ;;
-            fsdb) DUMP_FLAGS="$DUMP_FLAGS -kdb -debug_access+all +define+BSC_FSDB" ;;
+            none) ;;
+            vcd)  want_dump=yes ;;
+            fsdb) want_dump=yes
+                  DUMP_FLAGS="$DUMP_FLAGS -kdb -debug_access+all +define+BSC_FSDB" ;;
             *) echo "ERROR: vcs does not support waveform dump format '$fmt' (supported: vcd, fsdb)" >&2
                IFS=$OLDIFS; exit 1 ;;
         esac
     done
     IFS=$OLDIFS
+    # with "none", compile out the main.v dump trigger so a +bscvcd/+bscfst
+    # request errors instead of dumping (VCD is native to vcs, so this is the
+    # only honest way to honor "none")
+    if [ "$want_dump" = no ]; then DUMP_FLAGS="+define+BSC_NO_DUMP"; fi
 fi
 
 # compile Verilog files

--- a/src/exec/bsc_build_vsim_verilator
+++ b/src/exec/bsc_build_vsim_verilator
@@ -180,21 +180,33 @@ fi
 # path to Verilog files
 VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 
-# Validate the requested waveform dump formats (-dump-formats).  verilator
-# currently supports only VCD (via --trace); fst/fsdb are not yet wired here.
+# -dump-formats handling.  verilator compiles in exactly one trace format:
+# --trace (VCD) or --trace-fst (FST), which are mutually exclusive; "none"
+# builds with no tracing (faster).  fsdb is not a verilator format.  sim_main.cpp
+# selects the matching writer class via verilator's VM_TRACE_FST macro.
+TRACEFLAGS="--trace"
 if [ -n "$BSC_VSIM_TRACE_FORMATS" ]; then
+    want_vcd=no; want_fst=no
     OLDIFS=$IFS; IFS=','
     for fmt in $BSC_VSIM_TRACE_FORMATS; do
         case "$fmt" in
-            none|vcd) ;;
-            *) echo "ERROR: verilator does not support waveform dump format '$fmt' (supported: vcd)" >&2
+            none) ;;
+            vcd)  want_vcd=yes ;;
+            fst)  want_fst=yes ;;
+            *) echo "ERROR: verilator does not support waveform dump format '$fmt' (supported: vcd, fst)" >&2
                IFS=$OLDIFS; exit 1 ;;
         esac
     done
     IFS=$OLDIFS
+    if [ "$want_vcd" = yes ] && [ "$want_fst" = yes ]; then
+        echo "ERROR: verilator cannot build both vcd and fst into one binary (--trace and --trace-fst are mutually exclusive); choose one" >&2
+        exit 1
+    fi
+    if   [ "$want_fst" = yes ]; then TRACEFLAGS="--trace-fst"
+    elif [ "$want_vcd" = yes ]; then TRACEFLAGS="--trace"
+    else                             TRACEFLAGS=""   # none: no tracing compiled in
+    fi
 fi
-
-TRACEFLAGS="--trace"
 
 # Don't rely on the top module file being the first on the command-line
 TOPMOD=${BSC_TOPLEVEL_MODULE}

--- a/src/exec/bsc_build_vsim_verilator
+++ b/src/exec/bsc_build_vsim_verilator
@@ -180,6 +180,20 @@ fi
 # path to Verilog files
 VSIM_PATH_FLAGS=$BSC_VERILOG_DIRS
 
+# Validate the requested waveform dump formats (-dump-formats).  verilator
+# currently supports only VCD (via --trace); fst/fsdb are not yet wired here.
+if [ -n "$BSC_VSIM_TRACE_FORMATS" ]; then
+    OLDIFS=$IFS; IFS=','
+    for fmt in $BSC_VSIM_TRACE_FORMATS; do
+        case "$fmt" in
+            none|vcd) ;;
+            *) echo "ERROR: verilator does not support waveform dump format '$fmt' (supported: vcd)" >&2
+               IFS=$OLDIFS; exit 1 ;;
+        esac
+    done
+    IFS=$OLDIFS
+fi
+
 TRACEFLAGS="--trace"
 
 # Don't rely on the top module file being the first on the command-line

--- a/testsuite/bsc.options/bsc.help.out.expected
+++ b/testsuite/bsc.options/bsc.help.out.expected
@@ -25,6 +25,7 @@ Compiler flags:
 -continue-after-errors  aggressively continue compilation after an error has been detected
 -cpp                    preprocess the source with the C preprocessor
 -demote-errors list     treat a list of errors as warnings (``:'' sep list of tags)
+-dump-formats formats   waveform formats to compile into the simulation (comma-separated subset of vcd,fst,fsdb; or none)
 -e module               top-level module for simulation
 -elab                   generate a .ba file after elaboration and scheduling
 -fdir dir               working directory for relative file paths during elaboration

--- a/testsuite/bsc.options/bsc.path_dup_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_dup_bdir.out.expected
@@ -12,6 +12,7 @@ bsc -i BLUESPECDIR -print-flags -p foo::foo:bar:foo:baz:baz:foo -bdir bar
 Flags:
     -aggressive-conditions
     -bdir bar
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.path_dup_no_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_dup_no_bdir.out.expected
@@ -8,6 +8,7 @@ bsc -i BLUESPECDIR -print-flags -p foo::foo:bar:foo:baz:baz:foo
 
 Flags:
     -aggressive-conditions
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.path_nonidentical_dup_no_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_nonidentical_dup_no_bdir.out.expected
@@ -15,6 +15,7 @@ bsc -i BLUESPECDIR -print-flags -p foo:foo/:./foo:bar/../foo:./foo/../foo:baz:./
 
 Flags:
      -aggressive-conditions
+    -dump-formats   vcd
      -i   BLUESPECDIR
      -lift
      -o   a.out

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -19,6 +19,7 @@ Flags {
 	disableAssertions = False,
 	doICheck = True,
 	dumpAll = Nothing,
+	dumpFormats = ["vcd"],
 	dumps = [],
 	enablePoisonPills = False,
 	entry = Nothing,

--- a/testsuite/bsc.options/bsc.print-flags.expand-if.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.expand-if.out.expected
@@ -5,6 +5,7 @@ bsc -i BLUESPECDIR -print-flags -expand-if
 
 Flags:
     -aggressive-conditions
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.print-flags.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.out.expected
@@ -3,6 +3,7 @@ bsc -i BLUESPECDIR -print-flags
 
 Flags:
     -aggressive-conditions
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.print-flags.split-if.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.split-if.out.expected
@@ -3,6 +3,7 @@ bsc -i BLUESPECDIR -print-flags -split-if
 
 Flags:
     -aggressive-conditions
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.simdir_invalid_no_backend.out.expected
+++ b/testsuite/bsc.options/bsc.simdir_invalid_no_backend.out.expected
@@ -9,6 +9,7 @@ bsc -i BLUESPECDIR -print-flags -simdir INVALID
 
 Flags:
      -aggressive-conditions
+    -dump-formats   vcd
      -i   BLUESPECDIR
      -lift
      -o   a.out

--- a/testsuite/bsc.options/bsc.test_bsc_option.out.expected
+++ b/testsuite/bsc.options/bsc.test_bsc_option.out.expected
@@ -3,6 +3,7 @@ bsc -print-flags -vsearch foo -steps 12345678 -i BLUESPECDIR
 
 Flags:
     -aggressive-conditions
+    -dump-formats   vcd
     -i BLUESPECDIR
     -lift
     -o a.out

--- a/testsuite/bsc.options/bsc.vdir_invalid_no_backend.out.expected
+++ b/testsuite/bsc.options/bsc.vdir_invalid_no_backend.out.expected
@@ -16,6 +16,7 @@ bsc -i BLUESPECDIR -print-flags -vdir INVALID
 
 Flags:
      -aggressive-conditions
+    -dump-formats   vcd
      -i   BLUESPECDIR
      -lift
      -o   a.out

--- a/testsuite/bsc.options/messages/flag-test.out.expected
+++ b/testsuite/bsc.options/messages/flag-test.out.expected
@@ -3,6 +3,7 @@ bsc -i BLUESPECDIR -print-flags -suppress-warnings G0001:G0002 -suppress-warning
 
 Flags:
      -aggressive-conditions
+    -dump-formats   vcd
      -i   BLUESPECDIR
      -lift
      -o   a.out

--- a/testsuite/bsc.options/messages/flag-test2.out.expected
+++ b/testsuite/bsc.options/messages/flag-test2.out.expected
@@ -3,6 +3,7 @@ bsc -i BLUESPECDIR -print-flags -suppress-warnings G0001:G0002 -suppress-warning
 
 Flags:
      -aggressive-conditions
+    -dump-formats   vcd
      -i   BLUESPECDIR
      -lift
      -o   a.out


### PR DESCRIPTION
Layer 4/6, stacked on `verilator/3-dpi-poly`.

Adds `-dump-formats` to select waveform dump formats at link time (vcd/fst/fsdb/none): reworked Verilog dump harness (+ iverilog FST), verilator FST, VCS fsdb via `-kdb`, Bluesim honoring `none` (omits per-signal VCD dump code), and an honest error for `none` on every backend. Mirrors upstream PR B-Lang-org/bsc#1000 (5 commits).

---
Full testsuite gate on the composed 6-layer stack tip: **20,323 PASS / 0 FAIL / 134 XFAIL / 0 ERROR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
