### PR TITLE
schedule: cut the sched-conditions solver cost without losing precision

### DIFF
--- a/src/comp/AExpr2STP.hs
+++ b/src/comp/AExpr2STP.hs
@@ -4,6 +4,7 @@ module AExpr2STP(
        addADefToSState,
 
        checkDisjointExpr,
+       checkDisjointExprWithCtx,
        checkDisjointRulePair,
 
        checkBiImplication,
@@ -60,6 +61,7 @@ initSState str flags doHardFail ds avis rs = do
                                             | avi <- avis],
                    proofMap = M.empty,
                    proofMapS = M.empty,
+                   ctxProofMap = M.empty,
 
                    anyId = 0,
                    unknownId = 0,
@@ -125,6 +127,54 @@ checkDisjointExprM e1 e2 = withTraceTest $ do
 
   -- if query(False) is Valid, then there is an inconsistency
   -- when both "e1" and "e2" are asserted, so they are ME
+  return $ case (sat_res) of
+              S.Invalid -> Just False
+              S.Valid   -> Just True
+              S.Timeout -> Nothing
+              S.Error   -> internalError ("STP query error")
+
+-- Disjointness of (ctx1 AND e1) vs (ctx2 AND e2), without ever building
+-- the composite expressions: the four conjuncts are asserted separately
+-- (logically identical) and the memo is keyed on the component tuple.
+checkDisjointExprWithCtx :: SState -> AExpr -> AExpr -> AExpr -> AExpr ->
+                            IO (Maybe Bool, SState)
+checkDisjointExprWithCtx s ctx1 ctx2 e1 e2 =
+    runStateT (checkDisjointExprWithCtxM ctx1 ctx2 e1 e2) s
+
+checkDisjointExprWithCtxM :: AExpr -> AExpr -> AExpr -> AExpr ->
+                             SM (Maybe Bool)
+checkDisjointExprWithCtxM ctx1 ctx2 e1 e2 = withTraceTest $ do
+  when traceTest $
+      traceM("comparing exprs with ctx: " ++ ppString ((ctx1, e1), (ctx2, e2)))
+
+  let doProof = do
+        ctx <- gets context
+        liftIO $ S.ctxPush ctx
+        --
+        (yctx1, _) <- convAExpr2SExpr_Force True ctx1
+        (yctx2, _) <- convAExpr2SExpr_Force True ctx2
+        (ye1, _) <- convAExpr2SExpr_Force True e1
+        (ye2, _) <- convAExpr2SExpr_Force True e2
+
+        liftIO $ S.assert ctx yctx1
+        liftIO $ S.assert ctx yctx2
+        liftIO $ S.assert ctx ye1
+        liftIO $ S.assert ctx ye2
+
+        yf <- gets falseExpr
+        sat_res <- liftIO $ S.query ctx yf
+        liftIO $ S.ctxPop ctx
+        --
+        addToCtxProofMap ctx1 ctx2 e1 e2 sat_res
+        return sat_res
+
+  memRes <- lookupCtxProofMap ctx1 ctx2 e1 e2
+  sat_res <- case memRes of
+    Just r -> return r
+    Nothing -> doProof
+
+  -- if query(False) is Valid, then there is an inconsistency
+  -- when all four conjuncts are asserted, so they are ME
   return $ case (sat_res) of
               S.Invalid -> Just False
               S.Valid   -> Just True
@@ -300,6 +350,9 @@ data SState =
                stateMap      :: M.Map AId VModInfo,
                proofMap      :: M.Map (AExpr, AExpr) S.Result,
                proofMapS     :: M.Map S.Expr S.Result,
+               -- context-augmented disjointness results, keyed on the
+               -- four component exprs (see AExpr2Yices.ctxProofMap)
+               ctxProofMap   :: M.Map (AExpr, AExpr, AExpr, AExpr) S.Result,
 
                anyId         :: Integer,
                unknownId     :: Integer,
@@ -365,6 +418,20 @@ lookupProofMap :: AExpr -> AExpr -> SM (Maybe S.Result)
 lookupProofMap e1 e2 = do
   rmap <- gets proofMap
   return $ M.lookup (e1,e2) rmap
+
+addToCtxProofMap :: AExpr -> AExpr -> AExpr -> AExpr -> S.Result -> SM ()
+addToCtxProofMap ctx1 ctx2 e1 e2 res = do
+  rmap <- gets ctxProofMap
+  -- insert both orderings for expressions
+  let rmap1 = M.insert (ctx1, ctx2, e1, e2) res rmap
+      rmapX = M.insert (ctx2, ctx1, e2, e1) res rmap1
+  modify (\s -> s {ctxProofMap = rmapX})
+
+lookupCtxProofMap :: AExpr -> AExpr -> AExpr -> AExpr ->
+                     SM (Maybe S.Result)
+lookupCtxProofMap ctx1 ctx2 e1 e2 = do
+  rmap <- gets ctxProofMap
+  return $ M.lookup (ctx1, ctx2, e1, e2) rmap
 
 addToProofMapS :: S.Expr -> S.Result -> SM()
 addToProofMapS e1 res = do

--- a/src/comp/AExpr2Yices.hs
+++ b/src/comp/AExpr2Yices.hs
@@ -4,6 +4,7 @@ module AExpr2Yices(
        addADefToYState,
 
        checkDisjointExpr,
+       checkDisjointExprWithCtx,
        checkDisjointRulePair,
 
        checkBiImplication,
@@ -60,6 +61,7 @@ initYState str flags doHardFail ds avis rs = do
                    stateMap = M.fromList [(avi_vname avi, avi_vmi avi)
                                             | avi <- avis],
                    proofMap = M.empty,
+                   ctxProofMap = M.empty,
 
                    anyId = 0,
                    unknownId = 0,
@@ -120,6 +122,49 @@ checkDisjointExprM e1 e2 = withTraceTest $ do
         return sat_res
 
   memRes <- lookupProofMap e1 e2
+  sat_res <- case memRes of
+    Just r  -> return r
+    Nothing -> doProof
+
+  -- if the conditions can both be satisfied, then they are not ME
+  return $ case (cvtStatus sat_res) of
+              Just b -> Just (not b)
+              Nothing -> Nothing
+
+-- Disjointness of (ctx1 AND e1) vs (ctx2 AND e2), without ever building
+-- the composite expressions: the four conjuncts are asserted separately
+-- (logically identical) and the memo is keyed on the component tuple.
+checkDisjointExprWithCtx :: YState -> AExpr -> AExpr -> AExpr -> AExpr ->
+                            IO (Maybe Bool, YState)
+checkDisjointExprWithCtx s ctx1 ctx2 e1 e2 =
+    runStateT (checkDisjointExprWithCtxM ctx1 ctx2 e1 e2) s
+
+checkDisjointExprWithCtxM :: AExpr -> AExpr -> AExpr -> AExpr ->
+                             YM (Maybe Bool)
+checkDisjointExprWithCtxM ctx1 ctx2 e1 e2 = withTraceTest $ do
+  when traceTest $
+      traceM("comparing exprs with ctx: " ++ ppString ((ctx1, e1), (ctx2, e2)))
+
+  let doProof = do
+        (yctx1, _) <- convAExpr2YExpr_Force True ctx1
+        (yctx2, _) <- convAExpr2YExpr_Force True ctx2
+        (ye1, _) <- convAExpr2YExpr_Force True e1
+        (ye2, _) <- convAExpr2YExpr_Force True e2
+        ctx <- gets context
+
+        liftIO $ Y.ctxPush ctx
+        liftIO $ Y.assert ctx yctx1
+        liftIO $ Y.assert ctx yctx2
+        liftIO $ Y.assert ctx ye1
+        liftIO $ Y.assert ctx ye2
+
+        sat_res <- liftIO $ Y.ctxStatus ctx
+
+        liftIO $ Y.ctxPop ctx
+        addToCtxProofMap ctx1 ctx2 e1 e2 sat_res
+        return sat_res
+
+  memRes <- lookupCtxProofMap ctx1 ctx2 e1 e2
   sat_res <- case memRes of
     Just r  -> return r
     Nothing -> doProof
@@ -320,6 +365,12 @@ data YState =
                ruleMap       :: M.Map ARuleId RuleTriple,
                stateMap      :: M.Map AId VModInfo,
                proofMap      :: M.Map (AExpr, AExpr) Y.Status,
+               -- context-augmented disjointness results, keyed on the
+               -- four component exprs: composing "ctx AND e" per query
+               -- would allocate fresh trees whose deep-Ord comparison
+               -- and permanent retention here dominated the schedule
+               -- phase's GC time (they can never be pointer-equal)
+               ctxProofMap   :: M.Map (AExpr, AExpr, AExpr, AExpr) Y.Status,
 
                anyId         :: Integer,
                unknownId     :: Integer,
@@ -383,6 +434,19 @@ lookupProofMap :: AExpr -> AExpr -> YM (Maybe Y.Status)
 lookupProofMap e1 e2 = do
   rmap <- gets proofMap
   return $ M.lookup (e1,e2) rmap
+
+addToCtxProofMap :: AExpr -> AExpr -> AExpr -> AExpr -> Y.Status -> YM ()
+addToCtxProofMap ctx1 ctx2 e1 e2 res = do
+  rmap <- gets ctxProofMap
+  -- insert both orderings for expressions
+  let rmap1 = M.insert (ctx1, ctx2, e1, e2) res rmap
+      rmapX = M.insert (ctx2, ctx1, e2, e1) res rmap1
+  modify (\s -> s {ctxProofMap = rmapX})
+
+lookupCtxProofMap :: AExpr -> AExpr -> AExpr -> AExpr -> YM (Maybe Y.Status)
+lookupCtxProofMap ctx1 ctx2 e1 e2 = do
+  rmap <- gets ctxProofMap
+  return $ M.lookup (ctx1, ctx2, e1, e2) rmap
 
 
 -- -------------------------

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -3911,11 +3911,21 @@ mkConflictMap :: Flags -> DisjointTestState ->
                  SM (ConflictMap, S.Set (ARuleId, ARuleId), DisjointTestState)
 mkConflictMap flags dtstate rule_meth_map ncset ignore_conflicts =
     let
-        checkOneUse :: AExpr -> AExpr ->
+        checkOneUse :: Bool -> AExpr -> AExpr ->
                        ([(MethodId, MethodId)], Bool, DisjointTestState) ->
                        ((MethodId, AExpr), (MethodId, AExpr)) ->
                        SM ([(MethodId, MethodId)], Bool, DisjointTestState)
-        checkOneUse p1 p2 (cs, b, dts) ((m1,c1), (m2,c2)) = do
+        -- Unconditional uses between two distinct rules need no solver
+        -- call: with both conditions True the context-augmented test
+        -- degenerates to the rule-pair disjointness question, which
+        -- ignore_conflicts already answered False (a provably-disjoint
+        -- pair never reaches this point), so the conflict stands.
+        -- (Not valid for a rule against itself: self-pairs are not
+        -- covered by genDisjointSet.)
+        checkOneUse distinct_rules _ _ (cs, b, dts) ((m1,c1), (m2,c2))
+          | distinct_rules && isTrue c1 && isTrue c2
+          = return ((m1,m2):cs, b, dts)
+        checkOneUse _ p1 p2 (cs, b, dts) ((m1,c1), (m2,c2)) = do
           (res, dts') <- convIO $ checkDisjointExprWithCtx dts p1 p2 c1 c2
           case res of
             Just True -> return (cs, True, dts')
@@ -3940,7 +3950,8 @@ mkConflictMap flags dtstate rule_meth_map ncset ignore_conflicts =
                            es' = ((rule2, [CUse cs']):es)
                        in  return (es', igns, dts)
                   else do (cs', ignored, dts')
-                              <- foldM (checkOneUse p1 p2) ([], False, dts) cs
+                              <- foldM (checkOneUse (rule1 /= rule2) p1 p2)
+                                       ([], False, dts) cs
                           let igns' = if ignored
                                       then S.insert (rule1, rule2) igns
                                       else igns

--- a/src/comp/DisjointTest.hs
+++ b/src/comp/DisjointTest.hs
@@ -21,7 +21,7 @@ import PPrint(PPrint(..), ppReadable)
 
 import Flags
 import ASyntax
-import ASyntaxUtil(AExprs(..), aAnd)
+import ASyntaxUtil(AExprs(..))
 import Pragma
 
 import VModInfo(VModInfo)
@@ -30,10 +30,12 @@ import AExpr2Util(getMethodOutputPorts)
 
 import qualified AExpr2STP as STP
          (SState, initSState, addADefToSState,
-          checkDisjointRulePair, checkDisjointExpr)
+          checkDisjointRulePair, checkDisjointExpr,
+          checkDisjointExprWithCtx)
 import qualified AExpr2Yices as Yices
          (YState, initYState, addADefToYState,
-          checkDisjointRulePair, checkDisjointExpr)
+          checkDisjointRulePair, checkDisjointExpr,
+          checkDisjointExprWithCtx)
 
 -- -------------------------
 
@@ -102,10 +104,25 @@ checkDisjointExprWithCtx dts ctx1 ctx2 e1 e2 = do
     (res, dts') <- checkDisjointExpr dts e1 e2
     case res of
       Just True -> return (res, dts')
-      _ -> do -- try again but with the context included
-              let e1' = aAnd ctx1 e1
-                  e2' = aAnd ctx2 e2
-              checkDisjointExpr dts' e1' e2'
+      -- constant-True contexts add nothing; the retry would repeat the
+      -- same query
+      _ | isTrue ctx1 && isTrue ctx2 -> return (res, dts')
+      -- try again but with the contexts included; the backend asserts
+      -- the four conjuncts separately (identical satisfiability) so no
+      -- "ctx AND e" composite is ever built or used as a memo key
+      _ -> checkDisjointExprCtx dts' ctx1 ctx2 e1 e2
+
+checkDisjointExprCtx :: DisjointTestState -> AExpr -> AExpr ->
+                        AExpr -> AExpr ->
+                        IO (Maybe Bool, DisjointTestState)
+checkDisjointExprCtx (DTS_Yices m yices_state) ctx1 ctx2 e1 e2 = do
+    (res, yices_state') <-
+        Yices.checkDisjointExprWithCtx yices_state ctx1 ctx2 e1 e2
+    return (res, DTS_Yices m yices_state')
+checkDisjointExprCtx (DTS_STP m stp_state) ctx1 ctx2 e1 e2 = do
+    (res, stp_state') <-
+        STP.checkDisjointExprWithCtx stp_state ctx1 ctx2 e1 e2
+    return (res, DTS_STP m stp_state')
 
 -- -------------------------
 


### PR DESCRIPTION
Weave-chain re-cut (old #29) onto clean `upstream-main` — single-topic, no chain dependency. Clean cherry-pick, no adaptation needed.

Full gate on this head: **20,280 PASS / 0 FAIL / 134 XFAIL / 0 XPASS**.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt