### PR TITLE
IType: bring interned nodes to normal form once per unique

### DIFF
--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -24,6 +24,8 @@ import Prelude hiding ((<>))
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
+import qualified Data.IntSet as IS
+import System.IO.Unsafe(unsafeDupablePerformIO)
 import Data.Maybe(isJust, fromJust)
 import System.IO.Unsafe(unsafePerformIO)
 
@@ -31,7 +33,7 @@ import ErrorUtil(internalError)
 import IOUtil(progArgs)
 import Id(Id, getIdBase, getIdQual, setIdPosition, setIdProps, setIdQual)
 import PreIds(idArrow, idId, idTNumToStr)
-import TypeOps(opNumT, opStrT)
+import TypeOps(opNumT, opStrT, isPrimTFunName)
 import CType(Type(..), CType, TyCon(..), TyVar(..), Kind(..),
              TISort(..), StructSubType(..),
              cTApplys, cTVar, cTCon, cTNum, cTStr)
@@ -504,9 +506,31 @@ instance Show IType where
 
 -- --------------------------------
 -- NFData Instances
+
+-- Interned interior nodes deep-force ONCE per intern unique: forcing
+-- is idempotent, so remembering "this node is fully forced" is
+-- observationally identical to the plain walk -- but linear on
+-- exponentially shared DAGs, which per-path rnf (e.g. the per-phase
+-- dump deepseq) would re-walk once per path.  Unconditional: the
+-- interning (and hence the DAG shape) is unconditional upstream.
+{-# NOINLINE itRnfSeen #-}
+itRnfSeen :: IORef IS.IntSet
+itRnfSeen = unsafePerformIO $ newIORef IS.empty
+
+itRnfOnce :: Int -> () -> ()
+itRnfOnce u force = unsafeDupablePerformIO $ do
+    s <- readIORef itRnfSeen
+    if IS.member u s
+      then return ()
+      else do -- force BEFORE marking: an exception mid-force must not
+              -- leave the node marked as fully forced
+              _ <- return $! force
+              atomicModifyIORef' itRnfSeen (\ ss -> (IS.insert u ss, ()))
+              return ()
+
 instance NFData IType where
-    rnf (ITForAll i k t) = rnf3 i k t
-    rnf (ITAp a b) = rnf2 a b
+    rnf (ITForAll_ u _ i k t) = itRnfOnce u (rnf3 i k t)
+    rnf (ITAp_ u _ a b) = itRnfOnce u (rnf2 a b)
     rnf (ITVar i) = rnf i
     rnf (ITCon i k s) = rnf3 i k s
     rnf (ITNum i) = rnf i
@@ -627,6 +651,10 @@ ppQuant s d p i t e =
 -- ---------------------------------------------------
 -- Convert ISyntax kinds/types to CType
 
+-- (No conversion memo here: iToCT's only hot caller is
+-- fullTypeNormalizer's ATF-miss path, which the atfrules replacement
+-- deletes outright; a memo would also share result objects across
+-- callers that today receive fresh trees.)
 iToCT :: IType -> CType
 iToCT (ITForAll _ _ _) = internalError "IConv.iToCT: ITForAll"
 iToCT (ITAp t1 t2) = TAp (iToCT t1) (iToCT t2)
@@ -634,6 +662,7 @@ iToCT (ITVar i) = internalError "IConv.iToCT: ITVar"
 iToCT (ITCon i k s) = TCon (TyCon i (Just (iToCK k)) s)
 iToCT (ITNum n) = TCon (TyNum n noPosition)
 iToCT (ITStr s) = TCon (TyStr s noPosition)
+
 
 iToCK :: IKind -> Kind
 iToCK (IKStar) = KStar


### PR DESCRIPTION
Fourth of the ATF/interning series (II-22 group, split single-topic). deepseq on an interned IType walked it as a tree: an exponentially shared DAG — a 16-line synonym tower suffices — overflows the stack in rnf on stock bsc. rnf now records fully-forced intern uniques in a process-global set and never descends twice: O(distinct nodes), like the interner.

Planned successor (per Ravi): the weave-chain #28 re-cut establishes deep-NF-at-construction as an *invariant* (with a DO_INTERNAL_CHECKS assertion — the interning line's canary) and retires this memo as redundant. This PR is the fix-now form; the invariant PR is the upgrade.

Gate at the group tip (atf/4c): 20,278 PASS / 0 FAIL / 134 XFAIL / 0 XPASS; this head builds standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt