### PR TITLE
sched: check at simulation that conflicting methods are not co-enabled

### DIFF
--- a/src/comp/AAddScheduleDefs.hs
+++ b/src/comp/AAddScheduleDefs.hs
@@ -6,15 +6,20 @@ import AScheduleInfo
 import AUses
 import Flags
 import Pragma
+import SchedInfo(SchedInfo(..), MethodConflictInfo(..))
+import ASchedule(errAction)
+import FStringCompat(mkFString)
 import ProofObligation(ProofObligation(..), ProofResult(..), MsgFn(..),
                        MsgTuple, warnUnlessProof, errorUnlessProof)
 import PFPrint
 import Error(ErrMsg(..))
 import ErrorUtil(internalError)
 import VModInfo(VModInfo(..), VFieldInfo(..), VeriPortProp(..), mkNamedEnable)
-import Id (Id, getIdString, isRdyId, dropReadyPrefixId,
-           mkIdWillFire, mkIdCanFire, mkRdyId)
+import Id (Id, getIdString, getIdBaseString, mkId, isRdyId, addIdProp,
+           IdProp(..),
+           dropReadyPrefixId, mkIdWillFire, mkIdCanFire, mkRdyId)
 import Position
+
 import BackendNamingConventions
 import PreIds(id_write)
 
@@ -150,6 +155,41 @@ aAddScheduleDefs flags pps pkg aschedinfo =
      let rules1 = map replaceRulePredicate rules0
          ifc2   = map replaceIfcRulePredicates ifc1
 
+     -- Interface method pairs the schedule marks as conflicting.  A parent
+     -- compiled by bsc can never enable both in one cycle -- the scheduler
+     -- enforces the annotation -- but an instantiator written directly in
+     -- Verilog has no such enforcement, and the module then misbehaves
+     -- silently: the muxes whose arm exclusivity the scheduler derived from
+     -- this very relationship stop being exclusive, with no diagnostic
+     -- anywhere.
+     --
+     -- Carried as an assumption on each method's own body rules, the way the
+     -- conflict-free assumptions already work, so the whole lowering path is
+     -- shared: aRemoveAssumps turns it into a predicated $error, and the
+     -- backends put that inside translate_off.  A method's rule firing
+     -- already implies its own enable, so the assumption only has to name the
+     -- other one.  One direction is enough: the lowered check is guarded by
+     -- the condition alone, not by the host rule firing, so it reports
+     -- whenever both enables are asserted.
+     let conflict_pairs =
+           [ (m1, m2)
+           | (m1, m2) <- sC (methodConflictInfo (asi_v_sched_info aschedinfo))
+           -- a method conflicts with itself, which says only that it cannot
+           -- be called twice in a cycle; one enable cannot assert twice
+           , m1 /= m2
+           ]
+         conflictAssumps m =
+           [ AAssumption e [errAction (conflictMsg m other)]
+           | (me, other) <- conflict_pairs
+           , me == m
+           , Just e <- [M.lookup other en_map]
+           ]
+         addConflictAssumps ifc =
+           case conflictAssumps (aif_name ifc) of
+             []      -> ifc
+             asmps   -> mapARules (addAsmps asmps) ifc
+         addAsmps asmps r = r { arule_assumps = arule_assumps r ++ asmps }
+
      -- return a modified APackage
      let cf_defs = user_cfs ++ ifc_cfs
          wf_defs = user_wfs ++ ifc_wfs
@@ -157,9 +197,16 @@ aAddScheduleDefs flags pps pkg aschedinfo =
 
      return pkg { apkg_local_defs        = defs1
                 , apkg_rules             = rules1
-                , apkg_interface         = ifc2
+                , apkg_interface         = map addConflictAssumps ifc2
                 , apkg_proof_obligations = proofs1
                 }
+
+conflictMsg :: Id -> Id -> String
+conflictMsg m1 m2 =
+    "Methods " ++ quote (getIdBaseString m1) ++ " and " ++
+    quote (getIdBaseString m2) ++ " conflict and may not be enabled in the " ++
+    "same clock cycle."
+  where quote x = "\"" ++ x ++ "\""
 
 -- Helper function for use with looking up list values
 ll :: (Eq a) => a -> [(a,[b])] -> [b]

--- a/testsuite/bsc.verilog/method_conflict_check/Makefile
+++ b/testsuite/bsc.verilog/method_conflict_check/Makefile
@@ -1,0 +1,5 @@
+# for "make clean" to work everywhere
+
+CONFDIR = $(realpath ../..)
+
+include $(CONFDIR)/clean.mk

--- a/testsuite/bsc.verilog/method_conflict_check/MethodConflict.bsv
+++ b/testsuite/bsc.verilog/method_conflict_check/MethodConflict.bsv
@@ -1,0 +1,18 @@
+// Two methods that conflict through a shared resource: both call the same
+// FIFO's enq, and enq conflicts with itself, so the schedule marks a C b.
+//
+// Note two methods writing the same register would NOT conflict -- bsc
+// sequences those SB and warns about shadowing instead.
+import FIFO::*;
+
+interface MethodConflict;
+   method Action a;
+   method Action b;
+endinterface
+
+(* synthesize *)
+module mkMethodConflict (MethodConflict);
+   FIFO#(Bit#(8)) f <- mkFIFO;
+   method Action a; f.enq(1); endmethod
+   method Action b; f.enq(2); endmethod
+endmodule

--- a/testsuite/bsc.verilog/method_conflict_check/NoConflict.bsv
+++ b/testsuite/bsc.verilog/method_conflict_check/NoConflict.bsv
@@ -1,0 +1,16 @@
+// The same shape without a conflict: each method has its own FIFO, so
+// nothing is shared and no check should be emitted.
+import FIFO::*;
+
+interface NoConflict;
+   method Action a;
+   method Action b;
+endinterface
+
+(* synthesize *)
+module mkNoConflict (NoConflict);
+   FIFO#(Bit#(8)) f <- mkFIFO;
+   FIFO#(Bit#(8)) g <- mkFIFO;
+   method Action a; f.enq(1); endmethod
+   method Action b; g.enq(2); endmethod
+endmodule

--- a/testsuite/bsc.verilog/method_conflict_check/method_conflict_check.exp
+++ b/testsuite/bsc.verilog/method_conflict_check/method_conflict_check.exp
@@ -1,0 +1,39 @@
+#
+# A simulation check that two conflicting interface methods are never
+# enabled in the same cycle.
+#
+# A parent compiled by bsc cannot violate this -- the scheduler enforces the
+# annotation -- so the check exists for instantiators written directly in
+# Verilog, which nothing polices.  Without it the failure surfaces only as a
+# downstream complaint that does not name the cause (for these modules,
+# "Enqueuing to a full fifo").
+#
+
+# ----------
+# Two methods that conflict through a shared FIFO's enq: the check is
+# emitted, guarded by both enables, and only once -- the pair is reported
+# in one direction, not both.
+
+compile_verilog_pass MethodConflict.bsv mkMethodConflict
+
+find_n_strings mkMethodConflict.v {EN_a && EN_b} 1
+
+find_regexp mkMethodConflict.v \
+    {conflict and may not be enabled in the same clock cycle}
+
+# The check must be invisible to synthesis
+
+find_regexp mkMethodConflict.v {synopsys translate_off}
+
+# ----------
+# The same shape with no shared resource: nothing conflicts, so no check
+
+compile_verilog_pass NoConflict.bsv mkNoConflict
+
+find_regexp_fail mkNoConflict.v \
+    {conflict and may not be enabled in the same clock cycle}
+
+# ----------
+# The task itself is $display or $error depending on -system-verilog-output;
+# that is buildVerilogTask's existing desugaring for older simulators and is
+# not tested here.


### PR DESCRIPTION
II-7 of the integration series (upstream issue #1067), carved standalone onto `upstream-main`.

When two interface methods have schedule relationship C, a bsc-compiled parent can never enable both in one cycle — the scheduler enforces the annotation. An instantiator written directly in Verilog has no such enforcement, and the module then misbehaves silently: the muxes whose arm-exclusivity the scheduler derived from that relationship stop being exclusive, and the user sees a downstream symptom that does not name the cause ("Enqueuing to a full fifo").

Emit the same kind of dynamic check bsc already emits for user scheduling assumptions: an `AAssumption` on the method's body rules, lowered by the existing `aRemoveAssumps` path to a predicated `$error` inside `translate_off` with clock edge and reset guard. Built in `aAddScheduleDefs`, the one place holding both the schedule and the methods' enable expressions. One direction per pair suffices (a method's firing implies its own enable); self-pairs are dropped.

Carve note: the release-tree cut imported `DefProp`, a module that only exists on the matx line (factored out of `Pragma` there); the import was vestigial and is dropped — the commit builds standalone on `upstream-main`.

Testing: full `fullparallel` gate on this head: **20,286 PASS / 0 FAIL / 134 XFAIL / 0 XPASS, exit 0** — no existing golden churn; the new `bsc.verilog/method_conflict_check` tests (positive + negative) pass 6/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt