### PR TITLE
IType: cache free type variables on interned nodes; prune tSubst (on interning)

### DIFF
--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -500,6 +500,7 @@ traceflags = [
           "hack-disable-urgency-warnings",
           "hack-gate-clock-inputs",
           "hack-gate-default-clock",
+          "hack-no-itype-ftv-cache",
           "hack-strict-inst-tree",
           "outlaw-sv-kws-as-classic-ids",
           "show-qualifiers",

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -40,6 +40,7 @@ module ISyntax(
         fTVars,
         VarSet, fTVarSet,
         vsEmpty, vsSingleton, vsUnion, vsInsert, vsDelete, vsMember, vsNull,
+        ftvCacheEnabled,
         itArrow,
         iToCT,
         iToCK,

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -38,6 +38,8 @@ module ISyntax(
         splitITAp,
         aTVars,
         fTVars,
+        VarSet, fTVarSet,
+        vsEmpty, vsSingleton, vsUnion, vsInsert, vsDelete, vsMember, vsNull,
         itArrow,
         iToCT,
         iToCK,
@@ -413,13 +415,8 @@ aTVars (ITCon _ _ _) = S.empty
 aTVars (ITNum _) = S.empty
 aTVars (ITStr _) = S.empty
 
-fTVars :: IType -> S.Set Id
-fTVars (ITForAll i _ t) = S.delete i (fTVars t)
-fTVars (ITAp f a) = fTVars f `S.union` fTVars a
-fTVars (ITVar i) = S.singleton i
-fTVars (ITCon _ _ _) = S.empty
-fTVars (ITNum _) = S.empty
-fTVars (ITStr _) = S.empty
+-- fTVars now lives in IType (answered from the free-variable sets
+-- cached on interned nodes) and is re-exported here.
 
 
 splitITAp :: IType -> (IType, [IType])

--- a/src/comp/ISyntaxSubst.hs
+++ b/src/comp/ISyntaxSubst.hs
@@ -65,6 +65,11 @@ class SubstContext ctx v | ctx -> v where
   ctxRemove :: Id -> ctx -> SomeCtx v
   ctxAdd :: Id -> v -> ctx -> BatchCtx v
   ctxNorm :: ctx -> v -> Changed v
+  -- True if no variable in the given free-variable set is in the
+  -- substitution domain, i.e. substituting under a tree with these
+  -- free variables cannot change it.  Only type contexts answer
+  -- precisely; expression contexts conservatively say False.
+  ctxAvoids :: VarSet -> ctx -> Bool
 
 -- Constraint synonyms for clarity
 type ExprSubstCtx ctx a = SubstContext ctx (IExpr a)
@@ -83,6 +88,7 @@ instance SubstContext (EmptyExpr a) (IExpr a) where
   ctxRemove _ _ = SomeCtx (EmptyExpr :: EmptyExpr a)
   ctxAdd _ _ _ = error "ctxAdd on EmptyExpr: impossible (no free vars to cause alpha-conversion)"
   ctxNorm _ _ = Unchanged
+  ctxAvoids _ _ = True
 
 -- Single substitution (size 1) - uses direct equality, no Map
 data SingleExpr a = SingleExpr !Id !(IExpr a) !(S.Set Id)
@@ -96,6 +102,7 @@ instance SubstContext (SingleExpr a) (IExpr a) where
   ctxAdd i' x' (SingleExpr i x fvs) =
     BatchExpr (M.fromList [(i,x), (i',x')]) (fvs `S.union` fVars x')
   ctxNorm _ _ = Unchanged
+  ctxAvoids _ _ = False
 
 -- Batch substitution (size >= 2) - uses Map
 data BatchExpr a = BatchExpr !(M.Map Id (IExpr a)) !(S.Set Id)
@@ -114,6 +121,7 @@ instance SubstContext (BatchExpr a) (IExpr a) where
   ctxAdd i x (BatchExpr m fvs) =
     BatchExpr (M.insert i x m) (fvs `S.union` fVars x)
   ctxNorm _ _ = Unchanged
+  ctxAvoids _ _ = False
 
 -- ============================================================
 -- Type substitution contexts
@@ -128,40 +136,43 @@ instance SubstContext EmptyType IType where
   ctxRemove _ _ = SomeCtx EmptyType
   ctxAdd _ _ _ = error "ctxAdd on EmptyType: impossible (no free vars to cause alpha-conversion)"
   ctxNorm _ _ = Unchanged
+  ctxAvoids _ _ = True
 
 -- Single type substitution
-data SingleType = SingleType !Id !IType !(S.Set Id)
+data SingleType = SingleType !Id !IType !VarSet
 
 instance SubstContext SingleType IType where
   lookupVar i' (SingleType i t _) = if i == i' then Just t else Nothing
   ctxIsEmpty _ = False
-  ctxContainsVar i' (SingleType _ _ fvs) = i' `S.member` fvs
+  ctxContainsVar i' (SingleType _ _ fvs) = i' `vsMember` fvs
   ctxRemove i' s@(SingleType i _ _) =
     if i == i' then SomeCtx EmptyType else SomeCtx s
   ctxAdd i' t' (SingleType i t fvs) =
-    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `S.union` fTVars t') (\ _ -> Unchanged)
+    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t') (\ _ -> Unchanged)
   ctxNorm _ _ = Unchanged
+  ctxAvoids fvs (SingleType i _ _) = not (i `vsMember` fvs)
 
 -- Single type substitution with normalization
-data SingleTypeNorm = SingleTypeNorm !Id !IType !(S.Set Id) !(IType -> Changed IType)
+data SingleTypeNorm = SingleTypeNorm !Id !IType !VarSet !(IType -> Changed IType)
 
 instance SubstContext SingleTypeNorm IType where
   lookupVar i' (SingleTypeNorm i t _ _) = if i == i' then Just t else Nothing
   ctxIsEmpty _ = False
-  ctxContainsVar i' (SingleTypeNorm _ _ fvs _) = i' `S.member` fvs
+  ctxContainsVar i' (SingleTypeNorm _ _ fvs _) = i' `vsMember` fvs
   ctxRemove i' s@(SingleTypeNorm i _ _ _) =
     if i == i' then SomeCtx EmptyType else SomeCtx s
   ctxAdd i' t' (SingleTypeNorm i t fvs norm) =
-    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `S.union` fTVars t') norm
+    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t') norm
   ctxNorm (SingleTypeNorm _ _ _ norm) = norm
+  ctxAvoids fvs (SingleTypeNorm i _ _ _) = not (i `vsMember` fvs)
 
 -- Batch type substitution
-data BatchType = BatchType !(M.Map Id IType) !(S.Set Id)
+data BatchType = BatchType !(M.Map Id IType) !VarSet
 
 instance SubstContext BatchType IType where
   lookupVar i (BatchType m _) = M.lookup i m
   ctxIsEmpty _ = False
-  ctxContainsVar i (BatchType _ fvs) = i `S.member` fvs
+  ctxContainsVar i (BatchType _ fvs) = i `vsMember` fvs
   ctxRemove i (BatchType m fvs) =
     let m' = M.delete i m
     in case M.size m' of
@@ -170,16 +181,17 @@ instance SubstContext BatchType IType where
               in SomeCtx $ SingleType j t fvs
          _ -> SomeCtx $ BatchType m' fvs
   ctxAdd i t (BatchType m fvs) =
-    BatchTypeNorm (M.insert i t m) (fvs `S.union` fTVars t) (\ _ -> Unchanged)
+    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t) (\ _ -> Unchanged)
   ctxNorm _ _ = Unchanged
+  ctxAvoids fvs (BatchType m _) = not (any (`vsMember` fvs) (M.keys m))
 
 -- Batch type substitution with normalization
-data BatchTypeNorm = BatchTypeNorm !(M.Map Id IType) !(S.Set Id) !(IType -> Changed IType)
+data BatchTypeNorm = BatchTypeNorm !(M.Map Id IType) !VarSet !(IType -> Changed IType)
 
 instance SubstContext BatchTypeNorm IType where
   lookupVar i (BatchTypeNorm m _ _) = M.lookup i m
   ctxIsEmpty _ = False
-  ctxContainsVar i (BatchTypeNorm _ fvs _) = i `S.member` fvs
+  ctxContainsVar i (BatchTypeNorm _ fvs _) = i `vsMember` fvs
   ctxRemove i (BatchTypeNorm m fvs norm) =
     let m' = M.delete i m
     in case M.size m' of
@@ -188,8 +200,9 @@ instance SubstContext BatchTypeNorm IType where
               in SomeCtx $ SingleTypeNorm j t fvs norm
          _ -> SomeCtx $ BatchTypeNorm m' fvs norm
   ctxAdd i t (BatchTypeNorm m fvs norm) =
-    BatchTypeNorm (M.insert i t m) (fvs `S.union` fTVars t) norm
+    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t) norm
   ctxNorm (BatchTypeNorm _ _ norm) = norm
+  ctxAvoids fvs (BatchTypeNorm m _ _) = not (any (`vsMember` fvs) (M.keys m))
 
 -- ============================================================
 -- Type substitution
@@ -206,6 +219,16 @@ tSubstWith tctx allIds t
     -- sub needs to be polymorphic because the context type can change at
     -- ctxAdd (to batch) or ctxRemove (to single or empty)
     sub :: TypeSubstCtx tctx' => tctx' -> S.Set Id -> IType -> Changed IType
+    -- Pruning: if a subtree's cached free variables are disjoint from
+    -- the substitution domain, nothing under it can change; skip it.
+    -- The ITForAll case must ALSO check ctxContainsVar: when the
+    -- binder collides with the free variables of the substitution
+    -- payloads, the original code alpha-converts (renaming the binder)
+    -- even when the body contains no domain variable, and that rename
+    -- is observable.  Falling through preserves it exactly.
+    sub tctx allIds tt@(ITForAll i k t)
+      | ctxAvoids (fTVarSet tt) tctx, not (ctxContainsVar i tctx) =
+          Unchanged
     sub tctx allIds tt@(ITForAll i k t) =
       case lookupVar i tctx of
         Just _ ->
@@ -224,8 +247,10 @@ tSubstWith tctx allIds t
             in Changed $ ITForAll i' k $ changedOr t (sub tctx' allIds' t)
           else -- No conflict: continue with same context
             changed1 (ITForAll i k) (sub tctx allIds t)
-    sub tctx allIds tt@(ITAp f a) =
-      changed2 ITAp f a (sub tctx allIds f) (sub tctx allIds a)
+    sub tctx allIds tt@(ITAp f a)
+      | ctxAvoids (fTVarSet tt) tctx = Unchanged
+      | otherwise =
+          changed2 ITAp f a (sub tctx allIds f) (sub tctx allIds a)
     sub tctx _      tt@(ITVar i) = maybe Unchanged Changed (lookupVar i tctx)
     sub _    _      tt@(ITCon _ _ _) = Unchanged
     sub _    _      tt@(ITNum _) = Unchanged
@@ -234,7 +259,7 @@ tSubstWith tctx allIds t
 -- Public API: single type substitution
 {-# INLINE tSubst #-}
 tSubst :: Id -> IType -> IType -> IType
-tSubst i t ty = changedOr ty (tSubstWith (SingleType i t (fTVars t)) (fTVars t `S.union` aTVars ty) ty)
+tSubst i t ty = changedOr ty (tSubstWith (SingleType i t (fTVarSet t)) (fTVars t `S.union` aTVars ty) ty)
 
 -- Public API: batch type substitution
 {-# INLINE tSubstBatch #-}
@@ -245,9 +270,9 @@ tSubstBatch typeMap t
       let (i, ty) = M.findMin typeMap
       in tSubst i ty t
   | otherwise =
-      let ftx = S.unions $ M.elems $ M.map fTVars typeMap
-          tctx = BatchType typeMap ftx
-          allIds = ftx `S.union` aTVars t
+      let ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
+          tctx = BatchType typeMap ftxv
+          allIds = S.unions (map fTVars (M.elems typeMap)) `S.union` aTVars t
       in changedOr t (tSubstWith tctx allIds t)
 
 -- ============================================================
@@ -413,9 +438,8 @@ etSubst :: forall a. Id -> IType -> IExpr a -> IExpr a
 etSubst i t e
     | Changed e' <- result = e'
     | otherwise = e
-  where ftx = fTVars t
-        allIds = ftx `S.union` aVars e
-        result = eSubstWith (EmptyExpr :: EmptyExpr a) (SingleType i t ftx) allIds e
+  where allIds = fTVars t `S.union` aVars e
+        result = eSubstWith (EmptyExpr :: EmptyExpr a) (SingleType i t (fTVarSet t)) allIds e
 
 -- Public API: batch expression and type substitution, with normalization
 {-# INLINE eSubstBatch #-}
@@ -429,31 +453,31 @@ eSubstBatch norm exprMap typeMap e
     typeSize = M.size typeMap
     result = case (exprSize, typeSize) of
           (0, 1) -> let (i, t) = M.findMin typeMap
-                        ftx = fTVars t
-                    in eSubstWith (EmptyExpr :: EmptyExpr a) (SingleTypeNorm i t ftx norm) (ftx `S.union` aVars e) e
-          (0, _) -> let ftx = S.unions $ M.elems $ M.map fTVars typeMap
-                    in eSubstWith (EmptyExpr :: EmptyExpr a) (BatchTypeNorm typeMap ftx norm) (ftx `S.union` aVars e) e
+                    in eSubstWith (EmptyExpr :: EmptyExpr a) (SingleTypeNorm i t (fTVarSet t) norm) (fTVars t `S.union` aVars e) e
+          (0, _) -> let ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
+                        ftx = S.unions (map fTVars (M.elems typeMap))
+                    in eSubstWith (EmptyExpr :: EmptyExpr a) (BatchTypeNorm typeMap ftxv norm) (ftx `S.union` aVars e) e
           (1, 0) -> let (i, x) = M.findMin exprMap
                         fvx = fVars x
                     in eSubstWith (SingleExpr i x fvx) EmptyType (fvx `S.union` aVars e) e
           (1, 1) -> let (ei, ex) = M.findMin exprMap
                         (ti, tt) = M.findMin typeMap
                         fvx = fVars ex
-                        ftx = fTVars tt
-                    in eSubstWith (SingleExpr ei ex fvx) (SingleTypeNorm ti tt ftx norm) (fvx `S.union` ftx `S.union` aVars e) e
+                    in eSubstWith (SingleExpr ei ex fvx) (SingleTypeNorm ti tt (fTVarSet tt) norm) (fvx `S.union` fTVars tt `S.union` aVars e) e
           (1, _) -> let (ei, ex) = M.findMin exprMap
                         fvx = fVars ex
-                        ftx = S.unions $ M.elems $ M.map fTVars typeMap
-                    in eSubstWith (SingleExpr ei ex fvx) (BatchTypeNorm typeMap ftx norm) (fvx `S.union` ftx `S.union` aVars e) e
+                        ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
+                        ftx = S.unions (map fTVars (M.elems typeMap))
+                    in eSubstWith (SingleExpr ei ex fvx) (BatchTypeNorm typeMap ftxv norm) (fvx `S.union` ftx `S.union` aVars e) e
           (_, 0) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
                     in eSubstWith (BatchExpr exprMap fvx) EmptyType (fvx `S.union` aVars e) e
           (_, 1) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
                         (ti, tt) = M.findMin typeMap
-                        ftx = fTVars tt
-                    in eSubstWith (BatchExpr exprMap fvx) (SingleTypeNorm ti tt ftx norm) (fvx `S.union` ftx `S.union` aVars e) e
+                    in eSubstWith (BatchExpr exprMap fvx) (SingleTypeNorm ti tt (fTVarSet tt) norm) (fvx `S.union` fTVars tt `S.union` aVars e) e
           (_, _) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
-                        ftx = S.unions $ M.elems $ M.map fTVars typeMap
-                    in eSubstWith (BatchExpr exprMap fvx) (BatchTypeNorm typeMap ftx norm) (fvx `S.union` ftx `S.union` aVars e) e
+                        ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
+                        ftx = S.unions (map fTVars (M.elems typeMap))
+                    in eSubstWith (BatchExpr exprMap fvx) (BatchTypeNorm typeMap ftxv norm) (fvx `S.union` ftx `S.union` aVars e) e
 
 {-# INLINE mapChanged #-}
 mapChanged :: (a -> Changed a) -> [a] -> Changed [a]

--- a/src/comp/ISyntaxSubst.hs
+++ b/src/comp/ISyntaxSubst.hs
@@ -226,8 +226,12 @@ tSubstWith tctx allIds t
     -- payloads, the original code alpha-converts (renaming the binder)
     -- even when the body contains no domain variable, and that rename
     -- is observable.  Falling through preserves it exactly.
+    -- The pruning guards are gated on the flag itself, never on the
+    -- cached sets: with the cache disabled the fields hold dummy empty
+    -- sets, which would otherwise prune everything.
     sub tctx allIds tt@(ITForAll i k t)
-      | ctxAvoids (fTVarSet tt) tctx, not (ctxContainsVar i tctx) =
+      | ftvCacheEnabled, ctxAvoids (fTVarSet tt) tctx,
+        not (ctxContainsVar i tctx) =
           Unchanged
     sub tctx allIds tt@(ITForAll i k t) =
       case lookupVar i tctx of
@@ -248,7 +252,7 @@ tSubstWith tctx allIds t
           else -- No conflict: continue with same context
             changed1 (ITForAll i k) (sub tctx allIds t)
     sub tctx allIds tt@(ITAp f a)
-      | ctxAvoids (fTVarSet tt) tctx = Unchanged
+      | ftvCacheEnabled, ctxAvoids (fTVarSet tt) tctx = Unchanged
       | otherwise =
           changed2 ITAp f a (sub tctx allIds f) (sub tctx allIds a)
     sub tctx _      tt@(ITVar i) = maybe Unchanged Changed (lookupVar i tctx)

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -11,6 +11,7 @@ module IType(
   ,VarSet
   ,fTVarSet
   ,vsEmpty, vsSingleton, vsUnion, vsInsert, vsDelete, vsMember, vsNull
+  ,ftvCacheEnabled
   ,iToCT
   ,iToCK
    )
@@ -27,6 +28,7 @@ import Data.Maybe(isJust, fromJust)
 import System.IO.Unsafe(unsafePerformIO)
 
 import ErrorUtil(internalError)
+import IOUtil(progArgs)
 import Id(Id, getIdBase, getIdQual, setIdPosition, setIdProps, setIdQual)
 import PreIds(idArrow, idId, idTNumToStr)
 import TypeOps(opNumT, opStrT)
@@ -139,15 +141,23 @@ vsMember = S.member
 vsNull :: VarSet -> Bool
 vsNull = S.null
 
--- The cached free-variable set: interior nodes answer from their
--- field, leaves directly.
+-- The free-variable set used by the substitution machinery: interior
+-- nodes answer from their cached field, leaves directly.  When the
+-- cache is disabled (-hack-no-itype-ftv-cache, see below) the fields
+-- hold a shared dummy empty set, so this walks instead; consumers
+-- that need correct sets (context free-variable bookkeeping) must go
+-- through this function and never read the field directly.
 fTVarSet :: IType -> VarSet
-fTVarSet (ITForAll_ _ fvs _ _ _) = fvs
-fTVarSet (ITAp_ _ fvs _ _) = fvs
-fTVarSet (ITVar i) = vsSingleton i
-fTVarSet (ITCon _ _ _) = vsEmpty
-fTVarSet (ITNum _) = vsEmpty
-fTVarSet (ITStr _) = vsEmpty
+fTVarSet t0 | ftvCacheEnabled = cached t0
+            | otherwise       = walk t0
+  where cached (ITForAll_ _ fvs _ _ _) = fvs
+        cached (ITAp_ _ fvs _ _) = fvs
+        cached l = leaf l
+        walk (ITForAll_ _ _ i _ b) = vsDelete i (walk b)
+        walk (ITAp_ _ _ f a) = walk f `vsUnion` walk a
+        walk l = leaf l
+        leaf (ITVar i) = vsSingleton i
+        leaf _ = vsEmpty
 
 -- Free type variables as a Set Id (the historical interface).
 fTVars :: IType -> S.Set Id
@@ -337,6 +347,21 @@ data InternTable = InternTable !(M.Map NodeKey IType) {-# UNPACK #-} !Int
 internTable :: IORef InternTable
 internTable = unsafePerformIO $ newIORef (InternTable M.empty 0)
 
+-- The hidden flag -hack-no-itype-ftv-cache (registered with the
+-- other progArgs-queried flags in FlagsDecode.traceflags, so the
+-- command-line parser accepts it; BSC_OPTIONS reaches progArgs too)
+-- disables the free-variable cache and the tSubst pruning that
+-- consumes it: interned nodes store one shared empty set in the
+-- metadata field and the substitution machinery takes the exact
+-- pre-cache code paths (full free-variable walks, original
+-- alpha-conversion behavior).  Absent the flag they are enabled (the
+-- default).  The switch lets the optimization be measured A/B on any
+-- workload with a single binary, and doubles as a diagnostic chicken
+-- switch.
+{-# NOINLINE ftvCacheEnabled #-}
+ftvCacheEnabled :: Bool
+ftvCacheEnabled = not ("-hack-no-itype-ftv-cache" `elem` progArgs)
+
 {-# NOINLINE internAp #-}
 internAp :: IType -> IType -> IType
 internAp f a = unsafePerformIO $ do
@@ -349,7 +374,9 @@ internAp f a = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t  -> (st, t)
-          Nothing -> let t = ITAp_ n (fTVarSet f `vsUnion` fTVarSet a) f a
+          Nothing -> let fvs | ftvCacheEnabled = fTVarSet f `vsUnion` fTVarSet a
+                             | otherwise       = vsEmpty
+                         t = ITAp_ n fvs f a
                      in  (InternTable (M.insert key t m) (n+1), t)
 
 {-# NOINLINE mkITForAll #-}
@@ -366,7 +393,9 @@ mkITForAll i k t = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t' -> (st, t')
-          Nothing -> let t' = ITForAll_ n (vsDelete ti (fTVarSet t)) ti k t
+          Nothing -> let fvs | ftvCacheEnabled = vsDelete ti (fTVarSet t)
+                             | otherwise       = vsEmpty
+                         t' = ITForAll_ n fvs ti k t
                      in  (InternTable (M.insert key t' m) (n+1), t')
 
 -- The smart constructor behind the ITAp pattern synonym.  It first

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -123,6 +123,49 @@ type VarSet = S.Set Id
 vsEmpty :: VarSet
 vsEmpty = S.empty
 
+-- Canonicalization table for the free-variable sets stored on
+-- interned nodes.  The node table is immortal, so it amplifies every
+-- duplicate set: canonicalizing by content keeps one copy of each
+-- distinct set (thousands of tiny sets like {e,m} otherwise pile up,
+-- one per polymorphic node).  Same global-table posture as the node
+-- intern table; keyed by the set itself (Set's Ord is by content).
+-- Id's Ord (base name, then qualifier; positions and props ignored)
+-- is the right granularity for that key: the sets never serialize,
+-- and their consumers -- membership checks and alpha-conversion
+-- avoid-lists (cloneId reads only base FStrings) -- never look at
+-- the Id positions or props.
+{-# NOINLINE vsCanonTable #-}
+vsCanonTable :: IORef (M.Map VarSet VarSet)
+vsCanonTable = unsafePerformIO $ newIORef M.empty
+
+{-# NOINLINE vsCanon #-}
+vsCanon :: VarSet -> VarSet
+vsCanon x = unsafePerformIO $ do
+    m0 <- readIORef vsCanonTable
+    case M.lookup x m0 of
+      Just c  -> return c
+      Nothing -> atomicModifyIORef' vsCanonTable go
+  where go m = case M.lookup x m of
+                 Just c  -> (m, c)
+                 Nothing -> (M.insert x x m, x)
+
+-- Union and delete for sets about to be STORED on an interned node:
+-- the arms that can only return an existing set (empty sides, absent
+-- element) stay lookup-free -- those are the hot ground-type paths and
+-- already yield canonical objects -- and only freshly built sets are
+-- canonicalized.
+vsUnionCanon :: VarSet -> VarSet -> VarSet
+vsUnionCanon a b
+    | S.null a = b
+    | S.null b = a
+    | otherwise = vsCanon (S.union a b)
+
+vsDeleteCanon :: Id -> VarSet -> VarSet
+vsDeleteCanon i vs
+    | not (S.member i vs) = vs
+    | otherwise = let vs' = S.delete i vs
+                  in  if S.null vs' then vsEmpty else vsCanon vs'
+
 vsSingleton :: Id -> VarSet
 vsSingleton = S.singleton
 
@@ -374,7 +417,7 @@ internAp f a = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t  -> (st, t)
-          Nothing -> let fvs | ftvCacheEnabled = fTVarSet f `vsUnion` fTVarSet a
+          Nothing -> let fvs | ftvCacheEnabled = fTVarSet f `vsUnionCanon` fTVarSet a
                              | otherwise       = vsEmpty
                          t = ITAp_ n fvs f a
                      in  (InternTable (M.insert key t m) (n+1), t)
@@ -393,7 +436,7 @@ mkITForAll i k t = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t' -> (st, t')
-          Nothing -> let fvs | ftvCacheEnabled = vsDelete ti (fTVarSet t)
+          Nothing -> let fvs | ftvCacheEnabled = vsDeleteCanon ti (fTVarSet t)
                              | otherwise       = vsEmpty
                          t' = ITForAll_ n fvs ti k t
                      in  (InternTable (M.insert key t' m) (n+1), t')

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -7,6 +7,10 @@ module IType(
   ,itArrow
   ,mkNumConT
   ,iTypeNodeId
+  ,fTVars
+  ,VarSet
+  ,fTVarSet
+  ,vsEmpty, vsSingleton, vsUnion, vsInsert, vsDelete, vsMember, vsNull
   ,iToCT
   ,iToCK
    )
@@ -17,6 +21,7 @@ import Prelude hiding ((<>))
 #endif
 
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
 import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
 import Data.Maybe(isJust, fromJust)
 import System.IO.Unsafe(unsafePerformIO)
@@ -65,20 +70,29 @@ data IKind
 -- The uniques are arrival-order identifiers.  They must never influence
 -- anything observable (ordering, printing, serialization); they may
 -- only be used for pointer-style equality (same unique => same node).
+--
+-- Interior nodes also cache their free type variables (a VarSet) in a
+-- strict field computed at construction.  Since the intern table is
+-- immortal, a lazy field would be a permanent thunk; the eager cost
+-- is near zero because set union and delete return an existing set by
+-- pointer when one side is empty or the element is absent, and ground
+-- types all share the one vsEmpty.  The field is metadata only: it
+-- never serializes, never prints, and never participates in
+-- comparison or intern keys.
 data IType
-        = ITForAll_ {-# UNPACK #-} !Int !Id !IKind IType
-        | ITAp_ {-# UNPACK #-} !Int IType IType
+        = ITForAll_ {-# UNPACK #-} !Int !VarSet !Id !IKind IType
+        | ITAp_ {-# UNPACK #-} !Int !VarSet IType IType
         | ITVar_ !Id
         | ITCon_ !Id !IKind !TISort
         | ITNum !Integer
         | ITStr !FString
 
 pattern ITForAll :: Id -> IKind -> IType -> IType
-pattern ITForAll i k t <- ITForAll_ _ i k t
+pattern ITForAll i k t <- ITForAll_ _ _ i k t
   where ITForAll i k t = mkITForAll i k t
 
 pattern ITAp :: IType -> IType -> IType
-pattern ITAp f a <- ITAp_ _ f a
+pattern ITAp f a <- ITAp_ _ _ f a
   where ITAp f a = mkITAp f a
 
 -- The Id-carrying leaves are sealed the same way: construction goes
@@ -97,6 +111,49 @@ pattern ITCon i k s <- ITCon_ i k s
 {-# COMPLETE ITForAll, ITAp, ITVar, ITCon, ITNum, ITStr #-}
 
 -- --------------------------------
+-- Free type variable sets
+
+-- The set representation used for the cached free-variable metadata
+-- and for substitution-domain checks.  Kept behind a small API so the
+-- representation can be specialized in one place.
+type VarSet = S.Set Id
+
+vsEmpty :: VarSet
+vsEmpty = S.empty
+
+vsSingleton :: Id -> VarSet
+vsSingleton = S.singleton
+
+vsUnion :: VarSet -> VarSet -> VarSet
+vsUnion = S.union
+
+vsInsert :: Id -> VarSet -> VarSet
+vsInsert = S.insert
+
+vsDelete :: Id -> VarSet -> VarSet
+vsDelete = S.delete
+
+vsMember :: Id -> VarSet -> Bool
+vsMember = S.member
+
+vsNull :: VarSet -> Bool
+vsNull = S.null
+
+-- The cached free-variable set: interior nodes answer from their
+-- field, leaves directly.
+fTVarSet :: IType -> VarSet
+fTVarSet (ITForAll_ _ fvs _ _ _) = fvs
+fTVarSet (ITAp_ _ fvs _ _) = fvs
+fTVarSet (ITVar i) = vsSingleton i
+fTVarSet (ITCon _ _ _) = vsEmpty
+fTVarSet (ITNum _) = vsEmpty
+fTVarSet (ITStr _) = vsEmpty
+
+-- Free type variables as a Set Id (the historical interface).
+fTVars :: IType -> S.Set Id
+fTVars = fTVarSet
+
+-- --------------------------------
 -- The intern unique of an interior node (ITAp / ITForAll).  Uniques
 -- are process-local, arrival-order identifiers: two types carry the
 -- same unique exactly when they are the same interned node.  They are
@@ -104,8 +161,8 @@ pattern ITCon i k s <- ITCon_ i k s
 -- sharing-map keys in BinData -- and must never be serialized or
 -- otherwise influence anything observable.
 iTypeNodeId :: IType -> Int
-iTypeNodeId (ITForAll_ u _ _ _) = u
-iTypeNodeId (ITAp_ u _ _) = u
+iTypeNodeId (ITForAll_ u _ _ _ _) = u
+iTypeNodeId (ITAp_ u _ _ _) = u
 iTypeNodeId t =
     internalError ("IType.iTypeNodeId: not an interior node: " ++ show t)
 
@@ -267,12 +324,12 @@ data NodeKey
         deriving (Eq, Ord)
 
 tKey :: IType -> TKey
-tKey (ITForAll_ u _ _ _) = TKNode u
-tKey (ITAp_ u _ _)       = TKNode u
-tKey (ITCon_ i _ _)      = TKCon (getIdQual i) (getIdBase i)
-tKey (ITVar_ i)          = TKVar (getIdBase i)
-tKey (ITNum n)           = TKNum n
-tKey (ITStr s)           = TKStr s
+tKey (ITForAll_ u _ _ _ _) = TKNode u
+tKey (ITAp_ u _ _ _)       = TKNode u
+tKey (ITCon_ i _ _)        = TKCon (getIdQual i) (getIdBase i)
+tKey (ITVar_ i)            = TKVar (getIdBase i)
+tKey (ITNum n)             = TKNum n
+tKey (ITStr s)             = TKStr s
 
 data InternTable = InternTable !(M.Map NodeKey IType) {-# UNPACK #-} !Int
 
@@ -292,7 +349,7 @@ internAp f a = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t  -> (st, t)
-          Nothing -> let t = ITAp_ n f a
+          Nothing -> let t = ITAp_ n (fTVarSet f `vsUnion` fTVarSet a) f a
                      in  (InternTable (M.insert key t m) (n+1), t)
 
 {-# NOINLINE mkITForAll #-}
@@ -309,7 +366,7 @@ mkITForAll i k t = unsafePerformIO $ do
     go key st@(InternTable m n) =
         case M.lookup key m of
           Just t' -> (st, t')
-          Nothing -> let t' = ITForAll_ n ti k t
+          Nothing -> let t' = ITForAll_ n (vsDelete ti (fTVarSet t)) ti k t
                      in  (InternTable (M.insert key t' m) (n+1), t')
 
 -- The smart constructor behind the ITAp pattern synonym.  It first
@@ -327,13 +384,13 @@ mkITForAll i k t = unsafePerformIO $ do
 -- real constructors (ITAp_): the ITAp synonym's builder is this very
 -- function.
 mkITAp :: IType -> IType -> IType
-mkITAp (ITAp_ _ (ITCon op _ _) (ITNum x)) (ITNum y) | isJust (res) =
+mkITAp (ITAp_ _ _ (ITCon op _ _) (ITNum x)) (ITNum y) | isJust (res) =
     mkNumConT (fromJust res)
   where res = opNumT op [x, y]
 mkITAp (ITCon op _ _) (ITNum x) | isJust (res) =
     mkNumConT (fromJust res)
   where res = opNumT op [x]
-mkITAp (ITAp_ _ (ITCon op _ _) (ITStr x)) (ITStr y) | isJust (res) =
+mkITAp (ITAp_ _ _ (ITCon op _ _) (ITStr x)) (ITStr y) | isJust (res) =
     ITStr (fromJust res)
   where res = opStrT op [x, y]
 mkITAp (ITCon op _ _) (ITNum x) | op == idTNumToStr =
@@ -357,10 +414,10 @@ mkNumConT i =
 -- intern uniques, matching what the derived instance printed before
 -- hash-consing (so debug dumps are unchanged).
 instance Show IType where
-    showsPrec d (ITForAll_ _ i k t) = showParen (d > 10) $
+    showsPrec d (ITForAll_ _ _ i k t) = showParen (d > 10) $
         showString "ITForAll " . showsPrec 11 i . showString " " .
         showsPrec 11 k . showString " " . showsPrec 11 t
-    showsPrec d (ITAp_ _ f a) = showParen (d > 10) $
+    showsPrec d (ITAp_ _ _ f a) = showParen (d > 10) $
         showString "ITAp " . showsPrec 11 f . showString " " .
         showsPrec 11 a
     showsPrec d (ITVar i) = showParen (d > 10) $
@@ -413,7 +470,7 @@ instance Ord IType where
 -- Interned interior nodes short-circuit on equal uniques (same unique
 -- means the same node, hence EQ).  Uniques are never used for LT/GT.
 cmpT :: IType -> IType -> Ordering
-cmpT (ITForAll_ u1 i1 _ t1) (ITForAll_ u2 i2 _ t2)  -- binder kind comparison skipped (see above)
+cmpT (ITForAll_ u1 _ i1 _ t1) (ITForAll_ u2 _ i2 _ t2)  -- binder kind comparison skipped (see above)
         | u1 == u2  = EQ
         | otherwise =
             case compare i1 i2 of
@@ -422,7 +479,7 @@ cmpT (ITForAll_ u1 i1 _ t1) (ITForAll_ u2 i2 _ t2)  -- binder kind comparison sk
 cmpT (ITForAll _  _  _ ) _                   = LT
 
 cmpT (ITAp _ _)          (ITForAll _  _  _)  = GT
-cmpT (ITAp_ u1 f1 a1)    (ITAp_ u2 f2 a2)
+cmpT (ITAp_ u1 _ f1 a1)  (ITAp_ u2 _ f2 a2)
         | u1 == u2  = EQ
         | otherwise =
             case cmpT f1 f2 of


### PR DESCRIPTION
Third of the ATF/interning series: upstream **#1055**'s three commits rebased onto the interning PR below — zero conflicts (the base drift is entirely absorbed by the two PRs beneath).

- Free-variable sets are computed once per interned node and cached on it; `tSubst` prunes substitution descent using them.
- This is the layer the sharing-aware walkers (next PR group) key their memos on.

Testing: full `fullparallel` gate on this head: **20,278 PASS / 0 FAIL / 134 XFAIL / 0 XPASS, exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt