### PR TITLE
Strictness: def-collection accumulators and PSQ priority updates

### DIFF
--- a/src/comp/AExpand.hs
+++ b/src/comp/AExpand.hs
@@ -5,7 +5,7 @@ module AExpand (
                 expandAPackage
                 ) where
 
-import Data.List(group, sort, nub, genericLength)
+import Data.List(foldl', group, sort, nub, genericLength)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import PFPrint
@@ -301,7 +301,11 @@ collDefs used ds = coll (S.fromList used) [] (reverse (tsortADefs ds))
                     --traces ("drop-coll " ++ ppString i) $
                     coll used rs ds
                 else
-                    coll (foldr S.insert used (aVars e)) (d:rs) ds
+                    -- forced: a run of kept defs never consults the set
+                    -- (the guard short-circuits on isLocalAId), so a lazy
+                    -- accumulator would chain one thunk per def
+                    let used' = foldl' (flip S.insert) used (aVars e)
+                    in  used' `seq` coll used' (d:rs) ds
 
 
 -- ==============================
@@ -410,7 +414,10 @@ xcollDefs keepFires used ds = --traces( "xCollDefs: " ++ ppReadable used ) $
                 --traces ("\n drop-coll " ++ ppString i ++ " " ++ ppReadable (hasIdProp i IdPCanFire)) $
                 coll used rs ds
                 else
-                    coll (foldr S.insert used (aVars e)) (d:rs) ds
+                    -- forced, like collDefs: keepFires fire defs can also
+                    -- skip the set consultation, so keep the accumulator strict
+                    let used' = foldl' (flip S.insert) used (aVars e)
+                    in  used' `seq` coll used' (d:rs) ds
 
 
 -- ==============================

--- a/src/comp/Balanced.lhs
+++ b/src/comp/Balanced.lhs
@@ -324,10 +324,14 @@ Determining the second-best player.
 
 \paragraph{Modifier}
 
+The new priority is forced before it is stored: `adjust' callers (SCC's
+Kahn decrement) apply it once per incoming edge, and storing the update
+as a thunk would chain them as deep as a node's in-degree.
+
 > adjust f k q                  =  case tourView q of
 >   Null                        -> empty
 >   Single k' p
->     | k == k'                 -> single' k' (f p)
+>     | k == k'                 -> let p' = f p in p' `seq` single' k' p'
 >     | otherwise               -> single' k' p
 >   tl `Play` tr
 >     | k <= maxKey tl          -> adjust f k tl `unsafePlay` tr


### PR DESCRIPTION
Third of the 5-PR `-stable-verilog` series. Stacked on the joinDefs NoCSE PR.

Two latent lazy-accumulator hazards in the Verilog backend, same shape: a structure grows one unforced thunk per step and is forced much later, unwinding the whole chain on the stack at once. Chain depth depends on def-list order (today: interning order), and the canonical text ordering introduced later in this series makes them reproducibly deep enough to overflow — that's how they were found (`CregMemBlowup` blew its 16M stack cap; the `-xc` trace bottoms out where the laziness is *forced*, not built).

- **`AExpand.collDefs`/`xcollDefs`**: the `used` set grew by lazy `foldr S.insert` and is only consulted at the `S.member` guard — which `collDefs` short-circuits past on `isLocalAId`. Text order clusters every `_d*` name, so the reversed processing order has huge non-local runs that never force the set: one thunk per def, tens of thousands deep. Now `foldl'` + `seq` per kept def.
- **`Balanced.adjust`**: the priority-search-queue stored the adjusted priority as a thunk; SCC's Kahn decrement applies it once per incoming edge, chaining as deep as a node's in-degree. Now forced before storing.

Semantics-preserving: finite sets, `Int` priorities — no bottoms for the added strictness to hide.

Testing: this head builds and perf-creg-blowup passes at its original caps; series-tip full gate 23,871/0/134XF/0XP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
