### PR TITLE
SignalNaming: drop whole generated-number suffixes (fallout assessment)

### DIFF
--- a/src/comp/SignalNaming.hs
+++ b/src/comp/SignalNaming.hs
@@ -120,10 +120,10 @@ signalNameFromAExpr' (expr@AMGate { }) =
     ppString (ae_objid expr) ++ "_" ++
     ppString (unQualId (ae_clkid expr)) ++ "_" ++ "GATE"
 
--- XXX assumes that "__[a-z][0-9]*" suffices are compiler-generated
+-- XXX assumes that "__[a-z][0-9]+" suffices are compiler-generated
 dropGeneratedSuffixes :: String -> String
 dropGeneratedSuffixes =
-    let generated_suffix = mkRegex "__[a-z][0-9]"
+    let generated_suffix = mkRegex "__[a-z][0-9]+"
     in  \name -> concat (splitRegex generated_suffix name)
 
 opToString :: PrimOp -> String


### PR DESCRIPTION
One-line regex fix: `__[a-z][0-9]` matched exactly one digit, so multi-digit generated numbers (`x__h12`) left a glued residue digit in derived stems — noise, and it embeds compile-history-dependent heap numbers into otherwise stable names.

**Draft on purpose**: opened to assess the golden fallout across the suite before deciding how to land it. Found by the -stable-verilog dormant-nondeterminism audit; deliberately NOT part of that work (stable-verilog is unaffected: stems come from the .ba on the regen path).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt