### PR TITLE
intg: de-quadratic orderGens + cumulative bound-tyvar sets

### DIFF
--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -850,10 +850,12 @@ findAssump i as =
 mkSchemeNoBVs :: CQType -> TI Scheme
 mkSchemeNoBVs cqt = do
     sy <- getSymTab
-    bvs <- getBoundTVs
+    bvs <- getBoundTVSet
     case convCQType sy cqt of
      Left emsg -> err emsg
-     Right qt -> return (quantify (tv qt \\ bvs) qt)
+     -- filter, not (\\): quantify numbers TGens in list order, so the
+     -- order of `tv qt` has to survive into the .bo
+     Right qt -> return (quantify (filter (`S.notMember` bvs) (tv qt)) qt)
 
 mkQualType :: CQType -> TI (Qual Type)
 mkQualType cqt = do

--- a/src/comp/TCheck.hs
+++ b/src/comp/TCheck.hs
@@ -402,15 +402,17 @@ tiExpr as td exp@(CApply f@(CVar gn) es@[(CVar i)]) | gn `qualEq` idPrimGetName 
 
 tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idValueOf = do
     let vs = nub (tv t)
-    bvs <- getBoundTVs
-    case vs \\ bvs of
+    bvs <- getBoundTVSet
+    -- filter, not (\\): keeps the order of `vs`
+    case filter (`S.notMember` bvs) vs of
         [] -> tiApply as td exp f e
         v : _ -> err (getPosition exp, EValueOf (pfpString v))
 
 tiExpr as td exp@(CApply f@(CVar vo) [e@(CHasType _ t)]) | vo == idStringOf = do
     let vs = nub (tv t)
-    bvs <- getBoundTVs
-    case vs \\ bvs of
+    bvs <- getBoundTVSet
+    -- filter, not (\\): keeps the order of `vs`
+    case filter (`S.notMember` bvs) vs of
         [] -> tiApply as td exp f e
         v : _ -> err (getPosition exp, EStringOf (pfpString v))
 
@@ -1923,10 +1925,10 @@ tiStmts' chke mon _ as td (e@(CSBindT _ _ _ (ty@(CQType (_:_) _)) _) : _) =
         -- XXX is that ever the right thing to do?
         err (getPosition e, EStmtContext (pfpString ty))
 tiStmts' chke mon mt as td (CSBindT (CPVar i) maybeName pprops (CQType [] ty) e : ss) = do
-        bs <- getBoundTVs
+        bs <- getBoundTVSet
         -- Of the type variables in the explicit declaration, separate the
         -- free type variables (fvs) from those bound by the context (bvs)
-        let (bvs, fvs) = partition (\x -> elem x bs) (tv ty)
+        let (bvs, fvs) = partition (`S.member` bs) (tv ty)
         -- Check that the variables bound in this declaration (bvs)
         -- have the same kind as where they were bound
         let kindCheckBV v =
@@ -2264,11 +2266,15 @@ tiExpl_1 as (i, cqt, alts, me) = do
 
     -- We're going to generalize this type over the type variables,
     -- so figure out which ones are bound.
-    bs           <- getBoundTVs
+    bs           <- getBoundTVSet
+    -- the cumulative list is cached, so taking both forms is free; the
+    -- union below feeds checkForAmbiguousPreds, which wants a list in
+    -- the original (stack) order rather than the set's sorted order
+    bsl          <- getBoundTVs
 
     -- Of the type variables in the explicit declaration, separate the
     -- free type variables (vs) from those bound by the context (bvs)
-    let (bvs, vs) = partition (\x -> elem x bs) (tv qt)
+    let (bvs, vs) = partition (`S.member` bs) (tv qt)
 
     -- Check that the variables bound in this declaration (bvs)
     -- have the same kind as where they were bound
@@ -2288,7 +2294,7 @@ tiExpl_1 as (i, cqt, alts, me) = do
     -- XXX do we need to apply the subst?
     --s <- getSubst
     --let fvs = tv (apSub s as) `union` bs
