### PR TITLE
-stable-verilog: deterministic Verilog emission (default off)

### DIFF
--- a/src/comp/AExpand.hs
+++ b/src/comp/AExpand.hs
@@ -5,7 +5,7 @@ module AExpand (
                 expandAPackage
                 ) where
 
-import Data.List(foldl', group, sort, nub, genericLength)
+import Data.List(foldl', group, sort, sortOn, nub, genericLength)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import PFPrint
@@ -67,20 +67,20 @@ data ExpandData a2 = ExpandData{
 -- expansion from a point inside the recursive structure.
 
 
-aExpand :: ErrorHandle -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
-aExpand errh keepFires expnond expcheap pkg =
-    aSRemoveUnused keepFires
-                   (expandASPackage errh keepFires expnond expcheap pkg)
+aExpand :: ErrorHandle -> Bool -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
+aExpand errh stable keepFires expnond expcheap pkg =
+    aSRemoveUnused stable keepFires
+                   (expandASPackage errh stable keepFires expnond expcheap pkg)
 
-xaXExpand :: ErrorHandle -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
-xaXExpand errh keepFires expnond expcheap pkg =
-    xaSRemoveUnused keepFires
-        (expandASPackage errh keepFires expnond expcheap pkg)
+xaXExpand :: ErrorHandle -> Bool -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
+xaXExpand errh stable keepFires expnond expcheap pkg =
+    xaSRemoveUnused stable keepFires
+        (expandASPackage errh stable keepFires expnond expcheap pkg)
 
 
 -- common core
-expandASPackage :: ErrorHandle -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
-expandASPackage errh keepFires expnond expcheap pkg =
+expandASPackage :: ErrorHandle -> Bool -> Bool -> Bool -> Bool -> ASPackage -> ASPackage
+expandASPackage errh stable keepFires expnond expcheap pkg =
     let
         ss = aspkg_state_instances pkg
         ws = aspkg_inlined_ports pkg
@@ -96,7 +96,7 @@ expandASPackage errh keepFires expnond expcheap pkg =
 
         (ss', ws', ds', fs') =
             -- trace ("aExpand " ++ ppReadable ds) $
-            aExpDefs errh keepFires expnond expcheap aoptExpandTest
+            aExpDefs errh stable keepFires expnond expcheap aoptExpandTest
                      sigInfo os ios muxes (ss, ws, ds, fs)
     in
         pkg { aspkg_state_instances = ss',
@@ -145,14 +145,14 @@ expandASPackage errh keepFires expnond expcheap pkg =
 -- (7) Call "expand" on the ordered definitions, with the ExpandData
 
 
-aExpDefs :: ErrorHandle -> Bool -> Bool -> Bool -> ExpandTest [AForeignBlock] ->
+aExpDefs :: ErrorHandle -> Bool -> Bool -> Bool -> Bool -> ExpandTest [AForeignBlock] ->
             ASPSignalInfo -> [AOutput] -> [AInput] -> [AId] ->
             ([AVInst], [AId], [ADef], [AForeignBlock]) ->
             ([AVInst], [AId], [ADef], [AForeignBlock])
-aExpDefs errh keepFires expnond expcheap expTest sigInfo os ios muxes (ss', ws', ds', fs') =
+aExpDefs errh stable keepFires expnond expcheap expTest sigInfo os ios muxes (ss', ws', ds', fs') =
     let
         usemap = createUseMap muxes (ss', ws', ds', fs')
-        sorted_defs = tsortDefs errh ds'
+        sorted_defs = tsortDefs stable errh ds'
 
         -- compute the signal names to keep
         keepSchIds = if ( keepFires) then concat $ map snd (aspsi_rule_sched sigInfo) else []
@@ -184,9 +184,12 @@ aExpDefs errh keepFires expnond expcheap expTest sigInfo os ios muxes (ss', ws',
         expand edata M.empty sorted_defs []
 
 
--- Topologically sort defs
-tsortDefs :: ErrorHandle -> [ADef] -> [ADef]
-tsortDefs errh ds = sorted_defs
+-- Topologically sort defs.
+-- Under -stable-verilog (the Bool) the tie-break among ready nodes is
+-- the identifier's text, not Ord AId (SpeedyString intern order); see
+-- ASyntaxUtil.tsortADefs.
+tsortDefs :: Bool -> ErrorHandle -> [ADef] -> [ADef]
+tsortDefs stable errh ds = sorted_defs
   where
     -- compute the signal use edges for all defs
     uses :: [(AId,[AId])]
@@ -197,13 +200,29 @@ tsortDefs errh ds = sorted_defs
     --  the sorted ids back into sorted defs)
     def_ids :: S.Set AId -- the Ids which are defined on the LHS
     def_ids = S.fromList (map fst uses)
-    g = [(i, nub (filter (`S.member` def_ids) is)) | (i, is) <- uses]
-    sorted_def_ids =
-        case tsort g of
-        Left is ->
-            bsErrorUnsafe errh
-                [(noPosition, ECombCycle (map pfpString (concat is)))]
-        Right is -> is
+    edges = [(i, nub (filter (`S.member` def_ids) is)) | (i, is) <- uses]
+    -- text order precomputed as a strict Int rank; see ASyntaxUtil.tsortADefs
+    rank :: M.Map AId Int
+    rank = M.fromList
+             (zip (sortOn (\ i -> (getIdBaseString i, getIdQualString i))
+                          (map fst edges))
+                  [0..])
+    key i = case M.lookup i rank of
+              Just r -> r `seq` (r, i)
+              Nothing -> internalError "tsortDefs: rank"
+    sorted_def_ids
+      | stable =
+          case tsort [ (key i, map key js) | (i, js) <- edges ] of
+            Left is ->
+                bsErrorUnsafe errh
+                    [(noPosition, ECombCycle (map (pfpString . snd) (concat is)))]
+            Right is -> map snd is
+      | otherwise =
+          case tsort edges of
+            Left is ->
+                bsErrorUnsafe errh
+                    [(noPosition, ECombCycle (map pfpString (concat is)))]
+            Right is -> is
     omap = M.fromList [ (i, d) | d@(ADef i _ _ _) <- ds ]
     sorted_defs = map (getDef omap) sorted_def_ids
 
@@ -235,8 +254,8 @@ createUseMap  muxes (ss', ws', ds', fs') = usemap
 -- which the expression depends.
 
 
-aSRemoveUnused :: Bool -> ASPackage -> ASPackage
-aSRemoveUnused keepfires pkg =
+aSRemoveUnused :: Bool -> Bool -> ASPackage -> ASPackage
+aSRemoveUnused stable keepfires pkg =
     let ds = aspkg_values pkg
         vused = aVars (aspkg_state_instances pkg)
         fused = aVars (aspkg_foreign_calls pkg) ++
@@ -244,7 +263,7 @@ aSRemoveUnused keepfires pkg =
                         | (_,fcs) <- aspkg_foreign_calls pkg
                         , fc <- fcs ])
         fires = if keepfires then [i | (ADef i _t _e _) <- ds, isFire i] else []
-        ds' = (collDefs (vused ++ fused ++ fires ) ds)
+        ds' = (collDefs stable (vused ++ fused ++ fires ) ds)
     in
         -- trace ("aSRemoveUnused \nds = " ++ ppReadable ds ++
         --        "\n ds' = " ++ ppReadable ds') $
@@ -263,13 +282,13 @@ aSRemoveUnused keepfires pkg =
 -- in state instances, rules, or methods.
 
 
-aRemoveUnused :: APackage -> APackage
-aRemoveUnused apkg =
+aRemoveUnused :: Bool -> APackage -> APackage
+aRemoveUnused stable apkg =
 --    trace ("aRemoveUnused:\n   vused " ++ ppReadable vused
 --    ++ "\n   rused: " ++ ppReadable rused
 --    ++ "\n   iused: " ++ ppReadable iused) $
         apkg { apkg_local_defs = ds' }
-  where ds' = collDefs (vused ++ rused ++ iused) (apkg_local_defs apkg)
+  where ds' = collDefs stable (vused ++ rused ++ iused) (apkg_local_defs apkg)
         vused = aVars (apkg_state_instances apkg)
         rused = aVars (apkg_rules apkg)
         iused = aVars (apkg_interface apkg)
@@ -291,8 +310,8 @@ aRemoveUnused apkg =
 
 
 -- collect used definitions (and everything they use)
-collDefs :: [AId] -> [ADef] -> [ADef]
-collDefs used ds = coll (S.fromList used) [] (reverse (tsortADefs ds))
+collDefs :: Bool -> [AId] -> [ADef] -> [ADef]
+collDefs stable used ds = coll (S.fromList used) [] (reverse (tsortADefs stable ds))
   where coll _    rs [] = rs
         coll used rs (d@(ADef i _ e _) : ds) =
                 if isLocalAId i
@@ -339,8 +358,8 @@ collDefs used ds = coll (S.fromList used) [] (reverse (tsortADefs ds))
 --   list.  Plus, xaSRemoveUnused takes keepFires as an argument.
 
 
-xaSRemoveUnused :: Bool -> ASPackage -> ASPackage
-xaSRemoveUnused keepFires pkg =
+xaSRemoveUnused :: Bool -> Bool -> ASPackage -> ASPackage
+xaSRemoveUnused stable keepFires pkg =
     -- trace ("xaSremoveUNused \nds = " ++ ppReadable ds ++
     --        "\n ds' = " ++ ppReadable ds' ++ "\n os = " ++ ppReadable os) $
     pkg { aspkg_values = ds' }
@@ -361,7 +380,7 @@ xaSRemoveUnused keepFires pkg =
               --traces("xasRemovedUnused fused: " ++ ppReadable fused ) $
               --traces("xasRemovedUnused vused: " ++ ppReadable vused ) $
               --traces("xasRemovedUnused defs: " ++ ppReadable ds ) $
-              xcollDefs keepFires (vused ++ oused ++ fused) ds
+              xcollDefs stable keepFires (vused ++ oused ++ fused) ds
         --
 
         stArgs :: AVInst -> [AId]
@@ -402,9 +421,9 @@ xaSRemoveUnused keepFires pkg =
 --    firing signals when the -keep-fires flag is on.
 --
 
-xcollDefs :: Bool -> [AId] -> [ADef] -> [ADef]
-xcollDefs keepFires used ds = --traces( "xCollDefs: " ++ ppReadable used ) $
-                              coll (S.fromList used) [] (reverse (tsortADefs ds))
+xcollDefs :: Bool -> Bool -> [AId] -> [ADef] -> [ADef]
+xcollDefs stable keepFires used ds = --traces( "xCollDefs: " ++ ppReadable used ) $
+                              coll (S.fromList used) [] (reverse (tsortADefs stable ds))
   where coll _    rs [] = rs
         coll used rs (d@(ADef i _ e _) : ds) =
             if (((not keepFires)  || (not (isFire i)))
@@ -747,9 +766,9 @@ aoptExpandTest edata i e =
 
 
 -- SERI version
-expandAPackage :: ErrorHandle -> APackage -> APackage
-expandAPackage errh apkg = apkgN
-    where sorted_defs = tsortDefs errh (apkg_local_defs apkg)
+expandAPackage :: ErrorHandle -> Bool -> APackage -> APackage
+expandAPackage errh stable apkg = apkgN
+    where sorted_defs = tsortDefs stable errh (apkg_local_defs apkg)
           -- generate a always used def map, since predicates are not yet generated
           usemap = M.fromList ([ (i,2) | (ADef i _ _ _) <- sorted_defs])
           --
@@ -769,7 +788,7 @@ expandAPackage errh apkg = apkgN
           -- do the expansion
           (_,_, defs, (rules,ifc)) = expand edata M.empty sorted_defs []
           -- rebuild the package
-          apkgN = aRemoveUnused $ apkg { apkg_local_defs = defs,
+          apkgN = aRemoveUnused stable $ apkg { apkg_local_defs = defs,
                                          apkg_rules = rules,
                                          apkg_interface = ifc}
 

--- a/src/comp/AOpt.hs
+++ b/src/comp/AOpt.hs
@@ -15,8 +15,10 @@ import Control.Monad(when, foldM, zipWithM)
 import Control.Monad.State.Strict(State, StateT, evalState, evalStateT, liftIO,
                                   gets, get, put)
 import Data.List(sortBy, genericLength, sort, transpose, partition, groupBy, nub)
+import Data.Ord(Down(..), comparing)
 import Util(mapFst)
 import qualified Data.Map as M
+import qualified Data.Map.Strict as MS
 import qualified Data.Set as S
 import Util(allSame, flattenPairs, makePairs, remOrdDup, integerToBits,
             itos, eqSnd, cmpSnd, nubByFst, map_insertManyWith,
@@ -39,7 +41,7 @@ import Flags(Flags,
              optBitConst,
              keepFires,
              optSched,
-             optJoinDefs)
+             optJoinDefs, stableVerilog)
 import VModInfo(VArgInfo(..), vArgs)
 import Position(noPosition)
 import FStringCompat(mkFString)
@@ -87,6 +89,7 @@ aOpt errh flags pkg0 | not (optATS flags) =
         pkg1 = aExpandDynSelASPkg pkg0
 
         pkg2 = aExpand errh
+                   (stableVerilog flags)
                    keepF
                    False    -- expnond
                    inlineB  -- expcheap
@@ -99,6 +102,7 @@ aOpt errh flags pkg0 = do
         bflags = flagsToBFlags flags
 
         keepF = keepFires flags -- F
+        stable = stableVerilog flags
         optsch = optSched flags -- T
         optjoin = optJoinDefs flags -- F  see comments on b1072
         inlineB = inlineBool flags -- T
@@ -137,6 +141,7 @@ aOpt errh flags pkg0 = do
         -- aExpand is needed here after scheduling tsort defs
         --
         pkg2 = aExpand errh
+                   stable
                    keepF
                    False    -- expnond
                    inlineB  -- expcheap
@@ -158,10 +163,11 @@ aOpt errh flags pkg0 = do
                       aspkg_foreign_calls = fb1,
                       aspkg_state_instances = ss1 }
         -- XXX EWC Not sure why optSched is used here ???
-        pkg4 = xaSRemoveUnused keepF pkg3
+        pkg4 = xaSRemoveUnused stable keepF pkg3
     when debug $
       traceM ("trace defs, post xaSRemoveUnused (ds2): " ++ ppReadable (aspkg_values pkg4))
     let pkg5 = xaXExpand errh
+                   stable
                    keepF
                    optsch  -- expnond
                    False   -- expcheap
@@ -178,7 +184,7 @@ aOpt errh flags pkg0 = do
 
     -- CSE defs
     --
-    let ds3 = joinDefs optjoin ds2
+    let ds3 = joinDefs stable optjoin ds2
     when debug $
       traceM ("trace defs, post joinDefs (ds3): " ++ ppReadable ds3)
     let pkg6 = pkg5 { aspkg_values = ds3 }
@@ -188,6 +194,7 @@ aOpt errh flags pkg0 = do
     -- for the simple cases
     let
         pkg7 = xaXExpand errh
+                   stable
                    keepF
                    optsch  -- expnond
                    False   -- expcheap
@@ -206,7 +213,9 @@ data BFlags = BFlags  { ao_ifmux        :: Bool,
                         ao_keepfires    :: Bool,
                         ao_keepMethIO   :: Bool,
                         ao_aggInline    :: Bool,
-                        ao_ifsToPrimPri :: Bool
+                        ao_ifsToPrimPri :: Bool,
+                        -- canonical (text-keyed) orderings; see -stable-verilog
+                        ao_stable       :: Bool
                         }
 
 flagsToBFlags :: Flags -> BFlags
@@ -223,7 +232,8 @@ flagsToBFlags flags = BFlags {
                               ao_aggInline    = optAggInline flags, -- T
                               ao_keepfires    = keepFires flags, -- False
                               ao_keepMethIO   = keepFires flags,
-                              ao_ifsToPrimPri = True
+                              ao_ifsToPrimPri = True,
+                              ao_stable       = stableVerilog flags
                              }
 
 optFlagsOff :: BFlags -> BFlags
@@ -248,6 +258,7 @@ optExprBFlag = BFlags {
   ,ao_keepfires    = False
   ,ao_keepMethIO   = False
   ,ao_ifsToPrimPri = False
+  ,ao_stable       = False
                              }
 -----
 
@@ -430,9 +441,9 @@ aOptInstArg bflgs _ = aExp bflgs
 -- If any local id has the same definition (expr) as a previously
 -- encountered id, then change the def of the second occurrence to be
 -- just a reference to the first.
-joinDefs :: Bool -> [ADef] -> [ADef]
-joinDefs False ds = ds
-joinDefs True dsx = reverse (snd (foldl add (M.empty, []) dsx))
+joinDefs :: Bool -> Bool -> [ADef] -> [ADef]
+joinDefs _ False ds = ds
+joinDefs False True dsx = reverse (snd (foldl add (M.empty, []) dsx))
   where add :: (M.Map AExpr ADef, [ADef]) -> ADef -> (M.Map AExpr ADef,[ADef])
         add (m, ds) d@(ADef _ _ (ASInt _ _ _) _) = (m, d:ds)
         add (m, ds) d@(ADef _ _ (ASDef _ _) _)   = (m, d:ds)
@@ -457,6 +468,41 @@ joinDefs True dsx = reverse (snd (foldl add (M.empty, []) dsx))
                     | defPropsHasNoCSE props -> (m, d:ds)
                     | otherwise -> -- traces ("adding simple assignment: " ++ ppReadable (ie,i)) $
                                    (m, (ADef ie t (ASDef t i) p) : ds)
+-- Under -stable-verilog the surviving name of each expression class is
+-- chosen by name QUALITY (keep > user-visible > generated ids, via
+-- idQuality) with the lexicographically least name breaking ties -- a
+-- pure function of the class, independent of traversal order -- instead
+-- of first-come-wins over the (interning-order-sensitive) def list.
+joinDefs True True dsx = map rewrite dsx
+  where -- the RHS shapes joinDefs never touches (same as the fold above)
+        shapeOK (ASInt _ _ _)  = False
+        shapeOK (ASDef _ _)    = False
+        shapeOK (ASStr _ _ _)  = False
+        shapeOK (ASPort _ _)   = False
+        shapeOK (ASParam _ _)  = False
+        shapeOK (ASAny _ _)    = False
+        shapeOK _              = True
+        -- enable defs cannot BE the surviving name but -- exactly like
+        -- the first-come fold -- are still rewritten as aliases of it;
+        -- NoCSE defs are never merged in either direction
+        repCandidate (ADef ie _ e props) =
+            shapeOK e && not (hasIdProp ie IdP_enable)
+                      && not (defPropsHasNoCSE props)
+        rank d = (idQuality (Just (adef_objid d)),
+                  Down (getIdString (adef_objid d)))
+        better d1 d2 = if rank d1 >= rank d2 then d1 else d2
+        -- strict: with the lazy map every duplicate chains a `better'
+        -- thunk on the class's entry, and the first lookup would force
+        -- the whole chain at once
+        reps = MS.fromListWith better
+                   [ (adef_expr d, d) | d <- dsx, repCandidate d ]
+        rewrite d@(ADef ie _ e props)
+            | shapeOK e,
+              not (defPropsHasNoCSE props),  -- never merged, like the fold
+              Just (ADef i t _ p) <- M.lookup e reps,
+              i /= ie
+            = ADef ie t (ASDef t i) p
+            | otherwise = d
 
 -- if the expression is a primitive with 1-bit type, optimize it as
 -- a boolean expression
@@ -1161,13 +1207,13 @@ optMuxPairs bflgs aid dty op eps = eps3
       eps1 = filter (not . isFalse . fst) eps
       -- drop terms after the first true term
       eps2 = takeWhilePlus1 (not . isTrue . fst) eps1
-      eps3 = mergeIdenExpr op eps2
+      eps3 = mergeIdenExpr (ao_stable bflgs) op eps2
 
 -- merge Identical Expressions
 -- The sort function here can cause reordering in case expression, which can
 -- later turn to if expressions, and look totally wrong when comparing to older versions.
-mergeIdenExpr :: PrimOp -> [(AExpr,AExpr)] ->  [(AExpr,AExpr)]
-mergeIdenExpr op eps = if ( length newpairs < length eps ) then newpairs else eps
+mergeIdenExpr :: Bool -> PrimOp -> [(AExpr,AExpr)] ->  [(AExpr,AExpr)]
+mergeIdenExpr stable op eps = if ( length newpairs < length eps ) then newpairs else eps
     where
       flattenGrps :: [(AExpr,AExpr)] -> (AExpr,AExpr)
       flattenGrps [] = internalError( "AOpt::mergeIdenExpr" )
@@ -1189,7 +1235,14 @@ mergeIdenExpr op eps = if ( length newpairs < length eps ) then newpairs else ep
                 testf :: (AExpr,AExpr) -> (AExpr,AExpr) -> Bool
                 testf (_,x1) (_,x2) = isASAny x1 == isASAny x2
       --
-      sortfn = if (op == PrimMux) then (sortPairASAny . sortBy cmpSnd) else id
+      -- Under -stable-verilog the PrimMux arm sort keys on the arm's
+      -- TEXT (with ASAny arms last, the invariant sortPairASAny exists
+      -- to repair) instead of Ord AExpr, which bottoms out in intern
+      -- order; structurally equal arms have identical text, so groupBy
+      -- still finds them adjacent.
+      sortfn | op /= PrimMux = id
+             | stable        = sortBy (comparing (\ (_,e) -> (isASAny e, ppString e)))
+             | otherwise     = sortPairASAny . sortBy cmpSnd
       meps = groupBy eqSnd (sortfn eps)
       newpairs = map flattenGrps meps
 
@@ -1686,7 +1739,7 @@ aOptAPackageLite errh flags apkg =
     apkgN
   where
       -- Expand to inline some defs
-      apkg1 = expandAPackage errh apkg
+      apkg1 = expandAPackage errh (stableVerilog flags) apkg
       -- Optimize expressions
       (ds1) = aOptPackage1 apkg1
       apkg2 = apkg1 { apkg_local_defs = ds1 }

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -930,7 +930,7 @@ aSchedule_step1 errh flags prefix pps amod = do
   (resAllocTable, resDrops) <-
       tr "(resAllocTable, resDrops) <- rSchedule ..." $
       convEM errh $
-      rSchedule nm (resource flags) resMax' methodUseMap simultaneous
+      rSchedule (stableVerilog flags) nm (resource flags) resMax' methodUseMap simultaneous
 
   -- record the RAT in the state
   s <- get

--- a/src/comp/AState.hs
+++ b/src/comp/AState.hs
@@ -14,6 +14,7 @@ import qualified Data.Set as S
 import Data.List(transpose, sortBy, partition,
             unzip4, groupBy, intersect,
             genericLength)
+import Data.Ord(comparing)
 
 import Util
 import FStringCompat
@@ -21,7 +22,7 @@ import IntLit
 
 import Error(internalError, ErrMsg(..), ErrorHandle)
 import ErrorMonad(ErrorMonad(..), convErrorMonadToIO)
-import Flags(Flags, useDPI)
+import Flags(Flags, useDPI, stableVerilog)
 import Position(noPosition)
 
 import PreStrings( fsUnderUnder,
@@ -400,7 +401,8 @@ aState' flags pps schedule_info apkg = do
         fblocks = mapFst domain_osc_lookup fdomain_map
 
         -- New improved resource allocation
-        blobs = ratToBlobs (asi_method_uses_map schedule_info)
+        blobs = ratToBlobs (stableVerilog flags)
+                           (asi_method_uses_map schedule_info)
                            omMultMap
                            (asi_resource_alloc_table schedule_info)
         (ers, ars) = blobs
@@ -853,8 +855,8 @@ mkSignalInfoMethod aifaces = merged
 -- The first list ("es") is expression uses.
 -- The second list ("as") is action uses.
 
-ratToBlobs :: MethodUsesMap -> M.Map (AId, AId) Integer -> RAT -> ([MethBlob], [MethBlob])
-ratToBlobs mMap omMultMap rat =
+ratToBlobs :: Bool -> MethodUsesMap -> M.Map (AId, AId) Integer -> RAT -> ([MethBlob], [MethBlob])
+ratToBlobs stable mMap omMultMap rat =
   let
       -- True if there are 2 or more uses of the method,
       -- which means we need to do some sort of muxing
@@ -863,7 +865,7 @@ ratToBlobs mMap omMultMap rat =
       nonTrivial _ = False
 
       -- Create the MethBlobs and partition into expr and action
-      (es, as) = partition fst $ map (mkBlob mMap omMultMap) $ ratToNestedLists rat
+      (es, as) = partition fst $ map (mkBlob stable mMap omMultMap) $ ratToNestedLists rat
   in
       -- filter out the expr uses which don't need muxing
       (filter nonTrivial (map snd es), map snd as)
@@ -872,10 +874,18 @@ ratToBlobs mMap omMultMap rat =
 -- Given the method use map and an element from the RAT, produce a
 -- pair (Bool,MethBlob) where the Bool is True if the method use is an
 -- expression and False if it is an action
-mkBlob :: MethodUsesMap -> M.Map (AId, AId) Integer -> (MethodId, [(UniqueUse, Integer)]) ->
+mkBlob :: Bool -> MethodUsesMap -> M.Map (AId, AId) Integer -> (MethodId, [(UniqueUse, Integer)]) ->
           (Bool, MethBlob)
-mkBlob mMap omMultMap (method@(MethodId obj met), usedPorts) =
+mkBlob stable mMap omMultMap (method@(MethodId obj met), usedPorts0) =
   let
+      -- Under -stable-verilog, canonicalize the per-port use order by
+      -- the use's TEXT (the same trick sortRatList applies one level
+      -- up): the relative order here decides mux arm order, the
+      -- MUX_/SEL_/VAL_ numbering assigned below, EN or-lists, and the
+      -- derived sensitivity lists, and is otherwise Map-iteration
+      -- (interning) order.
+      usedPorts | stable    = sortBy (comparing (ppString . fst)) usedPorts0
+                | otherwise = usedPorts0
       -- We will use information for this method from both the
       -- MethodUsesMap and the RAT, so prepare an error in case
       -- the two are inconsistent:

--- a/src/comp/ASyntaxUtil.hs
+++ b/src/comp/ASyntaxUtil.hs
@@ -11,9 +11,9 @@ import PPrint
 import IntLit
 import SCC(tsort)
 import Util(separate)
-import Data.List(nub, genericIndex, genericDrop)
+import Data.List(nub, sortOn, genericIndex, genericDrop)
 import Data.Maybe(mapMaybe, fromMaybe)
-import Id(Id)
+import Id(Id, getIdBaseString, getIdQualString)
 import Control.Monad(liftM)
 import PreIds(idInout_)
 
@@ -704,29 +704,49 @@ aIdFnToAActionFn fn (ATaskAction aid fun isC cookie args temp ty isA) =
 
 -- ---------------
 
--- topological sorting of ADefs
-tsortADefs :: [ADef] -> [ADef]
-tsortADefs ds =
---    trace ("tsortADefs enter " ++ show (length ds)) $
-    -- ds_ids are the AIds from the input ADefs
-    -- s is a OrdSet of AId from the input ADefs
+-- topological sorting of ADefs.
+-- Under -stable-verilog (the Bool), ties among ready nodes break on the
+-- identifier's TEXT instead of Ord AId -- which bottoms out in the
+-- SpeedyString intern unique, i.e. the order strings happened to be
+-- interned in THIS process -- so the linearization (and every
+-- first-come-wins choice downstream of it) is a pure function of the
+-- input defs.  Any topological order is semantically legal; the flag
+-- only selects a reproducible member of that set.
+tsortADefs :: Bool -> [ADef] -> [ADef]
+tsortADefs stable ds =
     let
         ds_ids = (map adef_objid ds)
         s = S.fromList ds_ids
-    -- g is a list of (AId, [AIds used by that ADef which are in 's'
-    --   drop all other AIds (mostly AVars)
---        g = [(i, filter (`S.member` s) (aVars e)) | ADef i _ e <- ds ]
-        g = zip ds_ids (map ((filter (`S.member` s)) . aVars . adef_expr) ds)
-    -- tsort returns Left if there is a loop, Right if sorted
-    in  case tsort g of
-        Left is -> internalError ("tsortADefs: cyclic " ++ ppReadable is ++ ppReadable ds)
-        Right is -> --trace ("tsortADefs exit " ++ show (length is)) $
+        deps = map ((filter (`S.member` s)) . aVars . adef_expr) ds
     -- m is OrdMap of (AId of ADef, ADef) from input ADefs
-            let m = M.fromList (zip ds_ids ds)
+        m = M.fromList (zip ds_ids ds)
     -- get i is OrdMap lookup giving ADef in m from AId
-                get i = case M.lookup i m of Just d -> d; Nothing -> internalError "tsortADefs: get"
-    -- return ADefs in tsort-ed order removing AIds.
-            in  map get is
+        get i = case M.lookup i m of Just d -> d; Nothing -> internalError "tsortADefs: get"
+    -- decorate ids so Ord compares in text order; the text order is
+    -- precomputed as a strict Int rank so that graph keys stay small
+    -- (string keys on every edge overflow the stack on large designs)
+        rank :: M.Map AId Int
+        rank = M.fromList
+                 (zip (sortOn (\ i -> (getIdBaseString i, getIdQualString i))
+                              ds_ids)
+                      [0..])
+        key i = case M.lookup i rank of
+                  Just r -> r `seq` (r, i)
+                  Nothing -> internalError "tsortADefs: rank"
+        sorted_ids
+          | stable =
+              let g = [ (key i, map key js) | (i, js) <- zip ds_ids deps ]
+              in  case tsort g of
+                    Left is -> internalError ("tsortADefs: cyclic " ++
+                                   ppReadable (map (map snd) is) ++ ppReadable ds)
+                    Right is -> map snd is
+          | otherwise =
+              let g = zip ds_ids deps
+              in  case tsort g of
+                    Left is -> internalError ("tsortADefs: cyclic " ++
+                                   ppReadable is ++ ppReadable ds)
+                    Right is -> is
+    in  map get sorted_ids
 
 -- ---------------
 

--- a/src/comp/AVerilogUtil.hs
+++ b/src/comp/AVerilogUtil.hs
@@ -32,12 +32,13 @@ module AVerilogUtil (
                     ) where
 
 import Data.List(nub, partition, genericLength, genericIndex, union, intersect,
-                 (\\), uncons)
+                 (\\), uncons, sortBy)
+import Data.Ord(comparing)
 import Data.Maybe
 
 import FStringCompat(FString, getFString)
 import ErrorUtil
-import Flags(Flags, readableMux, unSpecTo, v95, systemVerilogTasks, useDPI)
+import Flags(Flags, readableMux, unSpecTo, v95, systemVerilogTasks, useDPI, stableVerilog)
 import PPrint
 import IntLit
 import Id
@@ -75,7 +76,9 @@ data VConvtOpts = VConvtOpts {
                               vco_v95_tasks   :: [String],
                               vco_readableMux :: Bool,
                               vco_sv_tasks    :: Bool,
-                              vco_use_dpi     :: Bool
+                              vco_use_dpi     :: Bool,
+                              -- canonical (text-keyed) orderings; -stable-verilog
+                              vco_stable      :: Bool
                               }
 
 
@@ -86,7 +89,8 @@ flagsToVco flags = VConvtOpts {
                                vco_v95_tasks = ["$signed", "$unsigned"],
                                vco_readableMux = readableMux flags,
                                vco_sv_tasks = systemVerilogTasks flags,
-                               vco_use_dpi = useDPI flags
+                               vco_use_dpi = useDPI flags,
+                               vco_stable = stableVerilog flags
                               }
 
 -- This has been abolished from the compiler everywhere but the Verilog backend
@@ -148,14 +152,21 @@ vForeignBlock vco ffmap ds (clks, fcalls) =
       av_depend_defs = getAVDependDefs rev_dep_map fcalls
       -- find the defs which fcalls depend on
       fcall_depend_defs = getFCallDependDefs dep_map fcalls
-      -- the intersection of these lists is the defs that we need to inline
-      inline_def_ids = av_depend_defs `intersect` fcall_depend_defs
+      -- the intersection of these lists is the defs that we need to inline.
+      -- Under -stable-verilog the list is canonicalized by the ids' text:
+      -- it arrives in Ord AId (interning) order from the closure Sets and
+      -- becomes the foreign-block group's reg-declaration order.
+      inline_def_ids
+        | vco_stable vco = sortBy (comparing idKey) inline_def_ids0
+        | otherwise      = inline_def_ids0
+        where idKey i = (getIdBaseString i, getIdQualString i)
+      inline_def_ids0 = av_depend_defs `intersect` fcall_depend_defs
 
       -- convert from the ids back to the defs
       inline_defs = map findDef inline_def_ids
 
       -- tsort these inlined defs among the fcalls
-      fcalls_and_defs = tsortForeignCallsAndDefs inline_defs fcalls
+      fcalls_and_defs = tsortForeignCallsAndDefs (vco_stable vco) inline_defs fcalls
 
       -- convert the sorted list to VStmts
       convert :: Either ADef AForeignCall -> [VStmt]
@@ -275,18 +286,26 @@ buildVerilogTask vco etask es | vco_sv_tasks vco == False &&
 buildVerilogTask vco taskid es | isMappedAVId (vidToId taskid) = VSeq [VTask taskid es, VZeroDelay]
 buildVerilogTask vco taskid es = VTask taskid es
 
-tsortForeignCallsAndDefs :: [ADef] -> [AForeignCall] ->
+tsortForeignCallsAndDefs :: Bool -> [ADef] -> [AForeignCall] ->
                             [Either ADef AForeignCall]
 -- if there are no defs, just return the fcalls
-tsortForeignCallsAndDefs [] fcalls = map Right fcalls
-tsortForeignCallsAndDefs ds fcalls =
+tsortForeignCallsAndDefs _ [] fcalls = map Right fcalls
+tsortForeignCallsAndDefs stable ds fcalls =
     let
         -- we will create a graph where the edges are:
-        -- * "Left AId" to represent a def (by it's name)
+        -- * "Left key" to represent a def (by it's name)
         -- * "Right Integer" to represent an fcall (by it's position)
 
         -- The use of Left and Right was chosen to make Defs lower in
         -- the Ord order than ForeignCalls.  This way, tsort puts them first.
+
+        -- Under -stable-verilog the def-node key carries the id's TEXT
+        -- first, so the tsort tie-break among ready defs (SCC's PSQ
+        -- pops equal-priority nodes in Ord order) is interning-history
+        -- independent; with the flag off the constant text component
+        -- makes the key order-isomorphic to bare Ord AId.
+        mkKey i | stable    = ((getIdBaseString i, getIdQualString i), i)
+                | otherwise = (("", ""), i)
 
         -- ----------
         -- Defs
@@ -298,7 +317,7 @@ tsortForeignCallsAndDefs ds fcalls =
         s = S.fromList ds_ids
 
         -- make edges for def-to-def dependencies
-        def_edges = [ (Left i, map Left uses)
+        def_edges = [ (Left (mkKey i), map (Left . mkKey) uses)
                           | ADef i _ e _ <- ds,
                             let uses = filter (`S.member` s) (aVars e) ]
 
@@ -343,7 +362,7 @@ tsortForeignCallsAndDefs ds fcalls =
 
         -- any defs used by an fcall have to be computed before the
         -- fcall is called
-        fcall_def_edges = [ (Right n, map Left uses)
+        fcall_def_edges = [ (Right n, map (Left . mkKey) uses)
                                 | (n,f) <- numbered_fcalls,
                                   let uses = filter (`S.member` s) (aVars f) ]
 
@@ -368,7 +387,7 @@ tsortForeignCallsAndDefs ds fcalls =
                                    let refs = filter isAV (aVars e),
                                    not (null refs) ]
             in  -- make the edges
-                [ (Left i, map (Right . findNum) refs)
+                [ (Left (mkKey i), map (Right . findNum) refs)
                      | (i, refs) <- aval_refs ]
 
         -- ----------
@@ -394,7 +413,7 @@ tsortForeignCallsAndDefs ds fcalls =
         -- convert a graph node back into a def/action
         -- and then to a SimCCFnStmt
 
-        convertNode (Left i) = Left (getDef i)
+        convertNode (Left (_, i)) = Left (getDef i)
         convertNode (Right n) = Right (getFCall n)
 
     in

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -163,7 +163,18 @@ data Flags = Flags {
         -- derive the Verilog "Ports:" comment from the APackage analysis
         -- (getIOPropsA) instead of the netlist measurement; off by default
         -- so the emitted Verilog is unchanged
-        semanticPortsComment :: Bool
+        semanticPortsComment :: Bool,
+        semanticPortsComment :: Bool,
+        -- stop after the stage's checks without producing its artifact:
+        -- at Verilog link, validate the link closure and have the
+        -- simulator builder write a manifest instead of building
+        checkOnly :: Bool,
+        -- deterministic Verilog emission: canonical counter numbering,
+        -- deterministic CSE-representative names, and canonical operand
+        -- ordering, so the same .ba yields byte-identical .v in any
+        -- compile (off by default: the emitted names then match what
+        -- this compiler has historically produced)
+        stableVerilog :: Bool
         }
 -- don't derive Show -- it causes an optimized ghc build to take a long time
 --        deriving (Show)

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -164,11 +164,9 @@ data Flags = Flags {
         -- (getIOPropsA) instead of the netlist measurement; off by default
         -- so the emitted Verilog is unchanged
         semanticPortsComment :: Bool,
-        semanticPortsComment :: Bool,
         -- stop after the stage's checks without producing its artifact:
         -- at Verilog link, validate the link closure and have the
         -- simulator builder write a manifest instead of building
-        checkOnly :: Bool,
         -- deterministic Verilog emission: canonical counter numbering,
         -- deterministic CSE-representative names, and canonical operand
         -- ordering, so the same .ba yields byte-identical .v in any

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -747,7 +747,10 @@ defaultFlags bluespecdir = Flags {
         warnActionShadowing = True,
         warnMethodUrgency = True,
         warnUndetPred = False,
-        semanticPortsComment = False
+        semanticPortsComment = False,
+        semanticPortsComment = False,
+        checkOnly = False,
+        stableVerilog = False
         }
 
 -- Default path value replaced in adjustFinalFlags
@@ -1561,6 +1564,9 @@ externalFlags = [
          (Toggle (\f x -> f {semanticPortsComment=x})
                  (showIfTrue semanticPortsComment),
           "derive the Verilog Ports comment from the APackage analysis",
+        ("stable-verilog",
+         (Toggle (\f x -> f {stableVerilog=x}) (showIfTrue stableVerilog),
+          "deterministic Verilog emission (canonical names and ordering)",
           Hidden)),
 
         ("show-compiles",
@@ -2058,6 +2064,9 @@ showFlagsRaw flags =
           ("warnMethodUrgency", show (warnMethodUrgency flags)),
           ("warnUndetPred", show (warnUndetPred flags)),
           ("semanticPortsComment", show (semanticPortsComment flags))
+          ("semanticPortsComment", show (semanticPortsComment flags)),
+          ("checkOnly", show (checkOnly flags)),
+          ("stableVerilog", show (stableVerilog flags))
          ]
         in "Flags {\n" ++
                (intercalate ",\n" (map render fields)) ++

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -2063,7 +2063,6 @@ showFlagsRaw flags =
           ("warnActionShadowing", show (warnActionShadowing flags)),
           ("warnMethodUrgency", show (warnMethodUrgency flags)),
           ("warnUndetPred", show (warnUndetPred flags)),
-          ("semanticPortsComment", show (semanticPortsComment flags))
           ("semanticPortsComment", show (semanticPortsComment flags)),
           ("stableVerilog", show (stableVerilog flags))
          ]

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -748,8 +748,6 @@ defaultFlags bluespecdir = Flags {
         warnMethodUrgency = True,
         warnUndetPred = False,
         semanticPortsComment = False,
-        semanticPortsComment = False,
-        checkOnly = False,
         stableVerilog = False
         }
 
@@ -1564,6 +1562,8 @@ externalFlags = [
          (Toggle (\f x -> f {semanticPortsComment=x})
                  (showIfTrue semanticPortsComment),
           "derive the Verilog Ports comment from the APackage analysis",
+          Hidden)),
+
         ("stable-verilog",
          (Toggle (\f x -> f {stableVerilog=x}) (showIfTrue stableVerilog),
           "deterministic Verilog emission (canonical names and ordering)",
@@ -2065,7 +2065,6 @@ showFlagsRaw flags =
           ("warnUndetPred", show (warnUndetPred flags)),
           ("semanticPortsComment", show (semanticPortsComment flags))
           ("semanticPortsComment", show (semanticPortsComment flags)),
-          ("checkOnly", show (checkOnly flags)),
           ("stableVerilog", show (stableVerilog flags))
          ]
         in "Flags {\n" ++

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260802-3"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260803-5"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -568,7 +568,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135 a_136) =
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4; wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8; wr_chunk9
       where
         -- The 137-field serialization is split into NOINLINE chunks so
@@ -621,7 +621,7 @@ instance Bin Flags where
              toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
         {-# NOINLINE wr_chunk9 #-}
         wr_chunk9 =
-          do toBin a_135; toBin a_136
+          do toBin a_135; toBin a_136; toBin a_137
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -641,7 +641,7 @@ instance Bin Flags where
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
            a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
-          (a_135, a_136) <- rd_chunk9
+          (a_135, a_136, a_137) <- rd_chunk9
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -656,7 +656,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135 a_136)
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136 a_137)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -723,8 +723,8 @@ instance Bin Flags where
                      a_128, a_129, a_130, a_131, a_132, a_133, a_134)
         {-# NOINLINE rd_chunk9 #-}
         rd_chunk9 =
-          do a_135 <- fromBin; a_136 <- fromBin
-             return (a_135, a_136)
+          do a_135 <- fromBin; a_136 <- fromBin; a_137 <- fromBin
+             return (a_135, a_136, a_137)
 
 -- ----------
 

--- a/src/comp/InlineReg.hs
+++ b/src/comp/InlineReg.hs
@@ -3,14 +3,15 @@ module InlineReg (
                   RegInstInfo
                   ) where
 
-import Data.List(partition)
+import Data.List(partition, sortBy)
+import Data.Ord(comparing)
 import qualified Data.Map as M
 import IntLit
 import IntegerUtil(aaaa)
 import Util(itos)
 import PPrint
 import Error
-import Flags(Flags)
+import Flags(Flags, stableVerilog)
 import Id
 import ASyntax
 import VModInfo
@@ -31,17 +32,27 @@ vInlineReg :: ErrorHandle -> Flags -> [AVInst] -> ([VMItem], [RegInstInfo])
 vInlineReg errh flags avis =
     let
         vco = flagsToVco flags
+        stable = stableVerilog flags
+        -- Under -stable-verilog, the clock/reset domain groups are
+        -- ordered by the printed text of their keys; the Map iteration
+        -- order is Ord AExpr, which bottoms out in interning order.
+        stableGroups :: PPrint k => [(k, v)] -> [(k, v)]
+        stableGroups gs = if stable
+                          then sortBy (comparing (ppString . fst)) gs
+                          else gs
         -- separate the RegAs from the RegN and RegUN
         (regas, regns_and_reguns) = partition isRegA avis
 
         -- make a map from clock to the RegNs and RegUNs in that clock
-        ns_and_uns_by_clock = M.toList (partitionByClock errh regns_and_reguns)
+        ns_and_uns_by_clock =
+            stableGroups (M.toList (partitionByClock errh regns_and_reguns))
 
         -- translate the partitioned RegN/RegUNs into always blocks
-        ns_and_uns_items = map (vInlineN errh vco) ns_and_uns_by_clock
+        ns_and_uns_items = map (vInlineN errh vco stable) ns_and_uns_by_clock
 
         -- make a map from clock and reset to the RegAs for that pair
-        as_by_clock_and_reset = M.toList (partitionByClockAndReset errh regas)
+        as_by_clock_and_reset =
+            stableGroups (M.toList (partitionByClockAndReset errh regas))
 
         -- translate the partitioned RegAs into always blocks
         as_items = map (vInlineA vco) as_by_clock_and_reset
@@ -99,8 +110,8 @@ mkRegInstInfo errh flags avi =
 -- ==============================
 
 -- Generate an always block for RegN and RegUN on the same clock
-vInlineN :: ErrorHandle -> VConvtOpts -> (AExpr, [AVInst]) -> VMItem
-vInlineN errh vco (clk, avis) =
+vInlineN :: ErrorHandle -> VConvtOpts -> Bool -> (AExpr, [AVInst]) -> VMItem
+vInlineN errh vco stable (clk, avis) =
     let
         -- partition the avis into those with resets and those without
         (regns, reguns) = partition isRegN avis
@@ -109,9 +120,12 @@ vInlineN errh vco (clk, avis) =
         regns_by_reset = partitionByReset errh regns
 
         -- translate into statements inside the always block
+        stableGroups gs = if stable
+                          then sortBy (comparing (ppString . fst)) gs
+                          else gs
         body_items =
             -- put a comment here "initialized registers"
-            map (translateRegN vco) (M.toList regns_by_reset) ++
+            map (translateRegN vco) (stableGroups (M.toList regns_by_reset)) ++
             -- put a comment here "uninitialized registers"
             map (translateRegUN vco) reguns
 

--- a/src/comp/InlineReg.hs
+++ b/src/comp/InlineReg.hs
@@ -28,6 +28,18 @@ import BackendNamingConventions
 --      * the name of the instance
 --      * the list of inputs and their sizes
 --      * the output, to be declared "Reg" and its size
+-- tie-break for text-identical (but distinct) clock/reset key
+-- expressions: the key id's own string -- interning-free -- since
+-- pretty-printing drops the id for constant-shaped exprs
+exprIdText :: AExpr -> String
+exprIdText (APrim i _ _ _)  = getIdBaseString i
+exprIdText (ASInt i _ _)    = getIdBaseString i
+exprIdText (ASStr i _ _)    = getIdBaseString i
+exprIdText (ASPort _ i)     = getIdBaseString i
+exprIdText (ASParam _ i)    = getIdBaseString i
+exprIdText (ASDef _ i)      = getIdBaseString i
+exprIdText _                = ""
+
 vInlineReg :: ErrorHandle -> Flags -> [AVInst] -> ([VMItem], [RegInstInfo])
 vInlineReg errh flags avis =
     let
@@ -36,10 +48,17 @@ vInlineReg errh flags avis =
         -- Under -stable-verilog, the clock/reset domain groups are
         -- ordered by the printed text of their keys; the Map iteration
         -- order is Ord AExpr, which bottoms out in interning order.
-        stableGroups :: PPrint k => [(k, v)] -> [(k, v)]
+        stableGroups :: [(AExpr, v)] -> [(AExpr, v)]
         stableGroups gs = if stable
-                          then sortBy (comparing (ppString . fst)) gs
+                          then sortBy (comparing (\ (k, _) -> (ppString k, exprIdText k))) gs
                           else gs
+        stableGroups2 :: [((AExpr, AExpr), v)] -> [((AExpr, AExpr), v)]
+        stableGroups2 gs =
+            if stable
+            then sortBy (comparing (\ ((c, r), _) ->
+                             (ppString (c, r),
+                              (exprIdText c, exprIdText r)))) gs
+            else gs
         -- separate the RegAs from the RegN and RegUN
         (regas, regns_and_reguns) = partition isRegA avis
 
@@ -52,7 +71,7 @@ vInlineReg errh flags avis =
 
         -- make a map from clock and reset to the RegAs for that pair
         as_by_clock_and_reset =
-            stableGroups (M.toList (partitionByClockAndReset errh regas))
+            stableGroups2 (M.toList (partitionByClockAndReset errh regas))
 
         -- translate the partitioned RegAs into always blocks
         as_items = map (vInlineA vco) as_by_clock_and_reset
@@ -121,7 +140,7 @@ vInlineN errh vco stable (clk, avis) =
 
         -- translate into statements inside the always block
         stableGroups gs = if stable
-                          then sortBy (comparing (ppString . fst)) gs
+                          then sortBy (comparing (\ (k, _) -> (ppString k, exprIdText k))) gs
                           else gs
         body_items =
             -- put a comment here "initialized registers"

--- a/src/comp/RSchedule.hs
+++ b/src/comp/RSchedule.hs
@@ -24,6 +24,7 @@ FlexibleInstances is necessary.
 module RSchedule(rSchedule, RAT, ratToNestedLists) where
 
 import Data.List((\\),partition,sortBy)
+import Data.Ord(comparing)
 import Data.Maybe(maybeToList)
 import Control.Monad(when)
 import qualified Data.Map as M
@@ -108,22 +109,22 @@ data StackItem v r = Vertex (v,[v]) | Edge r
 --  * RAT
 --  * [RRM]
 
-rSchedule :: Id -> ResourceFlag -> M.Map MethodId Integer -> MethodUsesMap ->
+rSchedule :: Bool -> Id -> ResourceFlag -> M.Map MethodId Integer -> MethodUsesMap ->
              (RuleId -> RuleId -> Bool) -> ErrorMonad (RAT,[RRM])
-rSchedule moduleId rFlag rMaxs rMap areSimult =
+rSchedule stable moduleId rFlag rMaxs rMap areSimult =
     -- We don't need to worry about keys conflicting when combining xxs
     -- because those keys came from the keys of rMap.
     let concatTuple (xxs,yys) = (M.unions xxs, concat yys)
-        f = rSchedule' moduleId rFlag rMaxs areSimult
+        f = rSchedule' stable moduleId rFlag rMaxs areSimult
     in
         mapM f (M.toList rMap) >>= return . concatTuple . unzip
 
 
-rSchedule' :: Id -> ResourceFlag -> M.Map MethodId Integer ->
+rSchedule' :: Bool -> Id -> ResourceFlag -> M.Map MethodId Integer ->
               (RuleId -> RuleId -> Bool) ->
               (MethodId, [(UniqueUse, MethodUsers)]) ->
               ErrorMonad (RAT, [RRM])
-rSchedule' moduleId rFlag rMaxs areSimult mu@(mId, uses0) =
+rSchedule' stable moduleId rFlag rMaxs areSimult mu@(mId, uses0) =
     let
         -- XXX condition-insensitive resource allocation
         -- our graph allocation is not smart enough to handle
@@ -141,7 +142,7 @@ rSchedule' moduleId rFlag rMaxs areSimult mu@(mId, uses0) =
                          errDropEdges mId rMax
                 RFsimple -> -- reschedule
                             -- arbitrate resource (drop edge in graph)
-                            simpleDropEdges moduleId areSimult (mId, uses) rMax
+                            simpleDropEdges stable moduleId areSimult (mId, uses) rMax
     in do
          when trace_ralloc
              (traceM $ "rSchedule: allocating " ++ show (length uses) ++
@@ -152,8 +153,12 @@ rSchedule' moduleId rFlag rMaxs areSimult mu@(mId, uses0) =
              (traceM $ "rSchedule: uugraph:\n" ++ ppReadable g)
          -- when (rMax <= 0) (verifySC g)
          if length uses > 16 && fromInteger rMax >= length uses
-           then return (M.singleton mId (M.fromList (zip (map fst uses) [1..])), [])
-           else do (colors, drops) <- color rMax dropEdges g
+           -- under -stable-verilog the splayed port numbering follows
+           -- the uses' text, not MethodUsesMap (interning) order
+           then let uses_c | stable    = sortBy (comparing (ppString . fst)) uses
+                           | otherwise = uses
+                in  return (M.singleton mId (M.fromList (zip (map fst uses_c) [1..])), [])
+           else do (colors, drops) <- color stable rMax dropEdges g
                    return (M.singleton mId colors, drops)
 
 
@@ -245,16 +250,20 @@ eArbitrate moduleId (r,r') =
 -- ==============================
 -- Function: simpleDropEdges
 
-simpleDropEdges :: Id -> (RuleId -> RuleId -> Bool) ->
+simpleDropEdges :: Bool -> Id -> (RuleId -> RuleId -> Bool) ->
                    (MethodId, [(UniqueUse, MethodUsers)]) ->
                    Integer -> StkL -> UUGraph -> ErrorMonad (StkL, UUGraph)
-simpleDropEdges moduleId areSimult (mId,uses) rMax st g =
+simpleDropEdges stable moduleId areSimult (mId,uses) rMax st g =
     if all null droppable || any sameRule rs
     then errDropEdges mId rMax st g
     else EMWarning warn (st',g')
-    where droppable = [map fromActionOf w
+    where droppable0 = [map fromActionOf w
                        | v <- G.vertices g, v' <- G.neighbors g v,
                        w <- maybeToList (G.lookup (v,v') g), all isActionOf w]
+          -- under -stable-verilog, WHICH all-ActionOf edge is dropped
+          -- follows the edge's text, not vertex (interning) order
+          droppable | stable    = sortBy (comparing ppString) droppable0
+                    | otherwise = droppable0
           rs = case droppable of
                (xs:_) -> xs
                _      -> internalError "simpleDropEdges: nothing to drop!"
@@ -277,24 +286,31 @@ simpleDropEdges moduleId areSimult (mId,uses) rMax st g =
 -- ==============================
 -- Function: color
 
-color :: Integer -> (StkL -> UUGraph -> ErrorMonad (StkL, UUGraph)) ->
+color :: Bool -> Integer -> (StkL -> UUGraph -> ErrorMonad (StkL, UUGraph)) ->
          UUGraph -> ErrorMonad (M.Map UniqueUse Integer, [RRM])
-color rMax dropEdges g
-    | rMax > 0 = colorFw rMax dropEdges [] g >>= colorBk [1..rMax] M.empty []
+color stable rMax dropEdges g
+    | rMax > 0 = colorFw stable rMax dropEdges [] g >>= colorBk [1..rMax] M.empty []
     | otherwise = return (M.fromList [(v,1) | v <- G.vertices g], [])
 
 
 -- forward pass: generate stack of colorable vertices and dropped edges
-colorFw :: Integer -> (StkL -> UUGraph -> ErrorMonad (StkL, UUGraph)) ->
+colorFw :: Bool -> Integer -> (StkL -> UUGraph -> ErrorMonad (StkL, UUGraph)) ->
            StkL -> UUGraph -> ErrorMonad StkL
-colorFw rMax dropEdges st g
+colorFw stable rMax dropEdges st g
     | G.null g = return st
     | otherwise =
-        case partition (colorable rMax g) (G.vertices g) of
-            (cv:_, _) -> colorFw rMax dropEdges
+        -- under -stable-verilog the vertex scan follows the uses' text,
+        -- not GraphMap key (interning) order, so WHICH use is peeled
+        -- first -- and hence the RAT color each use receives -- is a
+        -- pure function of the graph
+        let vs | stable    = sortBy (comparing ppString) (G.vertices g)
+               | otherwise = G.vertices g
+        in
+        case partition (colorable rMax g) vs of
+            (cv:_, _) -> colorFw stable rMax dropEdges
                              (Vertex (cv, G.neighbors g cv) : st)
                              (G.deleteVertex g cv)
-            (_, _) -> dropEdges st g >>= (uncurry $ colorFw rMax dropEdges)
+            (_, _) -> dropEdges st g >>= (uncurry $ colorFw stable rMax dropEdges)
 
 
 -- backward pass: pick up vertices and color them

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -1084,7 +1084,7 @@ mkActionMethodSchedStmts top_ifc top_vmeth_set top_ameth_set inst_map
       -- ----------
       -- Get all the defs needed for the WF expr
       ids = S.toList $ getExprIds True def_map S.empty [ASDef bit_type unqual_wf]
-      defs = tsortADefs $ map (findDef def_map) ids
+      defs = tsortADefs False $ map (findDef def_map) ids
 
       -- ----------
       -- Call the RDY method for top-level methods, since they may check their
@@ -1137,7 +1137,7 @@ mkRuleSchedStmts inst_map full_dmap method_calls
       -- ----------
       -- Get all the defs needed for the WF expr
       ids = S.toList $ getExprIds True def_map S.empty [ASDef bit_type unqual_wf]
-      defs = tsortADefs $ map (findDef def_map) ids
+      defs = tsortADefs False $ map (findDef def_map) ids
 
       -- ----------
       -- Make the statements

--- a/src/comp/Synthesize.hs
+++ b/src/comp/Synthesize.hs
@@ -1,6 +1,7 @@
 module Synthesize(aSynthesize) where
 
-import Data.List(transpose, sort, genericLength, nub)
+import Data.List(transpose, sort, sortBy, genericLength, nub)
+import Data.Ord(comparing)
 import Control.Monad(when, zipWithM, zipWithM_)
 import Control.Monad.State(State, runState, gets, get, put)
 import Debug.Trace
@@ -10,7 +11,7 @@ import Util(integerToBits, makePairs, log2, itos)
 import PPrint
 import IntLit
 import ErrorUtil
-import Flags(Flags, synthesize)
+import Flags(Flags, synthesize, stableVerilog)
 import Position(noPosition)
 import FStringCompat(mkFString)
 import Id
@@ -35,11 +36,12 @@ synthPref = "_dw"
 
 aSynthesize :: Flags -> ASPackage -> ASPackage
 aSynthesize flags p@(ASPackage { aspkg_values = ds }) =
+  let stable = stableVerilog flags in
     if not (synthesize flags) then
         p
     else
         -- XXX use some fast removal of unused defs & renamings.
-        aImprove (p { aspkg_values = synDefs ds })
+        aImprove stable (p { aspkg_values = synDefs stable ds })
 
 -- ---------------
 
@@ -48,8 +50,8 @@ aSynthesize flags p@(ASPackage { aspkg_values = ds }) =
 --   inline variables and constants
 --   propagate constants
 -- XXX - assuming foreign function calls need not be touched because state variable instantiations are not touched
-aImprove :: ASPackage -> ASPackage
-aImprove p@(ASPackage { aspkg_values = ds }) =
+aImprove :: Bool -> ASPackage -> ASPackage
+aImprove stable p@(ASPackage { aspkg_values = ds }) =
     let inline :: M.Map AId AExpr
         inline = M.fromList [ (i, e) | ADef i _ e _ <- ds, isSimple e ]
         repl :: AExpr -> AExpr
@@ -64,7 +66,7 @@ aImprove p@(ASPackage { aspkg_values = ds }) =
         repl e = e
         -- aOptBoolExpr is overkill...
         ds' = [ ADef i t (aOptBoolExpr (repl e)) p | ADef i t e p <- ds ]
-        p'' = aSRemoveUnused False (p { aspkg_values = ds' })
+        p'' = aSRemoveUnused stable False (p { aspkg_values = ds' })
         ds'' = aspkg_values p''
     in  if length ds == length ds'' && ds == ds'' then        -- length check is a fast check for inequality
             (if doTrace then trace "aImprove done" else id)
@@ -72,11 +74,13 @@ aImprove p@(ASPackage { aspkg_values = ds }) =
         else
             (if doTrace then trace ("aImprove iterates, " ++ show (length ds, length ds'')) else id) $
 --          trace (ppReadable p'') $
-            aImprove p''
+            aImprove stable p''
 
 --------
 
 data SState = SState {
+                -- canonical (text-keyed) operand ordering; -stable-verilog
+                sstable :: Bool,
                 -- unique name generator
                 uniqueId :: Integer,
                 -- definitions processed so far
@@ -134,14 +138,15 @@ newName = do
 
 --------
 
-synDefs :: [ADef] -> [ADef]
-synDefs ds =
-    let initState = SState { uniqueId = 1,
+synDefs :: Bool -> [ADef] -> [ADef]
+synDefs stable ds =
+    let initState = SState { sstable = stable,
+                             uniqueId = 1,
                              defs = [],
                              cse_map = M.empty,
                              simple_map = M.empty
                            }
-    in  fst $ runState (synDefsS (tsortADefs ds)) initState
+    in  fst $ runState (synDefsS (tsortADefs stable ds)) initState
 
 synDefsS :: [ADef] -> S [ADef]
 synDefsS ds = do
@@ -235,7 +240,8 @@ normExpr (APrim aid t op es) = do
     let getSimpleS e@(ASDef _ i) = getSimple i e
         getSimpleS e = return e
     es' <- mapM getSimpleS es
-    return (sortExpr (aOptPrim aid t op es'))
+    stable <- gets sstable
+    return (sortExpr stable (aOptPrim aid t op es'))
 normExpr e@(ASDef _ i) = getSimple i e
 normExpr e = return e
 
@@ -246,10 +252,14 @@ aOptPrim aid t PrimXor  es  = aXors aid es
 aOptPrim aid t PrimBNot [e] = aNot aid e
 aOptPrim aid t p es = APrim aid t p es
 
-sortExpr :: AExpr -> AExpr
-sortExpr (APrim aid t op es) | isGate op = APrim aid t op (sort es)
+-- Under -stable-verilog the commutative-gate operand sort keys on the
+-- operand's text instead of Ord AExpr (intern order).
+sortExpr :: Bool -> AExpr -> AExpr
+sortExpr stable (APrim aid t op es) | isGate op = APrim aid t op (sortOp es)
   where isGate op = op `elem` [PrimBAnd, PrimBOr, PrimXor]
-sortExpr e = e
+        sortOp | stable    = sortBy (comparing ppString)
+               | otherwise = sort
+sortExpr _ e = e
 
 wireId :: Id -> Int -> Id
 wireId i n = mkIdPre (mkFString (synthPref ++ itos n ++ "_")) i

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -1,6 +1,7 @@
 module VIOProps (VIOProps, getIOProps, getIOPropsA) where
 
 import Data.List(intersect, nub, tails, sortBy)
+import Data.Ord(comparing)
 import Data.Maybe(catMaybes, isNothing, fromMaybe, isJust)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -295,6 +296,13 @@ getIOProps flags ppp@(ASPackage _ _ _ os is ios vs _ ds io_ds fs _ _ _) =
         defuseMap = getDefUses ds
 
         -- given a signal, this determines its props
+        -- under -stable-verilog, iterate a signal's users in text
+        -- order (Set order is Ord AId = interning order); the joined
+        -- prop list's order reaches the emitted Ports comment
+        userList uset | stableVerilog flags =
+                          sortBy (comparing getIdBaseString) (S.toList uset)
+                      | otherwise = S.toList uset
+
         getSignalInProp :: AId -> [VeriPortProp]
         getSignalInProp i =
             let
@@ -326,7 +334,7 @@ getIOProps flags ppp@(ASPackage _ _ _ os is ios vs _ ds io_ds fs _ _ _) =
                                       else if okUse i user_e
                                            then Just [user]
                                            else Nothing
-                                      | user <- S.toList user_set,
+                                      | user <- userList user_set,
                                         let user_e = adef_expr $ getDef user ]
                          in
                              -- if any are not direct uses,

--- a/src/comp/VIOProps.hs
+++ b/src/comp/VIOProps.hs
@@ -1699,8 +1699,11 @@ getIOPropsA _flags pps mschedinfo apkg =
                            [(AId, AUse)])
         mkArmClassMaps si =
             let multMap = M.fromList (concatMap genMethodMult vs)
+                -- blob ORDER never reaches this analysis's results
+                -- (arm classes are keyed maps/sets), so the
+                -- -stable-verilog canonical ordering is not needed here
                 (expr_blobs, action_blobs) =
-                    ratToBlobs (asi_method_uses_map si) multMap
+                    ratToBlobs False (asi_method_uses_map si) multMap
                                (asi_resource_alloc_table si)
                 edb = asi_exclusive_rules_db si
                 (ASchedule _ rev_exec_order) = asi_schedule si

--- a/src/comp/VStableRenumber.hs
+++ b/src/comp/VStableRenumber.hs
@@ -1,0 +1,139 @@
+module VStableRenumber(stableRenumberVProgram) where
+
+import Data.Char(isDigit)
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Generics(everywhere, mkT, listify)
+
+import Id(setIdBaseString)
+import Verilog
+
+-- Under -stable-verilog, renumber the compiler-generated name families
+--
+--     <stem>___dN   (backend def temporaries)
+--     <stem>__hN    (elaboration heap ids, minted into the .ba)
+--     <stem>__qN    (Verilog-quirks temporaries)
+--
+-- per module, by order of first occurrence in the emitted structure,
+-- so the numbers are a pure function of the module's contents rather
+-- than of mint order.  Mint order varies with compile history (the
+-- heap ids arrive in the .ba with their elaboration-time numbers, and
+-- the backend counters run in traversal order), so without this pass
+-- two compiles that agree on structure can still disagree on N.
+--
+-- Soundness:
+--  * Renaming is a per-module simultaneous substitution.  A target
+--    name <stem><marker><k> can only collide with another family
+--    member -- any name matching the pattern is itself in the map --
+--    and family members all move at once.  Targets that would collide
+--    with a non-renameable name (below) are skipped over.
+--  * Names in non-renameable positions are never collected and never
+--    produced as targets: the module's own name, everything in the
+--    port list, instantiated module names, instance names, and the
+--    formal port/parameter keys of instantiations (they belong to the
+--    child module).  If a family-shaped name also occurs in such a
+--    position (a user port named x__h5), the whole name is left
+--    untouched to avoid capture.
+--  * This runs before removeDollarsFromVerilog; generated family
+--    names never contain '$', so the passes are disjoint.
+
+stableRenumberVProgram :: VProgram -> VProgram
+stableRenumberVProgram (VProgram ms dpis cs) =
+    VProgram (map renumberModule ms) dpis cs
+
+data Family = FamD | FamH | FamQ
+    deriving (Eq, Ord)
+
+markerText :: Family -> String
+markerText FamD = "___d"
+markerText FamH = "__h"
+markerText FamQ = "__q"
+
+-- split a name into (stem, family, number-text) at the rightmost
+-- marker-followed-by-digits suffix
+matchFamily :: String -> Maybe (String, Family)
+matchFamily s =
+    let (rds, rrest) = span isDigit (reverse s)
+        rest = reverse rrest
+        try fam = let m = markerText fam
+                      lm = length m
+                      (pre, suf) = splitAt (length rest - lm) rest
+                  in  if suf == m && not (null pre)
+                      then Just (pre, fam)
+                      else Nothing
+    in  if null rds
+        then Nothing
+        else case [ r | Just r <- map try [FamD, FamH, FamQ] ] of
+               (r : _) -> Just r
+               []      -> Nothing
+
+renumberModule :: VModule -> VModule
+renumberModule vm =
+    let
+        isVId :: VId -> Bool
+        isVId _ = True
+
+        vidStr :: VId -> String
+        vidStr (VId s _ _) = s
+
+        -- names that must not change (or be created by renaming)
+        instFixed :: VMItem -> [String]
+        instFixed (VMInst m i pas pos) =
+            [vidStr m, vidStr i] ++
+            either (const []) (map (vidStr . fst)) pas ++
+            map (vidStr . fst) pos
+        instFixed (VMComment _ it)      = instFixed it
+        instFixed (VMRegGroup _ _ _ it) = instFixed it
+        instFixed (VMGroup _ itss)      = concatMap (concatMap instFixed) itss
+        instFixed _                     = []
+
+        excluded :: S.Set String
+        excluded = S.fromList (
+            vidStr (vm_name vm) :
+            [ s | VId s _ _ <- listify isVId (vm_ports vm) ] ++
+            concatMap instFixed (vm_body vm))
+
+        -- family members in order of first occurrence in the body
+        occurrences :: [String]
+        occurrences = [ s | VId s _ _ <- listify isVId (vm_body vm) ]
+
+        firstSeen :: S.Set String -> [String] -> [(String, String, Family)]
+        firstSeen _ [] = []
+        firstSeen seen (s : ss)
+            | s `S.member` seen
+            = firstSeen seen ss
+            | not (s `S.member` excluded),
+              Just (stem, fam) <- matchFamily s
+            = (s, stem, fam) : firstSeen (S.insert s seen) ss
+            | otherwise
+            = firstSeen (S.insert s seen) ss
+
+        members :: [(String, String, Family)]  -- (name, stem, family)
+        members = firstSeen S.empty occurrences
+
+        -- assign numbers per family in first-occurrence order,
+        -- skipping targets that collide with non-renameable names
+        assign :: M.Map Family Integer -> [(String, String, Family)]
+               -> [(String, String)]
+        assign _ [] = []
+        assign ks ((nm, stem, fam) : rest) =
+            let next n = let tgt = stem ++ markerText fam ++ show n
+                         in  if tgt `S.member` excluded
+                             then next (n + 1)
+                             else (n, tgt)
+                (k, target) = next (M.findWithDefault 1 fam ks)
+            in  (nm, target) : assign (M.insert fam (k + 1) ks) rest
+
+        renames :: M.Map String String
+        renames = M.fromList [ (nm, tgt) | (nm, tgt) <- assign M.empty members
+                                         , nm /= tgt ]
+
+        subst :: VId -> VId
+        subst v@(VId s i info) =
+            case M.lookup s renames of
+              Just s' -> VId s' (setIdBaseString i s') info
+              Nothing -> v
+    in
+        if M.null renames
+        then vm
+        else vm { vm_body = everywhere (mkT subst) (vm_body vm) }

--- a/src/comp/VStableRenumber.hs
+++ b/src/comp/VStableRenumber.hs
@@ -41,13 +41,23 @@ stableRenumberVProgram :: VProgram -> VProgram
 stableRenumberVProgram (VProgram ms dpis cs) =
     VProgram (map renumberModule ms) dpis cs
 
-data Family = FamD | FamH | FamQ
+data Family = FamD | FamH | FamQ | FamF | FamDM | FamDS
     deriving (Eq, Ord)
 
 markerText :: Family -> String
-markerText FamD = "___d"
-markerText FamH = "__h"
-markerText FamQ = "__q"
+markerText FamD  = "___d"
+markerText FamH  = "__h"
+markerText FamQ  = "__q"
+markerText FamF  = "__f"   -- ANoInline instance-connection wires
+markerText FamDM = "_dm"   -- AOpt-minted names (whole name, no stem)
+markerText FamDS = "_ds"   -- Synthesize-minted names (whole name, no stem)
+
+-- whether the family's names are the bare marker plus number
+-- (no stem before the marker)
+stemlessOK :: Family -> Bool
+stemlessOK FamDM = True
+stemlessOK FamDS = True
+stemlessOK _     = False
 
 -- split a name into (stem, family, number-text) at the rightmost
 -- marker-followed-by-digits suffix
@@ -58,12 +68,12 @@ matchFamily s =
         try fam = let m = markerText fam
                       lm = length m
                       (pre, suf) = splitAt (length rest - lm) rest
-                  in  if suf == m && not (null pre)
+                  in  if suf == m && (stemlessOK fam || not (null pre))
                       then Just (pre, fam)
                       else Nothing
     in  if null rds
         then Nothing
-        else case [ r | Just r <- map try [FamD, FamH, FamQ] ] of
+        else case [ r | Just r <- map try [FamD, FamH, FamQ, FamF, FamDM, FamDS] ] of
                (r : _) -> Just r
                []      -> Nothing
 
@@ -87,10 +97,31 @@ renumberModule vm =
         instFixed (VMGroup _ itss)      = concatMap (concatMap instFixed) itss
         instFixed _                     = []
 
+        -- foreign linkage names must never change: the function/task
+        -- names of foreign calls (DPI declarations live at file scope,
+        -- outside this module walk)
+        -- (a user's imported function may itself be family-shaped,
+        -- e.g. import \"BDPI\" f__h1)
+        isFctName :: VExpr -> [String]
+        isFctName (VEFctCall f _) = [vidStr f]
+        isFctName _               = []
+
+        foreignFixed :: [String]
+        foreignFixed =
+            concatMap isFctName (listify (\e -> case e of
+                                                  VEFctCall _ _ -> True
+                                                  _             -> False)
+                                         (vm_body vm)) ++
+            [ vidStr t | VTask t _ <- listify (\st -> case st of
+                                                        VTask _ _ -> True
+                                                        _         -> False)
+                                              (vm_body vm) ]
+
         excluded :: S.Set String
         excluded = S.fromList (
             vidStr (vm_name vm) :
             [ s | VId s _ _ <- listify isVId (vm_ports vm) ] ++
+            foreignFixed ++
             concatMap instFixed (vm_body vm))
 
         -- family members in order of first occurrence in the body

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -164,6 +164,7 @@ import LambdaCalc(convAPackageToLambdaCalc)
 import SAL(convAPackageToSAL)
 
 import VVerilogDollar
+import VStableRenumber(stableRenumberVProgram)
 import ISplitIf(iSplitIf)
 import VFileName
 
@@ -1215,9 +1216,13 @@ genModuleVerilog errh pprops flags dumpnames time0 prefix moduleName
 
        -- Remove dollar signs from Verilog identifiers
        start flags DFverilogDollar
+       -- Canonicalize generated-name numbering (-stable-verilog)
+       let vprog0' = if (stableVerilog flags)
+                     then stableRenumberVProgram vprog0
+                     else vprog0
        let vprog = if (removeVerilogDollar flags)
-                   then (removeDollarsFromVerilog vprog0)
-                   else vprog0
+                   then (removeDollarsFromVerilog vprog0')
+                   else vprog0'
        t <- dump errh flags t DFverilogDollar dumpnames vprog
 
        -- Write the Verilog files

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -134,5 +134,8 @@ Flags {
 	warnActionShadowing = True,
 	warnMethodUrgency = True,
 	warnUndetPred = False,
-	semanticPortsComment = False
+	semanticPortsComment = False,
+	semanticPortsComment = False,
+	checkOnly = False
+	stableVerilog = False
 }

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -135,7 +135,5 @@ Flags {
 	warnMethodUrgency = True,
 	warnUndetPred = False,
 	semanticPortsComment = False,
-	semanticPortsComment = False,
-	checkOnly = False
 	stableVerilog = False
 }

--- a/testsuite/bsc.verilog/stable_verilog/Makefile
+++ b/testsuite/bsc.verilog/stable_verilog/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.verilog/stable_verilog/StableDpiName.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableDpiName.bsv
@@ -1,0 +1,11 @@
+// exclusion guard: a family-shaped imported function name must not be
+// renumbered (the C linkage depends on it)
+import "BDPI" function Bit#(8) f__h1(Bit#(8) v);
+
+(* synthesize *)
+module sysStableDpiName();
+   Reg#(Bit#(8)) r <- mkReg(0);
+   rule tick;
+      r <= f__h1(r);
+   endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableMultiReset.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableMultiReset.bsv
@@ -1,0 +1,16 @@
+// R1 trigger: multiple reset domains -> per-reset always-block groups
+import Clocks::*;
+
+(* synthesize *)
+module sysStableMultiReset();
+   Clock clk <- exposeCurrentClock;
+   Reset rst <- exposeCurrentReset;
+   Reset r1 <- mkSyncReset(2, rst, clk);
+   Reset r2 <- mkAsyncReset(2, rst, clk);
+   Reg#(UInt#(8)) a <- mkReg(0);
+   Reg#(UInt#(8)) b <- mkReg(1, reset_by r1);
+   Reg#(UInt#(8)) c <- mkReg(2, reset_by r2);
+   rule ra; a <= a + 1; endrule
+   rule rb; b <= b + a; endrule
+   rule rc; c <= c + b; endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableNoInline.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableNoInline.bsv
@@ -1,0 +1,11 @@
+// __f family + noinline instance naming
+(* noinline *)
+function Bit#(16) nadd(Bit#(16) p, Bit#(16) q) = p + q + 3;
+
+(* synthesize *)
+module sysStableNoInline();
+   Reg#(Bit#(16)) a <- mkReg(0);
+   Reg#(Bit#(16)) b <- mkReg(1);
+   rule r1; a <= nadd(a, b); endrule
+   rule r2; b <= nadd(b, 16'd7); endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableOptIfMux.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableOptIfMux.bsv
@@ -1,0 +1,13 @@
+// _dm mint family via -opt-if-mux
+(* synthesize *)
+(* options = "-opt-if-mux" *)
+module sysStableOptIfMux();
+   Reg#(Bit#(8)) r <- mkReg(0);
+   Reg#(Bool) p <- mkReg(False);
+   Reg#(Bool) q <- mkReg(True);
+   Reg#(Bool) s <- mkReg(False);
+   rule tick;
+      r <= (p && q) ? r + 1 : (s ? r + 2 : r + 3);
+      p <= !q; q <= !s; s <= !p;
+   endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableOptionsPragma.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableOptionsPragma.bsv
@@ -1,0 +1,10 @@
+// regen must honor the module's recorded codegen flags (the .ba carries
+// the options pragma): regression for -c taking flags from the .ba
+(* synthesize *)
+(* options = "-keep-fires" *)
+module sysStableOptionsPragma();
+   Reg#(UInt#(8)) a <- mkReg(0);
+   Reg#(UInt#(8)) b <- mkReg(1);
+   rule r1 (a < 100); a <= a + b; endrule
+   rule r2 (b < 50); b <= b + 1; endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableResource.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableResource.bsv
@@ -1,0 +1,25 @@
+// -resource-simple: exercises simpleDropEdges' edge pick and colorFw's
+// vertex order.  RegFile sub has multiplicity 5; six independent rules
+// each read once, so all six can fire simultaneously and one inter-rule
+// edge must be dropped (arbitrated), then the remaining uses colored
+// onto the five ports.
+import RegFile::*;
+
+(* synthesize *)
+(* options = "-resource-simple" *)
+module sysStableResource();
+   RegFile#(Bit#(4), Bit#(8)) rf <- mkRegFile(0, 15);
+   Reg#(Bit#(4)) i <- mkReg(0);
+   Reg#(Bit#(8)) a <- mkReg(0);
+   Reg#(Bit#(8)) b <- mkReg(0);
+   Reg#(Bit#(8)) c <- mkReg(0);
+   Reg#(Bit#(8)) d <- mkReg(0);
+   Reg#(Bit#(8)) e <- mkReg(0);
+   Reg#(Bit#(8)) f <- mkReg(0);
+   rule r1; a <= rf.sub(i); endrule
+   rule r2; b <= rf.sub(i + 1); endrule
+   rule r3; c <= rf.sub(i + 2); endrule
+   rule r4; d <= rf.sub(i + 3); endrule
+   rule r5; e <= rf.sub(i + 4); endrule
+   rule r6; f <= rf.sub(i + 5); i <= i + 1; endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableTasks.bsv
+++ b/testsuite/bsc.verilog/stable_verilog/StableTasks.bsv
@@ -1,0 +1,15 @@
+// R2 trigger: system-task foreign blocks with shared def closures
+(* synthesize *)
+module sysStableTasks();
+   Reg#(UInt#(16)) x <- mkReg(0);
+   Reg#(UInt#(16)) y <- mkReg(1);
+   rule tick;
+      let s = x + y;
+      let p = x * y;
+      $display("s=%0d", s);
+      $display("p=%0d", p);
+      $write("x=%0d y=%0d", x, y);
+      x <= s; y <= p;
+      if (x > 100) $finish(0);
+   endrule
+endmodule

--- a/testsuite/bsc.verilog/stable_verilog/StableWide.bs
+++ b/testsuite/bsc.verilog/stable_verilog/StableWide.bs
@@ -1,0 +1,38 @@
+-- >16-uses fast path: one method with multiplicity 20, seventeen
+-- distinct-argument uses (RSchedule's length uses > 16 branch)
+package StableWide(sysStableWide) where
+
+interface VWide =
+    f :: Bit 8 -> Bit 8
+
+vMkWide :: Module VWide
+vMkWide =
+    module verilog "WideMod" "CLK" {
+        f[20] = "A" "R";
+    } [ f <> f ]
+
+{-# verilog sysStableWide #-}
+sysStableWide :: Module Empty
+sysStableWide =
+    module
+        w <- vMkWide
+        r :: Reg (Bit 8) <- mkReg 0
+        rules
+            "go": when True ==> do
+                r := w.f (r + 1) +
+                     w.f (r + 2) +
+                     w.f (r + 3) +
+                     w.f (r + 4) +
+                     w.f (r + 5) +
+                     w.f (r + 6) +
+                     w.f (r + 7) +
+                     w.f (r + 8) +
+                     w.f (r + 9) +
+                     w.f (r + 10) +
+                     w.f (r + 11) +
+                     w.f (r + 12) +
+                     w.f (r + 13) +
+                     w.f (r + 14) +
+                     w.f (r + 15) +
+                     w.f (r + 16) +
+                     w.f (r + 17)

--- a/testsuite/bsc.verilog/stable_verilog/stable_verilog.exp
+++ b/testsuite/bsc.verilog/stable_verilog/stable_verilog.exp
@@ -1,0 +1,67 @@
+#
+# -stable-verilog: deterministic Verilog emission.  Each design compiles
+# with the flag, the direct .v is stashed, and the module is regenerated
+# from its .ba with -c (which takes codegen-semantic flags -- including
+# -stable-verilog and any (* options *) pragma -- from the .ba itself);
+# the two .v files must be byte-identical.  The designs are the trigger
+# cases from the dormant-nondeterminism audit: reset-domain always-block
+# groups, foreign-block def order, noinline __f wires, options-pragma
+# regen, _dm mint names, -resource-simple edge drops and coloring, and
+# the >16-uses port-splay fast path.
+#
+
+proc sv_regen_identical { testname mod } {
+    global srcdir subdir
+    set here [absolute $srcdir]
+    cd [file join $here $subdir]
+    if { ![file exists "$mod.v"] } {
+        fail "$testname: no direct $mod.v"
+        cd $here
+        return
+    }
+    file rename -force "$mod.v" "$mod.v.direct"
+    set opts "-no-show-timestamps -no-show-version -verilog -c $mod"
+    if [ gen_basic_output $opts "$mod.regen-out" ] {
+        if { ![file exists "$mod.v"] } {
+            fail "$testname: regen produced no $mod.v"
+        } elseif { [catch {exec cmp -s "$mod.v.direct" "$mod.v"}] } {
+            fail "$testname: regenerated $mod.v differs from the direct compile"
+        } else {
+            pass "$testname"
+        }
+    } else {
+        fail "$testname: regen (-c) failed"
+    }
+    cd $here
+}
+
+compile_verilog_pass StableMultiReset.bsv {} {-stable-verilog}
+sv_regen_identical "multi-reset regen identical" sysStableMultiReset
+
+compile_verilog_pass StableTasks.bsv {} {-stable-verilog}
+sv_regen_identical "system-task foreign-block regen identical" sysStableTasks
+
+compile_verilog_pass StableNoInline.bsv {} {-stable-verilog}
+sv_regen_identical "noinline __f regen identical" sysStableNoInline
+sv_regen_identical "noinline function module regen identical" module_nadd
+
+compile_verilog_pass StableOptionsPragma.bsv {} {-stable-verilog}
+sv_regen_identical "options-pragma (-keep-fires) regen identical" sysStableOptionsPragma
+# the pragma's -keep-fires must reach BOTH sides: fires present in the regen
+find_regexp sysStableOptionsPragma.v {WILL_FIRE_RL_r1}
+
+compile_verilog_pass StableOptIfMux.bsv {} {-stable-verilog}
+sv_regen_identical "-opt-if-mux _dm regen identical" sysStableOptIfMux
+
+compile_verilog_pass StableResource.bsv {} {-stable-verilog}
+sv_regen_identical "-resource-simple regen identical" sysStableResource
+
+compile_verilog_pass StableWide.bs {} {-stable-verilog}
+sv_regen_identical ">16-uses port splay regen identical" sysStableWide
+
+# the family-shaped imported function name must survive un-renumbered
+# (C linkage); its uses must not be rewritten either
+compile_verilog_pass StableDpiName.bsv {} {-stable-verilog -use-dpi}
+find_regexp sysStableDpiName.v {f__h1}
+find_regexp_fail sysStableDpiName.v {f__h2}
+sv_regen_identical "BDPI name exclusion regen identical" sysStableDpiName


### PR DESCRIPTION
# `-stable-verilog`: deterministic Verilog emission (default off)

Fourth of the 5-PR series, stacked on the strictness PR. Four commits: flag plumbing → the four mechanisms → residue orderings → hardenings + trigger battery. The default **stays off** here; the flip (and the corpus-wide regen enforcement plus regolds) is the last PR of the stack.

## What

With the flag on, generated Verilog becomes a **pure function of the elaborated design**: the same module regenerates byte-identically — in particular from its `.ba` via `-c` — regardless of what else is compiled in the same invocation or of compile history. Interned-`Id` (`SpeedyString`) `Ord` varies with compile history; every backend choice that leaned on it now uses the identifier's *text*.

## Mechanisms (all gated; flag-off takes the historical paths)

1. **Topological-sort tie-breaks** (`tsortADefs`/`tsortDefs`): ready nodes pop in text order — precomputed strict `Int` ranks, no per-edge string keys.
2. **CSE survivor names** (`joinDefs`): the surviving name of each expression class is chosen by name quality + lexicographic tie-break — a pure function of the class, not traversal order. Enable defs can't *be* the survivor but are still rewritten as aliases (else duplicate noinline instances); NoCSE defs never merge in either direction (matching the fold as fixed below in this stack); strict representative map.
3. **Construction-order text sorts**: `AState.mkBlob` used ports, `AOpt.mergeIdenExpr` PrimMux arms (`isASAny` last), `Synthesize.sortExpr` gates.
4. **`VStableRenumber`**: minted name families (`___d`/`__h`/`__q`, plus `__f`/`_dm`/`_ds` from the audit) renumber into first-use order, capture-guarded; module/instance/port names, instantiation parameters, and foreign linkage names (a `"BDPI"`-imported `f__h1` must keep its C symbol) are excluded.

Plus the two residue orderings (InlineReg reset-domain always-block groups; foreign-block def order) and dormant-source hardenings from a pipeline-wide audit of every Map/Set iteration and sort in the Verilog backend (RSchedule port-splay/coloring/edge-drop, VIOProps users, InlineReg constant-key ties).

## Tests in this PR

`bsc.verilog/stable_verilog/`: 8 audit-trigger designs, each compiled with the flag and byte-compared against its own `-c` regen (multi-reset domains, system-task blocks, noinline `__f`, options-pragma regen, `_dm` mints, `-resource-simple`, >16-uses port splay, BDPI-name exclusion).

## Testing

This head builds and passes flag-off targeted dirs (battery, method_conditions, impcondof, perf-creg-blowup); a full flag-off gate on this head is running and will be posted. The series tip (flag flipped on, regen check corpus-wide) gates 23,871 PASS / 0 FAIL / 134 XFAIL / 0 XPASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
