### PR TITLE
Skip type-function-free subtrees in the normalizers and reducers

### DIFF
--- a/src/comp/ATFRules.hs
+++ b/src/comp/ATFRules.hs
@@ -74,6 +74,7 @@ import Pred(Pred(..), Qual(..), Class(..), Inst(..), expandSyn,
 import StdPrel(isPreClass)
 import SymTab(SymTab, findSClass)
 import ISyntax(IType(..), IKind(..))
+import IType(itHasATF)
 import ISyntaxSubst(tSubstBatch)
 
 -- The rules are views of the instance declarations already in the
@@ -119,6 +120,9 @@ atfReduceGround rules atfId so args =
 atfReduceInType :: ATFRules -> IType -> Maybe IType
 atfReduceInType rules t0 = go maxFuel t0
   where
+    -- ATF-free subtrees (memoized per intern unique) are returned
+    -- unwalked: they may be exponentially shared DAGs
+    go _ t | not (itHasATF t) = Just t
     go fuel _ | fuel <= 0 = Nothing
     go fuel (ITForAll i k b) = ITForAll i k `fmap` go (fuel - 1) b
     go fuel t@(ITAp _ _) =

--- a/src/comp/IConv.hs
+++ b/src/comp/IConv.hs
@@ -36,6 +36,7 @@ import VModInfo(mkVModInfo, VName(..), VFieldInfo(..))
 import Type(tString, fn, tName, tAttributes)
 import TCMisc(expandSynN)
 import ATFRules(buildATFRules, atfReduceInType)
+import IType(itHasATF)
 import ISyntax
 import ISyntaxSubst
 import ISyntaxUtil
@@ -177,7 +178,10 @@ iConvVS errh flags r env pvs i vs (CQType _ t) cs =
 iConvT :: Flags -> SymTab -> Type -> IType
 iConvT flags s t =
     let it = iConvT' (expandSyn t)
-    in  case atfReduceInType (buildATFRules s) it of
+        -- ATF-free (memoized per unique): nothing to reduce, and the
+        -- reducer's walk must not descend an exponentially shared DAG
+    in  if not (itHasATF it) then it
+        else case atfReduceInType (buildATFRules s) it of
           Just it' -> it'
           Nothing  -> iConvT' (expandSynN flags s t)
 

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -94,6 +94,7 @@ import Id
 import PreIds
 import CSyntax(CExpr)
 import CType(TISort(..), StructSubType(..))
+import IType(itHasTFun)
 import VModInfo
 import ISyntax
 import ISyntaxUtil
@@ -2565,6 +2566,12 @@ updHeap tag (p, HeapData ref) e = do
 -- Type normalization function used in evaluation.
 -- Fully traverse and reduce all type function applications where possible.
 fullTypeNormalizer :: ATFRules -> IType -> Changed IType
+-- no ATF constructor anywhere inside (memoized per intern unique)
+-- means nothing can reduce: answer without descending -- the type may
+-- be an exponentially shared DAG, and this normalizer runs on every
+-- application node's computed type under iPCheck, four times per
+-- compile
+fullTypeNormalizer _ t | not (itHasTFun t) = Unchanged
 fullTypeNormalizer _ (ITCon _ _ _) = Unchanged
 fullTypeNormalizer _ (ITNum _)     = Unchanged
 fullTypeNormalizer _ (ITStr _)     = Unchanged

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -14,6 +14,8 @@ module IType(
   ,ftvCacheEnabled
   ,iToCT
   ,iToCK
+  ,itHasTFun
+  ,itHasATF
   ,sameITypeNode
    )
     where
@@ -26,6 +28,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
 import qualified Data.IntSet as IS
+import qualified Data.IntMap.Strict as IM
 import System.IO.Unsafe(unsafeDupablePerformIO)
 import Data.Maybe(isJust, fromJust)
 import System.IO.Unsafe(unsafePerformIO)
@@ -673,6 +676,69 @@ sameITypeNode (ITAp_ u _ _ _) (ITAp_ u' _ _ _) = u == u'
 sameITypeNode (ITForAll_ u _ _ _ _) (ITForAll_ u' _ _ _ _) = u == u'
 sameITypeNode _ _ = False
 
+-- | Does the type contain a TYPE-FUNCTION constructor anywhere -- an
+-- associated type function (TIatf) or a primitive type function
+-- (TAdd, TLog, ...)?  Only such types have anything the normalizers
+-- can reduce, and BOTH kinds count: a dormant application over
+-- variables becomes a redex when instantiation makes its arguments
+-- literal, so mere ATF-absence is not sufficient to skip
+-- normalization (nested prim applications reduce during elaboration;
+-- cf. bsc.evaluator/primtcons TestTAdd_Nested).  Memoized per intern
+-- unique, so exponentially shared DAGs answer in O(distinct nodes).
+{-# NOINLINE itHasTFunMemo #-}
+itHasTFunMemo :: IORef (IM.IntMap Bool)
+itHasTFunMemo = unsafePerformIO $ newIORef IM.empty
+
+itHasTFun :: IType -> Bool
+itHasTFun (ITCon _ _ (TIatf {})) = True
+-- idId: the identity type operator, eliminated by mkITAp's reduction
+-- but absent from isPrimTFunName's op list
+itHasTFun (ITCon i _ _) = isPrimTFunName i || i == idId
+itHasTFun (ITNum _) = False
+itHasTFun (ITStr _) = False
+itHasTFun (ITVar _) = False
+itHasTFun (ITAp_ u _ f a) = itHasTFunOnce u (itHasTFun f || itHasTFun a)
+itHasTFun (ITForAll_ u _ _ _ t) = itHasTFunOnce u (itHasTFun t)
+
+itHasTFunOnce :: Int -> Bool -> Bool
+itHasTFunOnce u v = unsafeDupablePerformIO $ do
+    m0 <- readIORef itHasTFunMemo
+    case IM.lookup u m0 of
+      Just r -> return r
+      Nothing -> do
+        let r = v
+        _ <- return $! r
+        atomicModifyIORef' itHasTFunMemo (\ m -> (IM.insert u r m, ()))
+        return r
+
+-- Does an applied-type-function constructor occur anywhere inside?
+-- Narrower than itHasTFun: the equation reducers only rewrite ATF
+-- applications, so ATF-absence alone licenses skipping their walks.
+-- Memoized per intern unique, separately from itHasTFun (the
+-- predicates differ on prim-TFun-only types).
+{-# NOINLINE itHasATFMemo #-}
+itHasATFMemo :: IORef (IM.IntMap Bool)
+itHasATFMemo = unsafePerformIO $ newIORef IM.empty
+
+itHasATF :: IType -> Bool
+itHasATF (ITCon _ _ (TIatf {})) = True
+itHasATF (ITCon _ _ _) = False
+itHasATF (ITNum _) = False
+itHasATF (ITStr _) = False
+itHasATF (ITVar _) = False
+itHasATF (ITAp_ u _ f a) = itHasATFOnce u (itHasATF f || itHasATF a)
+itHasATF (ITForAll_ u _ _ _ t) = itHasATFOnce u (itHasATF t)
+
+itHasATFOnce :: Int -> Bool -> Bool
+itHasATFOnce u v = unsafeDupablePerformIO $ do
+    m0 <- readIORef itHasATFMemo
+    case IM.lookup u m0 of
+      Just r -> return r
+      Nothing -> do
+        let r = v
+        _ <- return $! r
+        atomicModifyIORef' itHasATFMemo (\ m -> (IM.insert u r m, ()))
+        return r
 
 iToCK :: IKind -> Kind
 iToCK (IKStar) = KStar


### PR DESCRIPTION
Sixth of the ATF/interning series, completing the II-22 group. Two per-unique-memoized predicates, composed from sibling branches in the source tree that never coexisted (the fold is new here):

- **itHasTFun** — any type operator (TIatf, prim TFuns, and idId which mkITAp folds but isPrimTFunName omits). Gates fullTypeNormalizer: dormant prim applications become redexes under instantiation, so ATF-absence alone is insufficient there (cf. bsc.evaluator/primtcons TestTAdd_Nested).
- **itHasATF** — ATF constructors only. Gates the equation reducers (ATFRules.atfReduceInType, IConv's reduction path): they only rewrite ATFs.

Without these, the iPCheck-adjacent walks reintroduce the exponential on shared DAGs that interning killed. Excluded per the decomposition map: the iConvT' conversion memo (CType-interning dependency — lands with the ctype line).

Gate at this tip: **20,278 PASS / 0 FAIL / 134 XFAIL / 0 XPASS**; all three heads of the group build standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt