### PR TITLE
LiftDicts: pre-conversion dictionary pool restores O(1) occurrences

### DIFF
--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260715-5"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-1"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,7 +561,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133) =
+                a_130 a_131 a_132 a_133 a_134) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
       where
@@ -612,7 +612,7 @@ instance Bin Flags where
         wr_chunk8 =
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-             toBin a_130; toBin a_131; toBin a_132; toBin a_133
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -631,7 +631,7 @@ instance Bin Flags where
           (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-           a_128, a_129, a_130, a_131, a_132, a_133) <- rd_chunk8
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +646,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133)
+                a_130 a_131 a_132 a_133 a_134)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -708,9 +708,9 @@ instance Bin Flags where
         rd_chunk8 =
           do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin
+             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-                     a_128, a_129, a_130, a_131, a_132, a_133)
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
 
 -- ----------
 

--- a/src/comp/LiftDicts.hs
+++ b/src/comp/LiftDicts.hs
@@ -91,6 +91,15 @@ data LState a = LState {
   -- lifting order.  A dictionary is reused only on a structural match
   -- of its converted evidence (see the module note above).
   dictPool :: M.Map IType [(Id, IExpr a)],
+  -- Pre-conversion mirror of dictPool, keyed on the CSyntax type and
+  -- evidence (both position-insensitive Eq).  Equal (CType, CExpr)
+  -- convert to equal (IType, IExpr) -- convDict is deterministic and
+  -- convEnv entries are never redefined -- so a hit here returns the
+  -- id the interned pool would have chosen, without converting the
+  -- evidence at all.  This restores the O(1)-per-occurrence cost for
+  -- repeated dictionaries (the common case), which otherwise paid a
+  -- full iConvT+iConvExpr per occurrence.
+  dictPoolC :: M.Map CType [(CExpr, Id)],
   -- The lifted definitions, most recent first (reversed at the end, so
   -- the emitted order is lifting order and thus deterministic)
   liftedDefs :: [IDef a],
@@ -127,6 +136,7 @@ initLState errh fs r (CPackage mi exps imps impsigs fixs ds includes) = LState {
   flags = fs,
   dictNo = 0,
   dictPool = M.empty,
+  dictPoolC = M.empty,
   liftedDefs = [],
   liftedTypes = M.empty,
   convEnv = instConvEnv,
@@ -305,43 +315,56 @@ handleDict incoherent p t e = do
     CVar i' -> return $ Right i'
     CApply (CVar i') [] -> return $ Right i'
     _ -> do
-      (it, ie) <- convDict t e'
-      pool <- gets dictPool
-      let cands = M.findWithDefault [] it pool
-      case [ i0 | (i0, ie0) <- cands, ie0 == ie ] of
-        (i0:_) -> do
-          when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
-          return $ Right i0
-        [] -> do
-          when (trace_lift_dicts && not (null cands)) $ traceM $
-              "dictPool type collision (different evidence): " ++ ppReadable t
-          lift_i0 <- newDictId (getPosition e)
-          let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
-                       else lift_i0
-          when trace_lift_dicts $ traceM $
-              "adding lifted dict: " ++ ppReadable (lift_i, e')
-          s0 <- get
-          -- The evidence identity for cross-package deduplication (see
-          -- "renderEvidence"), recorded at mint time.  An incoherent
-          -- resolution depends on the instances visible HERE, so it
-          -- never gets one.
-          let mev = if incoherent then Nothing
-                    else renderEvidence (flags s0) (symt s0) e'
-              props = case mev of
-                        Nothing -> []
-                        Just (str, kids, tys) -> [ DefP_DictRendering str,
-                                                   DefP_DictKids kids,
-                                                   DefP_DictTypes tys ]
-          when (trace_lift_dicts && not incoherent && null props) $ traceM $
-              "no evidence rendering (not cross-package dedupable): "
-              ++ ppReadable (lift_i, e')
-          let ref = ICon lift_i (ICDef it (icUndetAt (getIdPosition lift_i) it UNoMatch))
-          modify (\s -> s {
-              dictPool = M.insertWith (\new old -> old ++ new) it [(lift_i, ie)] (dictPool s),
-              liftedDefs = IDef lift_i it ie props : liftedDefs s,
-              liftedTypes = M.insert lift_i t (liftedTypes s),
-              convEnv = M.insert lift_i ref (convEnv s) })
-          return $ Right lift_i
+      poolC <- gets dictPoolC
+      case [ i0 | (e0, i0) <- M.findWithDefault [] t poolC, e0 == e' ] of
+       (i0:_) -> do
+        when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
+        return $ Right i0
+       [] -> do
+        (it, ie) <- convDict t e'
+        -- future occurrences of this (type, evidence) hit the
+        -- pre-conversion pool and skip convDict
+        let recordC i0 = modify (\s -> s {
+                dictPoolC = M.insertWith (\new old -> old ++ new) t
+                                [(e', i0)] (dictPoolC s) })
+        pool <- gets dictPool
+        let cands = M.findWithDefault [] it pool
+        case [ i0 | (i0, ie0) <- cands, ie0 == ie ] of
+          (i0:_) -> do
+            when trace_lift_dicts $ traceM $ "dictPool hit: " ++ ppReadable (i0, t)
+            recordC i0
+            return $ Right i0
+          [] -> do
+            when (trace_lift_dicts && not (null cands)) $ traceM $
+                "dictPool type collision (different evidence): " ++ ppReadable t
+            lift_i0 <- newDictId (getPosition e)
+            let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
+                         else lift_i0
+            when trace_lift_dicts $ traceM $
+                "adding lifted dict: " ++ ppReadable (lift_i, e')
+            s0 <- get
+            -- The evidence identity for cross-package deduplication (see
+            -- "renderEvidence"), recorded at mint time.  An incoherent
+            -- resolution depends on the instances visible HERE, so it
+            -- never gets one.
+            let mev = if incoherent then Nothing
+                      else renderEvidence (flags s0) (symt s0) e'
+                props = case mev of
+                          Nothing -> []
+                          Just (str, kids, tys) -> [ DefP_DictRendering str,
+                                                     DefP_DictKids kids,
+                                                     DefP_DictTypes tys ]
+            when (trace_lift_dicts && not incoherent && null props) $ traceM $
+                "no evidence rendering (not cross-package dedupable): "
+                ++ ppReadable (lift_i, e')
+            let ref = ICon lift_i (ICDef it (icUndetAt (getIdPosition lift_i) it UNoMatch))
+            modify (\s -> s {
+                dictPool = M.insertWith (\new old -> old ++ new) it [(lift_i, ie)] (dictPool s),
+                liftedDefs = IDef lift_i it ie props : liftedDefs s,
+                liftedTypes = M.insert lift_i t (liftedTypes s),
+                convEnv = M.insert lift_i ref (convEnv s) })
+            recordC lift_i
+            return $ Right lift_i
 
 handleDictExpr :: BoundDicts -> CType -> CExpr -> L a (CExpr, Bool)
 handleDictExpr _ t e


### PR DESCRIPTION
Dicts-line re-cut (old #30) stacked on upstream #925's head (mirrored here as `dicts/0-lift-dicts-925` — #925 already carries the DefProp module, evidence-identity dedup, and their tag bumps). Standalone-build fix folded in: the original relied on a neighboring rc8 commit for the `Bin Flags` arity — this cut carries the slot itself (`.ba` tag → `bsc-ba-20260804-1`).

Head builds (compile-gated); tip gate rolls with the queue and will be posted.

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt