### PR TITLE
build: default the RTS to a large chunked nursery, no idle GC

### DIFF
--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -191,10 +191,17 @@ GHCTMP = '-tmpdir $(TMPDIR)'
 # which inflates peak stack usage by roughly an order of magnitude
 # on the perf regression suite.
 # If you modify this, also update rts_opts in ../vendor/htcl/haskell.c
+# -A64m: a large allocation area is the single biggest GC lever for
+# bsc's allocation-heavy batch workload (the default nursery forces
+# very frequent minor GCs; GC was ~22% of total CPU on the matx perf
+# suite).  -n4m chunks the nursery for cache behavior; -I0 disables
+# idle GC, which only triggered spurious collections in a short-lived
+# batch process.  Callers can still override per invocation via +RTS
+# (the binary is built with -rtsopts).
 ifeq ($(BSC_BUILD),PROF)
-RTSFLAGS = "-with-rtsopts=-H256m -K256m -i1"
+RTSFLAGS = "-with-rtsopts=-H256m -K256m -A64m -n4m -I0"
 else
-RTSFLAGS = "-with-rtsopts=-H256m -K10m -i1"
+RTSFLAGS = "-with-rtsopts=-H256m -K10m -A64m -n4m -I0"
 endif
 FVIA ?= -fasm
 GHCFLAGS = \

--- a/src/vendor/htcl/haskell.c
+++ b/src/vendor/htcl/haskell.c
@@ -13,7 +13,7 @@ htcl_initHaskellRTS(int *argc, char **argv[])
   RtsConfig conf = defaultRtsConfig;
 
   conf.rts_opts_enabled = RtsOptsAll;
-  conf.rts_opts = "-H256m -K10m -i1";
+  conf.rts_opts = "-H256m -K10m -A64m -n4m -I0"; /* keep in sync with RTSFLAGS in src/comp/Makefile */
   hs_init_ghc(argc, argv, conf);
 
   // register haskell exit function, finish


### PR DESCRIPTION
Weave-chain re-cut (old #34) onto clean `upstream-main` — single-topic, build-system only. Clean cherry-pick.

**Disposition (Ravi 2026-08-04): MatX-local tuning.** Upstream-clean geometry so it composes with the rest of the landscape, but not on the upstream socialization list — batch-compiler RTS defaults (big chunked nursery, no idle GC) are a throughput win we take locally; proposing upstream would spend review attention on tuning. Revisit only with benchmark numbers.

Head builds; full gate running, result to be posted here.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt