### PR TITLE
intg: declare live-read task results outside translate_off

### DIFF
--- a/src/comp/AVerilog.hs
+++ b/src/comp/AVerilog.hs
@@ -412,8 +412,20 @@ aVerilog errh flags pps aspack ffmap =
         -- Foreign block decls include directly written by foreign calls
         -- as well as defs inlinded into foreign blocks.
         foreign_writes = concatMap afc_writes $ concatMap snd fs
+        foreign_block_id_set =
+            S.fromList (foreign_writes ++ defs_in_foreign_blocks)
+        -- the ids read by synthesized logic: the uses of every def
+        -- that is emitted outside the translate_off foreign blocks
+        -- (a task result that only other sim-only code reads can
+        -- stay hidden with it)
+        synth_live_ids :: S.Set AId
+        synth_live_ids =
+            S.fromList [ v | d@(ADef i _ _ _) <- ds
+                           , not (i `S.member` foreign_block_id_set)
+                           , v <- aVars d ]
         (foreign_decls_group, defmap7) =
-            groupForeignBlockDefs vDef (foreign_writes ++ defs_in_foreign_blocks) defmap6
+            groupForeignBlockDefs vDef synth_live_ids
+                (foreign_writes ++ defs_in_foreign_blocks) defmap6
 
         -- -----
         -- other
@@ -708,22 +720,36 @@ groupMuxDefs vDef si ds =
         (mux_decl_group, mux_def_group, other_defs)
 
 -- returns
---  * group for decls (of regs for foreign function assignments)
+--  * groups for decls (of regs for foreign function assignments)
 --  * remaining ADefs
 -- Does not return a group of defs because these decls are assigned
 -- in the foreign function block.
-groupForeignBlockDefs :: (ADef -> [VMItem]) -> [AId] -> M.Map AId ADef ->
-                ([VMItem], M.Map AId ADef)
-groupForeignBlockDefs _ [] ds = ([], ds)
-groupForeignBlockDefs vDef foreign_block_ids  ds =
+-- A decl whose value is read by synthesized logic is emitted outside
+-- the translate_off group: hiding the only declaration of a
+-- synthesis-visible reference would leave it undeclared.
+groupForeignBlockDefs :: (ADef -> [VMItem]) -> S.Set AId -> [AId] ->
+                M.Map AId ADef -> ([VMItem], M.Map AId ADef)
+groupForeignBlockDefs _ _ [] ds = ([], ds)
+groupForeignBlockDefs vDef synth_live_ids foreign_block_ids ds =
     let (foreign_defs, other_defs) = findADefs foreign_block_ids ds
-        (foreign_vdecls, foreign_vdefs) = mkVDeclsAndDefs vDef foreign_defs
+        (live_defs, sim_defs) =
+            partition (\ (ADef i _ _ _) -> i `S.member` synth_live_ids)
+                      foreign_defs
+        (live_vdecls, live_vdefs) = mkVDeclsAndDefs vDef live_defs
+        (sim_vdecls, sim_vdefs) = mkVDeclsAndDefs vDef sim_defs
+        live_group =
+            vGroupWithComment False live_vdecls
+                ["registers assigned by system tasks," ++
+                 " read by synthesized logic"]
         comment = ["declarations used by system tasks"]
-        foreign_vgroup = VMGroup { vg_translate_off = True
-                                 , vg_body = [foreign_vdecls]
-                                 }
-    in case foreign_vdefs of
-         [] -> ([VMComment comment foreign_vgroup], other_defs)
+        sim_vgroup = VMGroup { vg_translate_off = True
+                             , vg_body = [sim_vdecls]
+                             }
+        sim_group = if null sim_vdecls
+                    then []
+                    else [VMComment comment sim_vgroup]
+    in case live_vdefs ++ sim_vdefs of
+         [] -> (live_group ++ sim_group, other_defs)
          _  -> internalError ("groupForeignBlockDefs: " ++ ppReadable (foreign_block_ids, ds))
 
 -- ----------

--- a/testsuite/bsc.verilog/task_result_live/Makefile
+++ b/testsuite/bsc.verilog/task_result_live/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.verilog/task_result_live/TaskResultLive.bsv
+++ b/testsuite/bsc.verilog/task_result_live/TaskResultLive.bsv
@@ -1,0 +1,19 @@
+import "BDPI" function ActionValue#(Bit#(8)) fetch_value();
+
+// The imported function's result is assigned inside the foreign-function
+// block but read by a register input, which is synthesized logic.
+interface TaskResultLive;
+   method Bit#(8) result;
+endinterface
+
+(* synthesize *)
+module mkTaskResultLive (TaskResultLive);
+   Reg#(Bit#(8)) held <- mkReg(0);
+
+   rule go;
+      let v <- fetch_value();
+      held <= v;
+   endrule
+
+   method result = held;
+endmodule

--- a/testsuite/bsc.verilog/task_result_live/task_result_live.exp
+++ b/testsuite/bsc.verilog/task_result_live/task_result_live.exp
@@ -1,0 +1,18 @@
+#
+# A value assigned by a foreign function but read by synthesized logic must
+# be declared outside translate_off.  Hiding the only declaration of a
+# synthesis-visible reference leaves it undeclared, and one such error
+# aborts the whole analysis -- so this is about the netlist being valid at
+# all, not about tidiness.
+#
+
+# The live/simulation split of this group is unconditional -- it is about
+# the netlist being valid, not about the partitioning flag -- so the
+# default compile is the one that matters.
+compile_verilog_pass TaskResultLive.bsv mkTaskResultLive
+
+sed mkTaskResultLive.v mkTaskResultLive-synth.v {-e "/translate_off/,/translate_on/d"}
+
+# the declaration the register input refers to survives the strip
+find_regexp mkTaskResultLive-synth.v {registers assigned by system tasks, read by synthesized logic}
+find_regexp mkTaskResultLive-synth.v {held\$D_IN}


### PR DESCRIPTION
Pre-existing stock-bsc bug (II-14): task result declarations move to the synthesis view when read by live logic; 24-file regold re-cut without the parked lint trio's EN-fold fallout.

---
Integration-release carve (see ~/bluespec/upstream/INTEGRATION-RELEASE.md). Also landed on release/integration-2026-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt