### PR TITLE
staged-flow 6/6: retire the parent-port-properties caveat

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -168,17 +168,11 @@ the `.ba`, exactly as a Bluesim compile does: `genModuleVerilog` is not run
 at all, and every module's `.v` comes from `-c` or the link.  The flag is
 backend-agnostic when compiling source -- with `-sim` (or no backend)
 stopping at the `.ba` is already the behavior, so it is accepted as a
-no-op, letting build systems pass it unconditionally.  One knock-on
-effect: the port properties that `getIOProps` deduces (`const`, `reg`,
-`unused`, ...) are a codegen product fed back into the module's import-BVI
-wrapper, so under `-elab-only` they are absent -- as they always are for
-Bluesim -- and a parent that re-exports such a port loses the deduced
-annotation in its own `.v` header comment ("Ports:" blurb) and wrapper.
-Nothing structural consumes these deduced properties (the structural ones
--- clock, reset, inout -- are attached by `AState`/`ASyntax` from
-`VModInfo`'s clock/reset fields, not from `getIOProps`), so per-module
-codegen from a given `.ba` is unchanged; only the annotation metadata in a
-parent's output can differ from a full compile's.
+no-op, letting build systems pass it unconditionally.  The wrapper's port
+properties come from the APackage analysis (`getIOPropsA`) before the
+backend split and are recorded in the `.bo` under `-elab-only` too, so a
+parent compiled against an `-elab-only` child deduces exactly what a full
+compile deduces -- the staged flow has no annotation caveat.
 
 ### Bluetcl
 

--- a/testsuite/bsc.verilog/elab_only/elab_only.exp
+++ b/testsuite/bsc.verilog/elab_only/elab_only.exp
@@ -4,8 +4,12 @@
 # later, from the .ba, by -c or by the linking stage.  For this design
 # that output is byte-identical to what the compile itself would have
 # written (the testsuite passes -no-show-timestamps -no-show-version, so
-# generated headers are deterministic); in general only deduced
-# port-property annotations in a parent's .v header comment can differ.
+# generated headers are deterministic).  The port properties are derived
+# from the APackage and recorded in the .bo even under -elab-only, so a
+# parent compiled against an -elab-only child deduces exactly what the
+# direct compile deduces -- the historical caveat about a parent's
+# port-property annotations no longer applies, and the identity holds
+# under -semantic-ports-comment too (checked below).
 #
 
 # Check that none of the listed files exist
@@ -145,3 +149,25 @@ compile_no_source_fail_error "elab_only_codegen" \
 
 # not with -no-elab (nothing would be generated at all)
 compile_fail_error ElabOnly.bsv S0101 1 {-verilog -elab-only -no-elab}
+
+# -------------------------
+# The staged flow is byte-identical under -semantic-ports-comment too:
+# the Ports comment's analysis (getIOPropsA) is recomputed from the .ba
+# itself when -c generates the .v, and the child properties a parent
+# deduces from ride the .bo in both flows.  (Flag effectiveness is
+# pinned separately in bsc.verilog/portprops; here we pin only
+# staged == direct.)
+
+erase mkESub.v
+erase sysETb.v
+elab_run "-c with -semantic-ports-comment" cgensem.bsc-out \
+    {-verilog -semantic-ports-comment -c mkESub -c sysETb}
+files_exist { mkESub.v sysETb.v }
+copy mkESub.v mkESub-from-c-sem.v
+copy sysETb.v sysETb-from-c-sem.v
+
+erase mkESub.v
+erase sysETb.v
+compile_verilog_pass ElabOnly.bsv sysETb {-semantic-ports-comment}
+compare_file mkESub.v mkESub-from-c-sem.v
+compare_file sysETb.v sysETb-from-c-sem.v


### PR DESCRIPTION
Staged-flow stack 6/6, on staged-flow/5-elab-only.

Retires the parent-port-properties caveat: the staged flow (elab-only then codegen) preserves port properties semantically, pinned by test, with DEVELOP.md updated to match.
---
Part of the staged-flow carve (nanavati#7 broken into one-topic PRs).  Whole-stack tree verified byte-identical to the gated stack-7-on-1060 (suite: 20,919 PASS / 0 FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt