### PR TITLE
joinDefs: never merge NoCSE defs (in either direction)

### DIFF
--- a/src/comp/AOpt.hs
+++ b/src/comp/AOpt.hs
@@ -446,8 +446,17 @@ joinDefs True dsx = reverse (snd (foldl add (M.empty, []) dsx))
                     | hasIdProp ie IdP_enable  -> (m, d:ds)
                     | defPropsHasNoCSE props   -> (m, d:ds)
                     | otherwise                -> (M.insert e d m, d:ds)
-                Just (ADef i t _ p) -> -- traces ("adding simple assignment: " ++ ppReadable (ie,i)) $
-                                     (m, (ADef ie t (ASDef t i) p) : ds)
+                -- a NoCSE def must not be merged in either direction:
+                -- it can neither BE the surviving name nor be rewritten
+                -- into an alias of one (-keep-method-conds relies on the
+                -- COND def keeping its own full expression); before this
+                -- guard, a NoCSE def whose twin happened to precede it
+                -- in (interning-order-sensitive) def order was silently
+                -- collapsed
+                Just (ADef i t _ p)
+                    | defPropsHasNoCSE props -> (m, d:ds)
+                    | otherwise -> -- traces ("adding simple assignment: " ++ ppReadable (ie,i)) $
+                                   (m, (ADef ie t (ASDef t i) p) : ds)
 
 -- if the expression is a primitive with 1-bit type, optimize it as
 -- a boolean expression


### PR DESCRIPTION
Second of the 5-PR `-stable-verilog` series. Stacked on the `-c` flags PR.

`joinDefs`' props guards protect only the map *insertion* (who can be the surviving name of an expression class); a def whose expression already has a representative is rewritten into an alias regardless. For NoCSE defs that's wrong: `-keep-method-conds` marks its COND defs NoCSE precisely so each keeps its own full expression — the feature's tests expect a per-COND `case` block, not `assign COND_x = twin` — and `AVeriQuirks`' CSE already excludes NoCSE defs in both directions. `DefP_NoCSE` has exactly one producer (the COND defs, IExpand), so this is the whole blast radius.

The bug is order-dependent and so has been latent: a NoCSE def is collapsed only when its expression twin happens to *precede* it in the def list, whose order tracks compile-history-sensitive string interning. Today's interning order happens to put the COND defs first, hiding it — which is also why no failing test can accompany this PR on its own: the deterministic reproducer needs the canonical ordering introduced later in the series (the method_conditions pins land with the feature/flip PRs, where this fix is what keeps the *committed* expectations passing).

Testing: this head builds and method_conditions passes unchanged (134/0 at the flip tip; the series-tip full gate is 23,871/0/134XF/0XP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
