### PR TITLE
intg: split coherence code out of T0164

### DIFF
--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -798,6 +798,7 @@ data ErrMsg =
         | WIncoherentMatch String String
         | WOrphanInst String
         | WTransitiveIncoherentMatch String String String
+        | ECoherentTransitiveIncoherentMatch String String String
         | EModInstWrongArgs [Position]
         | EAmbiguous [(String, Position, [(String, [Position])])]
         | EAmbiguousExplCtx [Doc] [Doc] Doc
@@ -3013,6 +3014,11 @@ getErrorText (WTransitiveIncoherentMatch pred root_pred root_inst) =
     (Type 158, empty,
      s2par ("Proviso " ++ pred ++ " is satisfied by a dictionary that transitively " ++
             "depends on an incoherent match of " ++ root_pred ++
+            " against instance " ++ root_inst))
+getErrorText (ECoherentTransitiveIncoherentMatch pred root_pred root_inst) =
+    (Type 164, empty,
+     s2par ("Coherent proviso " ++ pred ++ " is satisfied by a dictionary that " ++
+            "transitively depends on an incoherent match of " ++ root_pred ++
             " against instance " ++ root_inst))
 
 -- Generation Errors

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -240,8 +240,16 @@ warnTransitiveIncoherent sbs = do
       case M.lookup i clsMap >>= allowIncoherent of
         Just True -> return ()   -- incoherent class: suppress
         mallow    ->
-          let msg = (pos, WTransitiveIncoherentMatch tStr rootPredStr rootInstStr)
-          in  if fromMaybe ai mallow then twarn msg else err msg
+          -- Distinct codes, because these are different claims: the
+          -- warning says a proviso happens to rest on an incoherent
+          -- match, the error says a proviso PROMISED coherence and does
+          -- not deliver. One code for both could not be waived or
+          -- promoted independently of the other.
+          if fromMaybe ai mallow
+            then twarn (pos, WTransitiveIncoherentMatch
+                                 tStr rootPredStr rootInstStr)
+            else err   (pos, ECoherentTransitiveIncoherentMatch
+                                 tStr rootPredStr rootInstStr)
       where
         t  = fromJustOrErr "warnTransitiveIncoherent: id not in bindTypes"
                            (M.lookup i typeMap)

--- a/testsuite/bsc.typechecker/typeclasses/coherence/coherence.exp
+++ b/testsuite/bsc.typechecker/typeclasses/coherence/coherence.exp
@@ -1,6 +1,8 @@
-# Tests for transitive incoherence diagnostics (T0158: an error normally,
-# a warning under -incoherent-instance-matches or for classes annotated
-# incoherent).
+# Tests for transitive incoherence diagnostics.  Two codes, because the two
+# reports make different claims: T0164 (error) says a proviso PROMISED
+# coherence and does not deliver it, T0158 (warning) says a proviso merely
+# happens to rest on an incoherent match.  Which one fires depends on the
+# class annotation and on -incoherent-instance-matches.
 # IncoherentBase defines a class marked `incoherent` with a generic and a more
 # specific overlapping instance.  Each Instance_* test derives another class
 # (coherent, incoherent, or default-annotation) whose instance depends on
@@ -9,14 +11,15 @@
 
 # ---- Instance-level proviso constraints ----
 
-# coherent class depending on incoherent resolution: compile error T0158.
-compile_fail_error Instance_Coherent.bs T0158
+# coherent class depending on incoherent resolution: compile error T0164.
+compile_fail_error Instance_Coherent.bs T0164
 
-# default class (no annotation): T0158 error when the flag is off, T0158
-# warning when it is on.  One source serves both runs: the flag-off compile
-# fails (so it leaves no .bo behind for -u to reuse) and the flag-on run
-# compiles fresh.
-compile_fail_error Instance_Default.bs T0158
+# default class (no annotation): T0164 error when the flag is off, T0158
+# warning when it is on.  The code changing with the severity is the point:
+# the flag decides which claim is being made, not just how loudly.  One
+# source serves both runs: the flag-off compile fails (so it leaves no .bo
+# behind for -u to reuse) and the flag-on run compiles fresh.
+compile_fail_error Instance_Default.bs T0164
 
 test_c_veri_bs_modules_options Instance_Default {} {-incoherent-instance-matches}
 find_n_warning Instance_Default.bs.bsc-vcomp-out T0158 1
@@ -48,3 +51,8 @@ find_n_warning Super_Default.bs.bsc-vcomp-out T0158 0
 
 test_c_veri_bs_modules_options Super_Incoherent {} {}
 find_n_warning Super_Incoherent.bs.bsc-vcomp-out T0158 0
+
+# The error code is never emitted as a warning: that conflation is what
+# splitting T0164 off from T0158 exists to prevent.
+find_n_warning Instance_Default.bs.bsc-vcomp-out T0164 0
+find_n_warning Instance_Incoherent.bs.bsc-vcomp-out T0164 0


### PR DESCRIPTION
T0164 coherence-code split (II-8).

---
Integration-release carve (see ~/bluespec/upstream/INTEGRATION-RELEASE.md). Also landed on release/integration-2026-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt