### PR TITLE
-c: take codegen-semantic flags from the .ba, not the command line

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1490,15 +1490,36 @@ vGenMods errh flags t0 abmis = do
             blurb <- mkGenFileHeader flags
             let apkg = abmi_apkg abmi
                 pps = abmi_pps abmi
+                -- Codegen-SEMANTIC flags come from the .ba itself: they
+                -- were recorded there at the original compile with any
+                -- (* options *) pragma applied (see genModule), so the
+                -- regenerated output matches that compile by
+                -- construction.  Only environment/output flags follow
+                -- this invocation.
+                cgflags = (abmi_flags abmi) {
+                              bdir = bdir flags,
+                              vdir = vdir flags,
+                              infoDir = infoDir flags,
+                              ifcPath = ifcPath flags,
+                              verbosity = verbosity flags,
+                              showCodeGen = showCodeGen flags,
+                              showElabProgress = showElabProgress flags,
+                              printFlags = printFlags flags,
+                              printFlagsHidden = printFlagsHidden flags,
+                              printFlagsRaw = printFlagsRaw flags,
+                              timeStamps = timeStamps flags,
+                              showVersion = showVersion flags,
+                              updCheck = updCheck flags
+                          }
                 methodConflict = abmi_method_dump abmi
                 methodConflictBlurb
-                  | methodConf flags =
+                  | methodConf cgflags =
                       ["Method conflict info:"]
                       ++ lines (pretty 78 78
-                                  (vcat (dumpMethodInfo flags methodConflict)))
+                                  (vcat (dumpMethodInfo cgflags methodConflict)))
                   | otherwise = []
                 methodConflictBVI
-                  | methodBVI flags =
+                  | methodBVI cgflags =
                       ["BVI format method schedule info:"]
                       ++ lines (pretty 78 78
                                   (vcat (dumpMethodBVIInfo methodConflict)))
@@ -1508,9 +1529,9 @@ vGenMods errh flags t0 abmis = do
                 -- recompute the APackage-derived port properties from the
                 -- .ba's own contents, so a regenerated .v matches the
                 -- original compile's under -semantic-ports-comment too
-                (aioprops, _) = getIOPropsA flags pps (Just aschedinfo) apkg
+                (aioprops, _) = getIOPropsA cgflags pps (Just aschedinfo) apkg
             (t', vfns) <-
-                genModuleVerilog errh pps flags dumpnames t prefix modstr
+                genModuleVerilog errh pps cgflags dumpnames t prefix modstr
                     blurb methodConflictBlurb methodConflictBVI
                     pathinfo aschedinfo aioprops apkg
             return (t', vfns_so_far ++ vfns)


### PR DESCRIPTION
Stacked on `staged-flow/6-portprops-caveat`. First of the 5-PR `-stable-verilog` series (this PR → joinDefs NoCSE → strictness → feature → default flip).

`-c` regenerates a module's Verilog from its elaborated `.ba` — but codegen-semantic flags came from the `-c` invocation's command line. That is wrong for flags that are part of the module's definition, sharpest for the `(* options *)` pragma: the designer attached `-keep-fires` / `-unspecified-to` to the module in the source, `genModule` applied it before the `.ba` was written, and a `-c` run that doesn't replay it regenerates a *semantically different* netlist (different don't-care lifting, missing fires) than the design specified and verified. In a staged build flow, a stray flag in the `-c` step's environment silently changes the shipped Verilog.

The `.ba` already records the module's flags with the pragma applied, so `vGenMods` now regenerates under those stored flags — `-keep-fires`, `-unspecified-to`, `-readable-mux`, all of it — and the regenerated `.v` matches the original compile's codegen semantics by construction. Only environment/output flags (`-bdir`/`-vdir`/`-info-dir`, search path, verbosity, show/print toggles, `-u`) follow the `-c` invocation. This mirrors how Bluesim's `-c` already treats codegen options as part of the module's identity (`codeGenOptionDescr` in the reuse staleness check).

Trade-off made deliberately: `-c` can no longer produce a flag-*variant* from an existing `.ba` (e.g. a `-v95` flavor without re-elaborating) — reproducibility-by-default wins, and a source recompile covers the variant workflow. If that's ever wanted, an explicit override flag is the escape hatch.

This is a prerequisite for the `.ba` → `.v` byte-identity contract enforced at the top of this series, but justified standalone by the pragma-fidelity argument.

Testing: full stack gate at the series tip is 23,871 PASS / 0 FAIL / 134 XFAIL / 0 XPASS; this head builds and passes targeted dirs (bsc.options, method_conditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
