### PR TITLE
Exempt hot leaf modules from -fprof-auto cost centres

### DIFF
--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE ScopedTypeVariables, BangPatterns #-}
 {-# LANGUAGE PatternSynonyms, OverloadedLists, TypeFamilies #-}
 {-# OPTIONS_GHC -Werror -fwarn-incomplete-patterns #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module BinData ( Byte
                , putBs, putB, putI
                , getN, getB, getI -- , getBytesRead

--- a/src/comp/ConTagInfo.hs
+++ b/src/comp/ConTagInfo.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module ConTagInfo(ConTagInfo(..)) where
 
 import Eval

--- a/src/comp/Eval.hs
+++ b/src/comp/Eval.hs
@@ -1,3 +1,7 @@
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Eval(NFData(..), deepseq,
             rnf2, rnf3, rnf4, rnf5, rnf6, rnf7, rnf8, rnf9,
             rnf10, rnf11, rnf12, rnf13, rnf14, rnf15, rnf16,

--- a/src/comp/FStringCompat.hs
+++ b/src/comp/FStringCompat.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module FStringCompat(FString, getFString,
                      tmpFString, cloneFString, concatFString,
                      mkNumFString, mkStrFString, mkFString,

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternSynonyms #-}
 
+-- profiling-only: without this, -fprof-auto pins cost centres on the
+-- GHC-generated pattern-synonym matchers ($mITAp etc.), blocking
+-- their inlining; every IType pattern match in the compiler then
+-- becomes an out-of-line call and dominates any profile
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IType(
   IType(ITVar, ITCon, ITNum, ITStr, ITAp, ITForAll)
   ,IKind(..)

--- a/src/comp/Id.hs
+++ b/src/comp/Id.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE FlexibleInstances, DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fwarn-name-shadowing -fwarn-missing-signatures #-}
 
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Id(
         Id,
         mkId,

--- a/src/comp/IntLit.hs
+++ b/src/comp/IntLit.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IntLit (IntLit(..),
                ilDec, ilSizedDec, ilHex, ilSizedHex, ilBin, ilSizedBin,
                showVeriIntLit, showSizedVeriIntLit

--- a/src/comp/Libs/IOMutVar.hs
+++ b/src/comp/Libs/IOMutVar.hs
@@ -1,3 +1,7 @@
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IOMutVar(MutableVar, newVar, readVar, writeVar) where
 
 import Data.IORef

--- a/src/comp/Position.hs
+++ b/src/comp/Position.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Position where
 
 import Data.List(partition)

--- a/src/comp/Prim.hs
+++ b/src/comp/Prim.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Prim(
             PrimOp(..),
             toPrim,

--- a/src/comp/SpeedyString.hs
+++ b/src/comp/SpeedyString.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module SpeedyString(SString, toString, fromString, (++), concat, filter) where
 
 import Prelude hiding((++), concat, filter)

--- a/src/comp/Undefined.hs
+++ b/src/comp/Undefined.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Undefined (
                   UndefKind(..),
 

--- a/src/comp/Wires.hs
+++ b/src/comp/Wires.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Wires(ClockId, ClockDomain(..), ResetId,
              nextClockId, nextClockDomain, nextResetId,
              initClockId, initClockDomain, initResetId,


### PR DESCRIPTION
## What

Marks 13 modules `{-# OPTIONS_GHC -fno-prof-auto #-}` so that `BSC_BUILD=PROF` profiles attribute their time to callers. No effect on release builds — the pragma only suppresses automatic cost-centre insertion.

Two categories:

- **`IType`**: `-fprof-auto` pins cost centres on the GHC-generated pattern-synonym matchers (`$mITAp`, `$mITForAll`, …). An SCC on the matcher lambda blocks its inlining, so every `IType` pattern match in the compiler becomes an out-of-line CPS call — release builds compile the same matchers to plain `case` expressions.
- **Tiny hot leaf functions** (`Id`, `SpeedyString`, `FStringCompat`, `Position`, `Eval`, `IntLit`, `ConTagInfo`, `Undefined`, `Wires`, `Prim`, `BinData`, `Libs/IOMutVar`): interned-string and Id comparisons compile to machine-Int compares when inlined; an SCC forces them out of line with boxing, at ~10⁸–10⁹ call frequency. Knowing "Int compare took time" is not actionable — the callers doing a billion compares are.

## Why

Measured on a profiled Toooba compile (`RV64ACDFIMSU_Toooba_bluesim`, the CI config), successive fixes changed the profile from unusable to trustworthy:

| build | profiled wall | profiled CPU | reported alloc | top cost centre |
|---|---|---|---|---|
| stock `-fprof-auto` | 4067s | 3164s | 1.14 TB | pattern-synonym matcher, **36.6%** |
| + matcher exemption | 1771s | 1388s | 1.09 TB | `idCompare` 5.1% time / **18.7% alloc** |
| + leaf exemptions (this PR) | 1196s | 914s | **590 GB** | real code (`tSubstWith`, `pConj`, Yices FFI) |

The release build allocates 497 GB on the same compile, so the final profile's 590 GB is close to truth, where the stock profile fabricated ~2× the program's total allocation and charged ~19% of allocation to `idCompare` — a function that is two strict-field reads and two `Int` comparisons.

Selection principle: exempt a module when its functions (a) compile to primitive operations when inlined, (b) run at extreme frequency, and (c) are uninformative as attribution targets. Modules with genuine algorithmic content (`IExpandUtils`, `ISyntaxSubst`, `IExpand`, `Util`, `ITransform`, …) keep their cost centres.

## Testing

- Full release build + `make check-smoke` unaffected (pragma is inert without `-prof`).
- `BSC_BUILD=PROF` build compiles and runs; profile output verified on the Toooba CI configuration as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu)_