-    let fvs = tv as `union` bs
+    let fvs = tv as `union` bsl
     checkForAmbiguousPreds i fvs qt
 
 {-

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -11,7 +11,8 @@ module TIMonad(
         freshInst,
         VPred(..), getVPredPositions, expandSynVPred,
         EPred(..), Infer2, CheckT, TaskCheckT,
-        getBoundTVs, getTopBoundTVs, addBoundTVs, popBoundTVs,
+        getBoundTVs, getBoundTVSet, getTopBoundTVs, isBoundTV,
+        addBoundTVs, popBoundTVs,
         getExplPreds, getTopExplPreds, addExplPreds, popExplPreds, mkEPred,
         errorAtId, findCons, findTyCon, findFields, findCls,
         bitCls,
@@ -85,11 +86,27 @@ type CATFCache = M.Map (Id, [Type]) Type
 mergeCATFCaches :: CATFCache -> CATFCache -> CATFCache
 mergeCATFCaches = M.union
 
+-- one binding level of the bound-tyvar stack (see tsBoundTyVarStack)
+data BoundTVFrame = BoundTVFrame {
+  btvHere :: [TyVar],        -- bound at this level only
+  btvAll  :: [TyVar],        -- cumulative, outermost-last (as concat gave)
+  btvSet  :: S.Set TyVar     -- cumulative, for membership
+}
+
 -- typechecking state that is restored in case of error
 data TStateRecover = TStateRecover {
   tsCurSubst :: !Subst, -- current substitution
-  -- stack of bound tyvars (list of lists for stuff bound at each level)
-  tsBoundTyVarStack :: [[TyVar]],
+  -- Stack of bound tyvars, one frame per binding level.  Each frame
+  -- carries, besides the vars bound AT that level, the cumulative list
+  -- and set of everything bound at or below it.  The cumulative forms
+  -- are what the consumers actually want: getBoundTVs used to concat
+  -- the whole stack on every call, and newTVar -- which runs once per
+  -- fresh type variable, inside the satisfy loop -- then scanned that
+  -- list linearly.  Profiled at 6.6% of near-critical compile time
+  -- (newTVar.loopVar 4.5% + getBoundTVs 2.3%).  Cons and Set.union
+  -- share structure with the frame below, so a push stays proportional
+  -- to the vars it binds rather than to the depth of the stack.
+  tsBoundTyVarStack :: [BoundTVFrame],
   tsExplPreds :: [[EPred]],
   tsSatStack :: TSSuperSatStack
 }
@@ -320,15 +337,47 @@ updSubst :: (Subst -> Subst) -> TI ()
 updSubst f = modify (transSubst f)
 
 getBoundTVs :: TI [TyVar]
-getBoundTVs = gets tsBoundTyVarStack >>= (return . concat)
+getBoundTVs = gets tsBoundTyVarStack >>= (return . cumList)
+  where cumList st = case st of
+                       (f:_) -> btvAll f
+                       []    -> []
+
+-- | The cumulative bound set itself, for callers doing set algebra.
+-- Membership operands become O(log n) lookups; the ORDER-CARRYING list
+-- in those expressions must stay a list, because quantify assigns TGen
+-- indices in list order and those indices reach the .bo.
+getBoundTVSet :: TI (S.Set TyVar)
+getBoundTVSet = gets tsBoundTyVarStack >>= (return . cum)
+  where cum st = case st of
+                   (f:_) -> btvSet f
+                   []    -> S.empty
+
+-- | Is this tyvar bound at any enclosing level?  O(log n) against the
+-- cumulative set, instead of a linear scan of a freshly concatenated
+-- list -- this is the query newTVar makes for every variable it mints.
+isBoundTV :: TyVar -> TI Bool
+isBoundTV v = gets tsBoundTyVarStack >>= (return . mem)
+  where mem st = case st of
+                   (f:_) -> S.member v (btvSet f)
+                   []    -> False
 
 -- get just the most recently bound tvars
 getTopBoundTVs :: TI [TyVar]
-getTopBoundTVs = gets tsBoundTyVarStack >>= (return . headOrErr "getTopBoundTVs")
+getTopBoundTVs = gets tsBoundTyVarStack >>=
+                 (return . btvHere . headOrErr "getTopBoundTVs")
 
 addBoundTVs :: [TyVar] -> TI ()
 addBoundTVs is = modify addVars
-  where addVars s = s { tsBoundTyVarStack = is:(tsBoundTyVarStack s) }
+  where addVars s = s { tsBoundTyVarStack = push (tsBoundTyVarStack s) }
+        -- the cons and the union share the frame below, so the cost is
+        -- in |is|, not in the depth of the stack
+        push st = BoundTVFrame {
+                      btvHere = is,
+                      btvAll  = is ++ (case st of (f:_) -> btvAll f; [] -> []),
+                      btvSet  = foldr S.insert
+                                      (case st of (f:_) -> btvSet f; [] -> S.empty)
+                                      is
+                  } : st
 
 popBoundTVs :: TI ()
 popBoundTVs = modify dropVars
@@ -375,11 +424,15 @@ getTyVarNum = lift $ do
 newTVar :: HasPosition a => String -> Kind -> a -> TI Type
 newTVar msg k x = do
   let pos = getPosition x
-  bvs <- getBoundTVs
+  -- The capture check is a set lookup, not a scan: this runs once per
+  -- fresh type variable (so, constantly, inside the satisfy loop), and
+  -- concatenating the whole bound-tyvar stack and scanning it linearly
+  -- profiled at 6.6% of near-critical compile time.
   let loopVar = do
         n <- getTyVarNum
         let v = TyVar (enumId "tctyvar" pos n) n k
-        if (v `elem` bvs) then loopVar
+        clash <- isBoundTV v
+        if clash then loopVar
          else do
            when doVarTrace $ traceM ("newTVar: " ++ show n ++ " " ++ msg);
            return (TVar v)

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -540,12 +540,23 @@ compilePackage
                                 | (WrapInfo i _ _ _ _ _) <- gs ]
                 tr = [ (qualId pid i_, qualId pid i)
                                 | (WrapInfo i _ _ i_ _ _) <- gs ]
+                -- Set-backed membership for the three scans below.  As
+                -- lists these cost O(|ds| * |gis|) and, for the SCC edge
+                -- lists, O(|ds| * |fdVars| * |ds'|) Id comparisons -- and
+                -- one Id comparison is two FString compares, so this
+                -- single block dominated the compile on definition-heavy
+                -- packages (profiled at ~69% of runtime, split across
+                -- orderGens.g / idEq / id_fs, before this change).
+                -- Semantics are preserved: filter keeps the first list's
+                -- order and duplicates, which is what intersect does.
+                gisSet = S.fromList gis
                 ds' = [ IDef (lookupWithDefault tr i i) t e p
-                                | IDef i t e p <- ds, i `notElem` gis ]
-                is = [ i | IDef i _ _ _ <- ds' ]
-                g  = [ (i, fdVars e `intersect` is) | IDef i _ e _ <- ds' ]
+                                | IDef i t e p <- ds, i `S.notMember` gisSet ]
+                isSet = S.fromList [ i | IDef i _ _ _ <- ds' ]
+                g  = [ (i, filter (`S.member` isSet) (fdVars e))
+                                | IDef i _ e _ <- ds' ]
                 iis = scc g
-                os = concat iis `intersect` gis
+                os = filter (`S.member` gisSet) (concat iis)
                 get i = headOrErr "bsc.orderGens: no WrapInfo"
                                   [ x | x@(WrapInfo i' _ _ _ _ _) <- gs,
                                                 unQualId i == i' ]


### PR DESCRIPTION
Typecheck/elab perf pair (II-6): SCC edge-list construction over top-level defs de-quadraticized (3.4x on RotateRegisters); bound-tyvar stack keeps cumulative sets. .bo byte-identical.

---
Integration-release carve (see ~/bluespec/upstream/INTEGRATION-RELEASE.md). Also landed on release/integration-2026-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt