### PR TITLE
typecheck: change-tracking substitution (apSubC), apSub outside the class

### DIFF
--- a/src/comp/Assump.hs
+++ b/src/comp/Assump.hs
@@ -2,6 +2,7 @@ module Assump(Assump(..)) where
 import Id
 import Scheme
 import Subst
+import Changed
 import PPrint
 import Eval
 
@@ -13,7 +14,8 @@ instance PPrint Assump where
     pPrint d p (i :>: s) = pparen (p > 0) $ pPrint d 0 i <+> text ":>:" <+> pPrint d 0 s
 
 instance Types Assump where
-    apSub s (i :>: sc) = i :>: (apSub s sc)
+    apSubO s (i :>: sc) = i :>: (apSubO s sc)
+    apSubC s (i :>: sc) = changed1 (i :>:) (apSubC s sc)
     tv      (i :>: sc) = tv sc
 
 instance NFData Assump where

--- a/src/comp/CSyntaxTypes.hs
+++ b/src/comp/CSyntaxTypes.hs
@@ -7,30 +7,41 @@ import Util(mapSnd)
 import PPrint(ppReadable)
 import ErrorUtil(internalError)
 import Subst
+import Changed
 import CSyntax
+
+-- NB the instances below are deliberately LAZY (always Changed, with
+-- per-child sharing via changedOrId . apSubC): CSyntax trees are large
+-- and only partially demanded by the typechecker, so eager whole-node
+-- changed-detection (mapChanged/changedN) forces far more than is ever
+-- consumed -- measured +40% typecheck on a register-heavy module.
+-- Leaf constructors still return Unchanged, and Type-level detection
+-- (Subst.hs) stays eager where nodes are small.
 
 --import Debug.Trace
 
 
 instance Types CDefn where
-    apSub s (CValueSign d) = CValueSign (apSub s d)
-    apSub s d = d
+    apSubO s (CValueSign d) = CValueSign (apSubO s d)
+    apSubO s d = d
+    apSubC s (CValueSign d) = changed1 CValueSign (apSubC s d)
+    apSubC s d = Unchanged
     tv (CValueSign d) = tv d
     tv d = []
 
 instance Types CDef where
-    apSub s (CDef i qt cs) = CDef i (apSub s qt) (apSub s cs)
+    apSubO s (CDef i qt cs) = CDef i (apSubO s qt) (apSubO s cs)
     -- This line has been here since revision 1 with the comment "XXX vs ?"
-    --apSub s (CDefT i vs qt cs) = CDefT i vs (apSub s qt) (apSub s cs)
+    --apSubO s (CDefT i vs qt cs) = CDefT i vs (apSubO s qt) (apSubO s cs)
     -- The "vs" are the lambda-bound type variables in this definition.
     -- Thus, substituting for or to them is an error.  (Unless the caller
     -- knows what he's doing?)
     -- Below, we remove these variables from the substitution.
     -- This fixes bug 675, but is it fixing the problem or just masking it?
     -- More thought/investigation is needed.
-    apSub s (CDefT i vs qt cs) =
+    apSubO s (CDefT i vs qt cs) =
         let s' = if null vs then s else trimSubstByVars vs s
-        in  CDefT i vs (apSub s' qt) (apSub s' cs)
+        in  CDefT i vs (apSubO s' qt) (apSubO s' cs)
 {-
     -- For investigating, use this code to assert an internalError or trace
     -- on bad substitutions.
@@ -39,86 +50,151 @@ instance Types CDef where
         in
             --if (any (\v -> elem v r) removed_vs)
             if (any (\v -> elem v r) vs)
-            then internalError ("apSub CDefT:\n" ++
+            then internalError ("apSubO CDefT:\n" ++
                                 " i = " ++ ppReadable i ++
                                 " vs = " ++ ppReadable vs ++
                                 " removed_vs = " ++ ppReadable removed_vs ++
                                 " s' = " ++ ppReadable s')
             else
             if (length removed_vs > 0)
-            then trace ("apSub CDefT, removing from Subst:\n" ++
+            then trace ("apSubO CDefT, removing from Subst:\n" ++
                         " i = " ++ ppReadable i ++
                         " vs = " ++ ppReadable vs ++
                         " removed_vs = " ++ ppReadable removed_vs ++
                         " s = " ++ ppReadable s) $
-                 CDefT i vs (apSub s' qt) (apSub s' cs)
-            else CDefT i vs (apSub s' qt) (apSub s' cs)
+                 CDefT i vs (apSubO s' qt) (apSubO s' cs)
+            else CDefT i vs (apSubO s' qt) (apSubO s' cs)
 -}
+    apSubC s (CDef i qt cs) = Changed (CDef i (changedOrId (apSubC s) qt) (map (changedOrId (apSubC s)) cs))
+    apSubC s (CDefT i vs qt cs) =
+        let s' = if null vs then s else trimSubstByVars vs s
+        in  if isNullSubst s'
+            then Unchanged
+            else Changed (CDefT i vs (changedOrId (apSubC s') qt)
+                              (map (changedOrId (apSubC s')) cs))
     tv (CDef i qt cs) = tv (qt, cs)
     tv (CDefT i vs qt cs) = (nub (tv (qt, cs))) \\ vs
 
 instance Types CClause where
-    apSub s (CClause ps qs e) = CClause (apSub s ps) (apSub s qs) (apSub s e)
+    apSubO s (CClause ps qs e) = CClause (apSubO s ps) (apSubO s qs) (apSubO s e)
+    apSubC s (CClause ps qs e) =
+        Changed (CClause (map (changedOrId (apSubC s)) ps) (map (changedOrId (apSubC s)) qs) (changedOrId (apSubC s) e))
     tv (CClause ps qs e) = tv (ps, qs, e)
 
 instance Types CRule where
-    apSub s (CRule rps mi qs e) = CRule rps (apSub s mi) (apSub s qs) (apSub s e)
-    apSub s (CRuleNest rps mi qs rs) = CRuleNest rps (apSub s mi) (apSub s qs) (apSub s rs)
+    apSubO s (CRule rps mi qs e) = CRule rps (apSubO s mi) (apSubO s qs) (apSubO s e)
+    apSubO s (CRuleNest rps mi qs rs) = CRuleNest rps (apSubO s mi) (apSubO s qs) (apSubO s rs)
+    apSubC s (CRule rps mi qs e) =
+        Changed (CRule rps (fmap (changedOrId (apSubC s)) mi) (map (changedOrId (apSubC s)) qs) (changedOrId (apSubC s) e))
+    apSubC s (CRuleNest rps mi qs rs) =
+        Changed (CRuleNest rps (fmap (changedOrId (apSubC s)) mi) (map (changedOrId (apSubC s)) qs) (map (changedOrId (apSubC s)) rs))
     tv (CRule rps mi qs e) = tv (mi, qs, e)
     tv (CRuleNest rps mi qs rs) = tv (mi, qs, rs)
 
 instance Types CQual where
-    apSub s (CQGen t p e) = CQGen (apSub s t) (apSub s p) (apSub s e)
-    apSub s (CQFilter e) = CQFilter (apSub s e)
+    apSubO s (CQGen t p e) = CQGen (apSubO s t) (apSubO s p) (apSubO s e)
+    apSubO s (CQFilter e) = CQFilter (apSubO s e)
+    apSubC s (CQGen t p e) = Changed (CQGen (changedOrId (apSubC s) t) (changedOrId (apSubC s) p) (changedOrId (apSubC s) e))
+    apSubC s (CQFilter e) = changed1 CQFilter (apSubC s e)
     tv (CQGen t p e) = tv (t, p, e)
     tv (CQFilter e) = tv e
 
 instance Types CExpr where
-    apSub s (CLam i e) = CLam i (apSub s e)
-    apSub s (CLamT i t e) = CLamT i (apSub s t) (apSub s e)
-    apSub s (Cletrec ds e) = Cletrec (apSub s ds) (apSub s e)
-    apSub s (Cletseq ds e) = Cletseq (apSub s ds) (apSub s e)
-    apSub s (CSelect e i) = CSelect (apSub s e) i
-    apSub s (CSelectTT ti e i) = CSelectTT ti (apSub s e) i
-    apSub s (CCon i es) = CCon i (apSub s es)
-    apSub s (Ccase pos e as) = Ccase pos (apSub s e) (apSub s as)
-    apSub s (CStruct mb ti fs) = CStruct mb ti (mapSnd (apSub s) fs)
-    apSub s (CStructUpd e fs) = CStructUpd (apSub s e) (mapSnd (apSub s) fs)
-    apSub s (Cwrite pos e v) = Cwrite pos (apSub s e) (apSub s v)
-    apSub s e@(CAny {}) = e
-    apSub s e@(CVar _) = e
-    apSub s (CApply f es) = CApply (apSub s f) (apSub s es)
-    apSub s (CTaskApply f es) = CTaskApply (apSub s f) (apSub s es)
-    apSub s (CTaskApplyT f t es) = CTaskApplyT (apSub s f) (apSub s t) (apSub s es)
-    apSub s e@(CLit _) = e
-    apSub s (CBinOp e1 o e2) = CBinOp (apSub s e1) o (apSub s e2)
-    apSub s (CHasType e t) = CHasType (apSub s e) (apSub s t)
-    apSub s (Cif pos e1 e2 e3) = Cif pos (apSub s e1) (apSub s e2) (apSub s e3)
-    apSub s (CSub pos e1 e2) = CSub pos (apSub s e1) (apSub s e2)
-    apSub s (CSub2 e1 e2 e3) = CSub2 (apSub s e1) (apSub s e2) (apSub s e3)
-    apSub s (CSubUpdate pos e_vec (e_h, e_l) e_rhs) =
-        CSubUpdate pos (apSub s e_vec) (apSub s e_h, apSub s e_l) (apSub s e_rhs)
-    apSub s (Cmodule pos is) = Cmodule pos (apSub s is)
-    apSub s (Cinterface pos mi ds) = Cinterface pos mi (apSub s ds)
-    apSub s (CmoduleVerilog m ui c r ses fs sch ps) = CmoduleVerilog (apSub s m) ui c r (mapSnd (apSub s) ses) fs sch ps
-    apSub s (CForeignFuncC i wty) = CForeignFuncC i (apSub s wty)
-    apSub s (Cdo r ss) = Cdo r (apSub s ss)
-    apSub s (Caction pos ss) = Caction pos (apSub s ss)
-    apSub s (Crules ps rs) = Crules ps (apSub s rs)
-    apSub s (CTApply e ts) = CTApply (apSub s e) (apSub s ts)
-    apSub s (CSelectT ti i) = CSelectT ti i
-    apSub s (CStructT t fs) = CStructT (apSub s t) (mapSnd (apSub s) fs)
-    apSub s (CCon1 ti i e) = CCon1 ti i (apSub s e)
-    apSub s (CConT t i es) = CConT t i (apSub s es)
-    apSub s (CLitT t l) = CLitT (apSub s t) l
-    apSub s (CAnyT pos uk t) = CAnyT pos uk (apSub s t)
-    apSub s (CmoduleVerilogT t m ui c r ses fs sch ps) =
-        CmoduleVerilogT (apSub s t) (apSub s m) ui c r (mapSnd (apSub s) ses) fs sch ps
-    apSub s (CForeignFuncCT i pty) = CForeignFuncCT i (apSub s pty)
-    apSub s (COper os) = internalError ("CSyntaxTypes.Types(CExpr).apSub: COper " ++ ppReadable os)
-    apSub s e@(Cattributes pps) = e
-    apSub s e = internalError ("CSyntaxTypes.Types(CExpr).apSub: " ++ ppReadable e)
+    apSubO s (CLam i e) = CLam i (apSubO s e)
+    apSubO s (CLamT i t e) = CLamT i (apSubO s t) (apSubO s e)
+    apSubO s (Cletrec ds e) = Cletrec (apSubO s ds) (apSubO s e)
+    apSubO s (Cletseq ds e) = Cletseq (apSubO s ds) (apSubO s e)
+    apSubO s (CSelect e i) = CSelect (apSubO s e) i
+    apSubO s (CSelectTT ti e i) = CSelectTT ti (apSubO s e) i
+    apSubO s (CCon i es) = CCon i (apSubO s es)
+    apSubO s (Ccase pos e as) = Ccase pos (apSubO s e) (apSubO s as)
+    apSubO s (CStruct mb ti fs) = CStruct mb ti (mapSnd (apSubO s) fs)
+    apSubO s (CStructUpd e fs) = CStructUpd (apSubO s e) (mapSnd (apSubO s) fs)
+    apSubO s (Cwrite pos e v) = Cwrite pos (apSubO s e) (apSubO s v)
+    apSubO s e@(CAny {}) = e
+    apSubO s e@(CVar _) = e
+    apSubO s (CApply f es) = CApply (apSubO s f) (apSubO s es)
+    apSubO s (CTaskApply f es) = CTaskApply (apSubO s f) (apSubO s es)
+    apSubO s (CTaskApplyT f t es) = CTaskApplyT (apSubO s f) (apSubO s t) (apSubO s es)
+    apSubO s e@(CLit _) = e
+    apSubO s (CBinOp e1 o e2) = CBinOp (apSubO s e1) o (apSubO s e2)
+    apSubO s (CHasType e t) = CHasType (apSubO s e) (apSubO s t)
+    apSubO s (Cif pos e1 e2 e3) = Cif pos (apSubO s e1) (apSubO s e2) (apSubO s e3)
+    apSubO s (CSub pos e1 e2) = CSub pos (apSubO s e1) (apSubO s e2)
+    apSubO s (CSub2 e1 e2 e3) = CSub2 (apSubO s e1) (apSubO s e2) (apSubO s e3)
+    apSubO s (CSubUpdate pos e_vec (e_h, e_l) e_rhs) =
+        CSubUpdate pos (apSubO s e_vec) (apSubO s e_h, apSubO s e_l) (apSubO s e_rhs)
+    apSubO s (Cmodule pos is) = Cmodule pos (apSubO s is)
+    apSubO s (Cinterface pos mi ds) = Cinterface pos mi (apSubO s ds)
+    apSubO s (CmoduleVerilog m ui c r ses fs sch ps) = CmoduleVerilog (apSubO s m) ui c r (mapSnd (apSubO s) ses) fs sch ps
+    apSubO s (CForeignFuncC i wty) = CForeignFuncC i (apSubO s wty)
+    apSubO s (Cdo r ss) = Cdo r (apSubO s ss)
+    apSubO s (Caction pos ss) = Caction pos (apSubO s ss)
+    apSubO s (Crules ps rs) = Crules ps (apSubO s rs)
+    apSubO s (CTApply e ts) = CTApply (apSubO s e) (apSubO s ts)
+    apSubO s (CSelectT ti i) = CSelectT ti i
+    apSubO s (CStructT t fs) = CStructT (apSubO s t) (mapSnd (apSubO s) fs)
+    apSubO s (CCon1 ti i e) = CCon1 ti i (apSubO s e)
+    apSubO s (CConT t i es) = CConT t i (apSubO s es)
+    apSubO s (CLitT t l) = CLitT (apSubO s t) l
+    apSubO s (CAnyT pos uk t) = CAnyT pos uk (apSubO s t)
+    apSubO s (CmoduleVerilogT t m ui c r ses fs sch ps) =
+        CmoduleVerilogT (apSubO s t) (apSubO s m) ui c r (mapSnd (apSubO s) ses) fs sch ps
+    apSubO s (CForeignFuncCT i pty) = CForeignFuncCT i (apSubO s pty)
+    apSubO s (COper os) = internalError ("CSyntaxTypes.Types(CExpr).apSub: COper " ++ ppReadable os)
+    apSubO s e@(Cattributes pps) = e
+    apSubO s e = internalError ("CSyntaxTypes.Types(CExpr).apSub: " ++ ppReadable e)
 
+    apSubC s (CLam i e) = changed1 (CLam i) (apSubC s e)
+    apSubC s (CLamT i t e) = Changed (CLamT i (changedOrId (apSubC s) t) (changedOrId (apSubC s) e))
+    apSubC s (Cletrec ds e) = Changed (Cletrec (map (changedOrId (apSubC s)) ds) (changedOrId (apSubC s) e))
+    apSubC s (Cletseq ds e) = Changed (Cletseq (map (changedOrId (apSubC s)) ds) (changedOrId (apSubC s) e))
+    apSubC s (CSelect e i) = changed1 (\e' -> CSelect e' i) (apSubC s e)
+    apSubC s (CSelectTT ti e i) =
+        changed1 (\e' -> CSelectTT ti e' i) (apSubC s e)
+    apSubC s (CCon i es) = Changed (CCon i (map (changedOrId (apSubC s)) es))
+    apSubC s (Ccase pos e as) = Changed (Ccase pos (changedOrId (apSubC s) e) (map (changedOrId (apSubC s)) as))
+    apSubC s (CStruct mb ti fs) = Changed (CStruct mb ti (mapSnd (changedOrId (apSubC s)) fs))
+    apSubC s (CStructUpd e fs) = Changed (CStructUpd (changedOrId (apSubC s) e) (mapSnd (changedOrId (apSubC s)) fs))
+    apSubC s (Cwrite pos e v) = Changed (Cwrite pos (changedOrId (apSubC s) e) (changedOrId (apSubC s) v))
+    apSubC s (CAny {}) = Unchanged
+    apSubC s (CVar _) = Unchanged
+    apSubC s (CApply f es) = Changed (CApply (changedOrId (apSubC s) f) (map (changedOrId (apSubC s)) es))
+    apSubC s (CTaskApply f es) = Changed (CTaskApply (changedOrId (apSubC s) f) (map (changedOrId (apSubC s)) es))
+    apSubC s (CTaskApplyT f t es) =
+        Changed (CTaskApplyT (changedOrId (apSubC s) f) (changedOrId (apSubC s) t) (map (changedOrId (apSubC s)) es))
+    apSubC s (CLit _) = Unchanged
+    apSubC s (CBinOp e1 o e2) = Changed (CBinOp (changedOrId (apSubC s) e1) o (changedOrId (apSubC s) e2))
+    apSubC s (CHasType e t) = Changed (CHasType (changedOrId (apSubC s) e) (changedOrId (apSubC s) t))
+    apSubC s (Cif pos e1 e2 e3) =
+        Changed (Cif pos (changedOrId (apSubC s) e1) (changedOrId (apSubC s) e2) (changedOrId (apSubC s) e3))
+    apSubC s (CSub pos e1 e2) = Changed (CSub pos (changedOrId (apSubC s) e1) (changedOrId (apSubC s) e2))
+    apSubC s (CSub2 e1 e2 e3) =
+        Changed (CSub2 (changedOrId (apSubC s) e1) (changedOrId (apSubC s) e2) (changedOrId (apSubC s) e3))
+    apSubC s (CSubUpdate pos e_vec (e_h, e_l) e_rhs) =
+        Changed (CSubUpdate pos (changedOrId (apSubC s) e_vec) ((changedOrId (apSubC s) e_h), (changedOrId (apSubC s) e_l)) (changedOrId (apSubC s) e_rhs))
+    apSubC s (Cmodule pos is) = Changed (Cmodule pos (map (changedOrId (apSubC s)) is))
+    apSubC s (Cinterface pos mi ds) = Changed (Cinterface pos mi (map (changedOrId (apSubC s)) ds))
+    apSubC s (CmoduleVerilog m ui c r ses fs sch ps) =
+        Changed (CmoduleVerilog (changedOrId (apSubC s) m) ui c r (mapSnd (changedOrId (apSubC s)) ses) fs sch ps)
+    apSubC s (CForeignFuncC i wty) = changed1 (CForeignFuncC i) (apSubC s wty)
+    apSubC s (Cdo r ss) = Changed (Cdo r (map (changedOrId (apSubC s)) ss))
+    apSubC s (Caction pos ss) = Changed (Caction pos (map (changedOrId (apSubC s)) ss))
+    apSubC s (Crules ps rs) = Changed (Crules ps (map (changedOrId (apSubC s)) rs))
+    apSubC s (CTApply e ts) = Changed (CTApply (changedOrId (apSubC s) e) (map (changedOrId (apSubC s)) ts))
+    apSubC s (CSelectT ti i) = Unchanged
+    apSubC s (CStructT t fs) = Changed (CStructT (changedOrId (apSubC s) t) (mapSnd (changedOrId (apSubC s)) fs))
+    apSubC s (CCon1 ti i e) = changed1 (CCon1 ti i) (apSubC s e)
+    apSubC s (CConT t i es) = Changed (CConT t i (map (changedOrId (apSubC s)) es))
+    apSubC s (CLitT t l) = changed1 (\t' -> CLitT t' l) (apSubC s t)
+    apSubC s (CAnyT pos uk t) = changed1 (CAnyT pos uk) (apSubC s t)
+    apSubC s (CmoduleVerilogT t m ui c r ses fs sch ps) =
+        Changed (CmoduleVerilogT (changedOrId (apSubC s) t) (changedOrId (apSubC s) m) ui c r (mapSnd (changedOrId (apSubC s)) ses) fs sch ps)
+    apSubC s (CForeignFuncCT i pty) =
+        changed1 (CForeignFuncCT i) (apSubC s pty)
+    apSubC s (COper os) = internalError ("CSyntaxTypes.Types(CExpr).apSub: COper " ++ ppReadable os)
+    apSubC s e@(Cattributes pps) = Unchanged
+    apSubC s e = internalError ("CSyntaxTypes.Types(CExpr).apSub: " ++ ppReadable e)
     tv (CLam i e) = tv e
     tv (CLamT i t e) = tv (t, e)
     tv (Cletrec ds e) = tv (ds, e)
@@ -163,11 +239,18 @@ instance Types CExpr where
     tv e = internalError ("CSyntaxTypes.Types(CExpr).tv: " ++ ppReadable e)
 
 instance Types CStmt where
-    apSub s (CSBindT p name pprops t e) = CSBindT (apSub s p) name pprops (apSub s t) (apSub s e)
-    apSub s (CSBind p name pprops e) = CSBind (apSub s p) name pprops (apSub s e)
-    apSub s (CSletrec ds) = CSletrec (apSub s ds)
-    apSub s (CSletseq ds) = CSletseq (apSub s ds)
-    apSub s (CSExpr name e) = CSExpr name (apSub s e)
+    apSubO s (CSBindT p name pprops t e) = CSBindT (apSubO s p) name pprops (apSubO s t) (apSubO s e)
+    apSubO s (CSBind p name pprops e) = CSBind (apSubO s p) name pprops (apSubO s e)
+    apSubO s (CSletrec ds) = CSletrec (apSubO s ds)
+    apSubO s (CSletseq ds) = CSletseq (apSubO s ds)
+    apSubO s (CSExpr name e) = CSExpr name (apSubO s e)
+    apSubC s (CSBindT p name pprops t e) =
+        Changed (CSBindT (changedOrId (apSubC s) p) name pprops (changedOrId (apSubC s) t) (changedOrId (apSubC s) e))
+    apSubC s (CSBind p name pprops e) =
+        Changed (CSBind (changedOrId (apSubC s) p) name pprops (changedOrId (apSubC s) e))
+    apSubC s (CSletrec ds) = Changed (CSletrec (map (changedOrId (apSubC s)) ds))
+    apSubC s (CSletseq ds) = Changed (CSletseq (map (changedOrId (apSubC s)) ds))
+    apSubC s (CSExpr name e) = changed1 (CSExpr name) (apSubC s e)
     tv (CSBindT p _ _ t e) = tv (p, t, e)
     tv (CSBind p _ _ e) = tv (p, e)
     tv (CSletrec ds) = tv ds
@@ -176,26 +259,42 @@ instance Types CStmt where
 
 
 instance Types CMStmt where
-    apSub s (CMStmt t) = CMStmt (apSub s t)
-    apSub s (CMrules e) = CMrules (apSub s e)
-    apSub s (CMinterface e) = CMinterface (apSub s e)
-    apSub s (CMTupleInterface pos es) = CMTupleInterface pos (apSub s es)
+    apSubO s (CMStmt t) = CMStmt (apSubO s t)
+    apSubO s (CMrules e) = CMrules (apSubO s e)
+    apSubO s (CMinterface e) = CMinterface (apSubO s e)
+    apSubO s (CMTupleInterface pos es) = CMTupleInterface pos (apSubO s es)
+    apSubC s (CMStmt t) = changed1 CMStmt (apSubC s t)
+    apSubC s (CMrules e) = changed1 CMrules (apSubC s e)
+    apSubC s (CMinterface e) = changed1 CMinterface (apSubC s e)
+    apSubC s (CMTupleInterface pos es) =
+        Changed (CMTupleInterface pos (map (changedOrId (apSubC s)) es))
     tv (CMStmt t) = tv t
     tv (CMrules e) = tv e
     tv (CMinterface e) = tv e
     tv (CMTupleInterface pos es) = tv es
 
 instance Types CPat where
-    apSub s (CPCon c ps) = CPCon c (apSub s ps)
-    apSub s (CPstruct mb c fs) = CPstruct mb c (mapSnd (apSub s) fs)
-    apSub s p@(CPVar i) = p
-    apSub s (CPAs i p) = CPAs i (apSub s p)
-    apSub s p@(CPAny {}) = p
-    apSub s p@(CPLit l) = p
-    apSub s p@(CPMixedLit {}) = p
-    apSub s (CPCon1 ti c p) = CPCon1 ti c (apSub s p)
-    apSub s (CPConTs ti c ts ps) = CPConTs ti c (apSub s ts) (apSub s ps)
-    apSub s (CPOper os) = internalError ("CSyntaxTypes.Types(CPat).apSub: CPOper " ++ ppReadable os)
+    apSubO s (CPCon c ps) = CPCon c (apSubO s ps)
+    apSubO s (CPstruct mb c fs) = CPstruct mb c (mapSnd (apSubO s) fs)
+    apSubO s p@(CPVar i) = p
+    apSubO s (CPAs i p) = CPAs i (apSubO s p)
+    apSubO s p@(CPAny {}) = p
+    apSubO s p@(CPLit l) = p
+    apSubO s p@(CPMixedLit {}) = p
+    apSubO s (CPCon1 ti c p) = CPCon1 ti c (apSubO s p)
+    apSubO s (CPConTs ti c ts ps) = CPConTs ti c (apSubO s ts) (apSubO s ps)
+    apSubO s (CPOper os) = internalError ("CSyntaxTypes.Types(CPat).apSub: CPOper " ++ ppReadable os)
+    apSubC s (CPCon c ps) = Changed (CPCon c (map (changedOrId (apSubC s)) ps))
+    apSubC s (CPstruct mb c fs) = Changed (CPstruct mb c (mapSnd (changedOrId (apSubC s)) fs))
+    apSubC s (CPVar i) = Unchanged
+    apSubC s (CPAs i p) = changed1 (CPAs i) (apSubC s p)
+    apSubC s (CPAny {}) = Unchanged
+    apSubC s (CPLit l) = Unchanged
+    apSubC s (CPMixedLit {}) = Unchanged
+    apSubC s (CPCon1 ti c p) = changed1 (CPCon1 ti c) (apSubC s p)
+    apSubC s (CPConTs ti c ts ps) =
+        Changed (CPConTs ti c (map (changedOrId (apSubC s)) ts) (map (changedOrId (apSubC s)) ps))
+    apSubC s (CPOper os) = internalError ("CSyntaxTypes.Types(CPat).apSub: CPOper " ++ ppReadable os)
     tv (CPCon c ps) = tv ps
     tv (CPstruct _ _ fs) = tv (map snd fs)
     tv (CPVar p) = []
@@ -208,43 +307,59 @@ instance Types CPat where
     tv (CPOper os) = internalError ("CSyntaxTypes.Types(CPat).tv: CPOper " ++ ppReadable os)
 
 instance Types CDefl where
-    apSub s (CLValueSign d me) = CLValueSign (apSub s d) (apSub s me)
-    apSub s (CLValue i cs me) = CLValue i (apSub s cs) (apSub s me)
-    apSub s (CLMatch p e) = CLMatch (apSub s p) (apSub s e)
+    apSubO s (CLValueSign d me) = CLValueSign (apSubO s d) (apSubO s me)
+    apSubO s (CLValue i cs me) = CLValue i (apSubO s cs) (apSubO s me)
+    apSubO s (CLMatch p e) = CLMatch (apSubO s p) (apSubO s e)
+    apSubC s (CLValueSign d me) = Changed (CLValueSign (changedOrId (apSubC s) d) (map (changedOrId (apSubC s)) me))
+    apSubC s (CLValue i cs me) = Changed (CLValue i (map (changedOrId (apSubC s)) cs) (map (changedOrId (apSubC s)) me))
+    apSubC s (CLMatch p e) = Changed (CLMatch (changedOrId (apSubC s) p) (changedOrId (apSubC s) e))
     tv (CLValueSign d me) = tv (d, me)
     tv (CLValue i cs me) = tv (cs, me)
     tv (CLMatch p e) = tv (p, e)
 
 instance Types CQType where
-    apSub s (CQType ps t) = CQType (apSub s ps) (apSub s t)
+    apSubO s (CQType ps t) = CQType (apSubO s ps) (apSubO s t)
+    apSubC s (CQType ps t) = Changed (CQType (map (changedOrId (apSubC s)) ps) (changedOrId (apSubC s) t))
     tv (CQType ps t) = tv ps `union` tv t
 
 instance Types CPred where
-    apSub s (CPred c ts) = CPred c (apSub s ts)
+    apSubO s (CPred c ts) = CPred c (apSubO s ts)
+    apSubC s (CPred c ts) = Changed (CPred c (map (changedOrId (apSubC s)) ts))
     tv (CPred _ ts) = tv ts
 
 instance (Types t) => Types (Maybe t) where
-    apSub s (Just t) = Just (apSub s t)
-    apSub s Nothing = Nothing
+    apSubO s (Just t) = Just (apSubO s t)
+    apSubO s Nothing = Nothing
+    apSubC s mt = mapMaybeChanged (apSubC s) mt
     tv (Just t) = tv t
     tv Nothing = []
 
 instance (Types a, Types b) => Types (a, b) where
-    apSub s (a, b) = (apSub s a, apSub s b)
+    apSubO s (a, b) = (apSubO s a, apSubO s b)
+    apSubC s (a, b) = changed2 (,) a b (apSubC s a) (apSubC s b)
     tv (a, b) = tv a `union` tv b
 
 instance (Types a, Types b, Types c) => Types (a, b, c) where
-    apSub s (a, b, c) = (apSub s a, apSub s b, apSub s c)
+    apSubO s (a, b, c) = (apSubO s a, apSubO s b, apSubO s c)
+    apSubC s (a, b, c) =
+        changed3 (,,) a b c (apSubC s a) (apSubC s b) (apSubC s c)
     tv (a, b, c) = tv a `union` tv b `union` tv c
 
 instance (Types a, Types b, Types c, Types d) => Types (a, b, c, d) where
-    apSub s (a, b, c, d) = (apSub s a, apSub s b, apSub s c, apSub s d)
+    apSubO s (a, b, c, d) = (apSubO s a, apSubO s b, apSubO s c, apSubO s d)
+    apSubC s (a, b, c, d) =
+        changed2 (\(a', b') (c', d') -> (a', b', c', d')) (a, b) (c, d)
+                 (apSubC s (a, b)) (apSubC s (c, d))
     tv (a, b, c, d) = tv a `union` tv b `union` tv c `union` tv d
 
 instance Types CCaseArm where
-    apSub subst arm =
-        CCaseArm { cca_pattern = apSub subst (cca_pattern arm),
-                   cca_filters = apSub subst (cca_filters arm),
-                   cca_consequent = apSub subst (cca_consequent arm) }
+    apSubO subst arm =
+        CCaseArm { cca_pattern = apSubO subst (cca_pattern arm),
+                   cca_filters = apSubO subst (cca_filters arm),
+                   cca_consequent = apSubO subst (cca_consequent arm) }
+    apSubC s arm =
+        Changed (CCaseArm { cca_pattern = (changedOrId (apSubC s) (cca_pattern arm)),
+                            cca_filters = (map (changedOrId (apSubC s)) (cca_filters arm)),
+                            cca_consequent = (changedOrId (apSubC s) (cca_consequent arm)) })
     tv arm = tv (cca_pattern arm) `union` tv (cca_filters arm) `union`
              tv (cca_consequent arm)

--- a/src/comp/Changed.hs
+++ b/src/comp/Changed.hs
@@ -53,3 +53,17 @@ changed3 f     _     _     _ (Changed a') (Changed b') (Changed c') = Changed $ 
 mapMaybeChanged :: (a -> Changed a) -> Maybe a -> Changed (Maybe a)
 mapMaybeChanged _ Nothing  = Unchanged
 mapMaybeChanged f (Just x) = changed1 Just (f x)
+
+-- Map a function returning Changed over a list - returns Unchanged
+-- (sharing the original spine and elements) only if every element is
+-- unchanged.  NB this forces the whole list to decide; use only where
+-- the result is fully consumed or the list is bounded.
+{-# INLINE mapChanged #-}
+mapChanged :: (a -> Changed a) -> [a] -> Changed [a]
+mapChanged _ [] = Unchanged
+mapChanged f xs0@(x:xs) = changed2 (:) x xs (f x) (mapChanged f xs)
+
+-- Map over the snd of each assoc-list pair.
+{-# INLINE mapSndChanged #-}
+mapSndChanged :: (b -> Changed b) -> [(a, b)] -> Changed [(a, b)]
+mapSndChanged f = mapChanged (\ (k, v) -> changed1 ((,) k) (f v))

--- a/src/comp/ContextErrors.hs
+++ b/src/comp/ContextErrors.hs
@@ -15,7 +15,7 @@ import PFPrint
 
 import Pred
 
-import Subst(Types(..))
+import Subst(Types(..), apSub)
 import TIMonad
 import TCMisc
 import Unify

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -137,6 +137,7 @@ data Flags = Flags {
         unsafeAlwaysRdy :: Bool,
         unSpecTo :: String,
         updCheck :: Bool,
+        useApSubC :: Bool,
         useDPI :: Bool,
         useNegate :: Bool,
         usePrelude :: Bool,

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -637,6 +637,7 @@ defaultFlags bluespecdir = Flags {
         unsafeAlwaysRdy = False,
         unSpecTo = "A",
         updCheck = False,
+        useApSubC = False,
         useDPI = False,
         useNegate = True,
         usePrelude = True,
@@ -1098,6 +1099,10 @@ externalFlags = [
         ("aggressive-conditions",
          (Toggle (\f x -> f {aggImpConds=x}) (showIfTrue aggImpConds),
           "construct implicit conditions aggressively", Visible)),
+
+        ("apsubc",
+         (Toggle (\f x -> f {useApSubC=x}) (showIfTrue useApSubC),
+          "use change-tracking substitution (apSubC) in the typechecker", Hidden)),
 
         ("bdir",
          (Arg "dir" (\f s -> Left (f {bdir = Just s}))
@@ -1938,6 +1943,7 @@ showFlagsRaw flags =
           ("unsafeAlwaysRdy", show (unsafeAlwaysRdy flags)),
           ("unSpecTo", show (unSpecTo flags)),
           ("updCheck", show (updCheck flags)),
+          ("useApSubC", show (useApSubC flags)),
           ("useDPI", show (useDPI flags)),
           ("useNegate", show (useNegate flags)),
           ("usePrelude", show (usePrelude flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260712-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-7"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,7 +561,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133) =
+                a_130 a_131 a_132 a_133 a_134) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
       where
@@ -612,7 +612,7 @@ instance Bin Flags where
         wr_chunk8 =
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-             toBin a_130; toBin a_131; toBin a_132; toBin a_133
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -631,7 +631,7 @@ instance Bin Flags where
           (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-           a_128, a_129, a_130, a_131, a_132, a_133) <- rd_chunk8
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +646,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133)
+                a_130 a_131 a_132 a_133 a_134)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -708,9 +708,9 @@ instance Bin Flags where
         rd_chunk8 =
           do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin
+             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin; a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-                     a_128, a_129, a_130, a_131, a_132, a_133)
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
 
 -- ----------
 

--- a/src/comp/GenWrap.hs
+++ b/src/comp/GenWrap.hs
@@ -40,7 +40,7 @@ import VModInfo(VSchedInfo, VPathInfo(..), VeriPortProp(..), VArgInfo(..),
 import Type hiding (isPrimAction, isActionValue, getAVType,
                     isReset, isClock, isInout)
 import TypeCheck(cCtxReduceDef)
-import Subst(mkSubst, Types(..))
+import Subst(mkSubst, Types(..), apSub)
 import Classic(isClassic)
 import Pragma
 import PragmaCheck

--- a/src/comp/ISyntaxSubst.hs
+++ b/src/comp/ISyntaxSubst.hs
@@ -455,7 +455,3 @@ eSubstBatch norm exprMap typeMap e
                         ftx = S.unions $ M.elems $ M.map fTVars typeMap
                     in eSubstWith (BatchExpr exprMap fvx) (BatchTypeNorm typeMap ftx norm) (fvx `S.union` ftx `S.union` aVars e) e
 
-{-# INLINE mapChanged #-}
-mapChanged :: (a -> Changed a) -> [a] -> Changed [a]
-mapChanged _ [] = Unchanged
-mapChanged f xs0@(x:xs) = changed2 (:) x xs (f x) (mapChanged f xs)

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -15,6 +15,7 @@ import Prelude hiding ((<>))
 
 import Data.List(union, genericSplitAt, genericLength)
 import Data.Maybe(fromMaybe, isNothing)
+import Changed
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -52,7 +53,7 @@ instance PVPrint t => PVPrint (Qual t) where
     pvPrint d p (ps :=> t) = pvparen (p>0) $ pvPrint d 0 t <+> pvPreds d (map removePredPositions ps)
 
 instance Types t => Types (Qual t) where
-    apSub s q = fromMaybe q (apSubM s q)
+    apSubO s q = fromMaybe q (apSubM s q)
     -- local changed-detection: contexts are short, so forcing the
     -- element results here is cheap and buys whole-value sharing
     apSubM s (ps :=> t) =
@@ -61,6 +62,13 @@ instance Types t => Types (Qual t) where
         in  if all isNothing mps && isNothing mt
             then Nothing
             else Just (zipWith fromMaybe ps mps :=> fromMaybe t mt)
+    -- NB deliberately lazy (always Changed): schemes are substituted
+    -- far more often than their contexts are consumed, so forcing the
+    -- context list here to detect unchanged-ness costs more than the
+    -- sharing it buys (measured +50% typecheck on a register-heavy
+    -- module).  Element-level sharing still comes from apSubC.
+    apSubC s (ps :=> t) =
+        Changed (map (changedOrId (apSubC s)) ps :=> changedOr t (apSubC s t))
     tv      (ps :=> t) = tv ps `union` tv t
 
 instance (NFData a) => NFData (Qual a) where
@@ -111,11 +119,13 @@ instance PVPrint PredWithPositions where
     pvPrint d p (PredWithPositions pred _) = pvPrint d p pred
 
 instance Types PredWithPositions where
-    apSub s pwp = fromMaybe pwp (apSubM s pwp)
+    apSubO s pwp = fromMaybe pwp (apSubM s pwp)
     apSubM s (PredWithPositions p poss) =
         case apSubM s p of
           Nothing -> Nothing
           Just p' -> Just (PredWithPositions p' poss)
+    apSubC s (PredWithPositions p poss) =
+        changed1 (\p' -> PredWithPositions p' poss) (apSubC s p)
     tv      (PredWithPositions p poss) = tv p
 
 instance NFData PredWithPositions where
@@ -134,7 +144,7 @@ instance PVPrint Pred where
     pvPrint d p (IsIn c ts) = pvparen (p>0) $ pvpId d (typeclassId $ name c) <> pvParameterTypes d ts
 
 instance Types Pred where
-    apSub s p = fromMaybe p (apSubM s p)
+    apSubO s p = fromMaybe p (apSubM s p)
     -- expandSyn re-normalizes only when the substitution actually
     -- introduced new structure; an untouched pred is already expanded
     -- (preds are synonym-expanded at construction)
@@ -143,6 +153,15 @@ instance Types Pred where
         in  if all isNothing mts
             then Nothing
             else Just (IsIn c (expandSyn <$> zipWith fromMaybe ts mts))
+    -- NB deliberately lazy (always Changed): substitution over a pred
+    -- must be an O(1) thunk -- the satisfy stream substitutes every
+    -- residual pred every round and demands types selectively, so
+    -- eager per-element detection walks far more type structure than
+    -- is consumed (measured +25% typecheck on a register-heavy
+    -- module).  Per-element sharing still comes from apSubC; expandSyn
+    -- re-normalizes lazily on rebuild exactly as it always has.
+    apSubC s (IsIn c ts) =
+        Changed (IsIn c (map (expandSyn . changedOrId (apSubC s)) ts))
     tv      (IsIn c ts) = tv ts
 
 instance NFData Pred where
@@ -253,7 +272,16 @@ expandSynPred :: Pred -> Pred
 expandSynPred (IsIn c ts) = IsIn c (map expandSyn ts)
 
 instance Types Inst where
-    apSub s (Inst e _ i pkg) = Inst (apSub s e) [] (apSub s i) pkg
+    -- The tv cache is the freshening domain consumed by newInst BEFORE
+    -- substitution; the only apSub at this type is inside newInst
+    -- itself, and nothing ever reads the cache of a substituted Inst
+    -- (byInst and the fundep checks wildcard it).  [] is therefore the
+    -- cheapest correct value -- not a semantic signal.  (mkImpliedInst
+    -- constructs an empty cache deliberately, but that is a
+    -- construction-time choice independent of this instance.)
+    apSubO s (Inst e _ i pkg) = Inst (apSubO s e) [] (apSubO s i) pkg
+    apSubC s (Inst e _ i pkg) =
+        Changed (Inst (changedOrId (apSubC s) e) [] (changedOrId (apSubC s) i) pkg)
     tv (Inst _ vs _ _) = vs
 
 {-

--- a/src/comp/Scheme.hs
+++ b/src/comp/Scheme.hs
@@ -8,6 +8,7 @@ import Prelude hiding ((<>))
 import CType
 import Type
 import Subst
+import Changed
 import Pred
 import PFPrint
 import Position(noPosition, HasPosition(..))
@@ -29,7 +30,8 @@ instance PVPrint Scheme where
     (zip (map (TGen noPosition) [0..]) ks)
 
 instance Types Scheme where
-    apSub s (Forall ks qt) = Forall ks (apSub s qt)
+    apSubO s (Forall ks qt) = Forall ks (apSubO s qt)
+    apSubC s (Forall ks qt) = changed1 (Forall ks) (apSubC s qt)
     tv      (Forall ks qt) = tv qt
 
 instance NFData Scheme where

--- a/src/comp/SolvedBinds.hs
+++ b/src/comp/SolvedBinds.hs
@@ -27,6 +27,7 @@ import PPrint
 import Position
 import Pred(Class, Pred)
 import Subst
+import Changed
 
 -- Dictionary binding representation
 -- The CExpr produces the dictionary value by constructing it or referring to another dictionary
@@ -82,7 +83,14 @@ data SolvedBinds = SolvedBinds {
 } deriving (Show)
 
 instance Types SolvedBinds where
-  apSub s sbs = sbs {
+  apSubO s sbs = sbs {
+    recursiveBinds = [ ((i, apSubO s t, apSubO s e), fv) | ((i, t, e), fv) <- recursiveBinds sbs ],
+    nonRecursiveBinds = [ ((i, apSubO s t, apSubO s e), fv) | ((i, t, e), fv) <- nonRecursiveBinds sbs ],
+    bindTypes = M.map (apSubO s) (bindTypes sbs)
+  }
+  -- always rebuilt: the bind lists embed CExprs whose Types instance
+  -- offers no sharing, so detection would force everything for nothing
+  apSubC s sbs = Changed $ sbs {
     recursiveBinds = [ ((i, apSub s t, apSub s e), fv) | ((i, t, e), fv) <- recursiveBinds sbs ],
     nonRecursiveBinds = [ ((i, apSub s t, apSub s e), fv) | ((i, t, e), fv) <- nonRecursiveBinds sbs ],
     bindTypes = M.map (apSub s) (bindTypes sbs)

--- a/src/comp/StdPrel.hs
+++ b/src/comp/StdPrel.hs
@@ -27,7 +27,7 @@ import Type
 import Pred
 import PreIds
 import CSyntax
-import Subst(Types(..))
+import Subst(Types(..), apSub)
 import Unify(mgu)
 
 --import PPrint

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -2,13 +2,14 @@
 module Subst(
              Subst,
              nullSubst, isNullSubst, (+->), mkSubst,
-             Types(..), (@@), merge, mergeWith, mergeListWith,
+             Types(..), apSub, setUseApSubC,
+             (@@), merge, mergeWith, mergeListWith,
              mergeAgreements,
              trimSubst, trimSubstByVars,
              {- removeFromSubst, -}
              apSubstToSubst,
              getSubstDomain, getSubstRange, sizeSubst,
-             substDomainDisjoint,
+             substDomainDisjoint, substFVsUpdate,
              chkSubstOrder
              ) where
 
@@ -17,8 +18,11 @@ import CType
 import Type
 import Util(fromJustOrErr)
 import Data.List(nub,union)
-import Data.Maybe(fromMaybe, isNothing)
+import Data.Maybe(fromMaybe)
+import Changed
 import Position
+import IOMutVar(MutableVar, newVar, readVar, writeVar)
+import System.IO.Unsafe(unsafePerformIO)
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
@@ -198,22 +202,60 @@ mergeAgreements s1 s2 = fj $ merge diff1 diff2
 
 -------
 
+-- Substitution comes in two selectable implementations, chosen by the
+-- -apsubc flag (default off):
+--
+--  * apSubO/apSubM: the pre-apsubc pair.  apSubO rebuilds the value;
+--    apSubM is Maybe-based change tracking (Nothing means the
+--    substitution provably left the value untouched).  Instances
+--    without a hand-written apSubM get the conservative "always
+--    changed" default.  These keep exactly the behavior that predates
+--    apSubC; internal recursion in the old-path instance bodies stays
+--    on apSubO/apSubM.
+--
+--  * apSubC: change-tracking substitution.  Unchanged means the
+--    substitution provably left the value untouched, so the caller
+--    keeps the original object (preserving sharing and skipping any
+--    rebuild).  ALL internal recursion goes through apSubC and
+--    combines child results with the Changed combinators, so
+--    unchanged-ness propagates bottom-up with no per-node wrapper
+--    allocation.
+--
+-- apSub (below, outside the class) is the consumer-facing entry point
+-- and dispatches on the flag.
 class Types t where
-  apSub :: Subst -> t -> t
-  apSub s t = fromMaybe t (apSubM s t)
-  -- Change-tracking substitution: Nothing means the substitution
-  -- provably left the value untouched, so the caller keeps the
-  -- original object (preserving sharing and skipping any rebuild or
-  -- re-normalization).  Instances without a hand-written apSubM get
-  -- the conservative "always changed" default; new hot-path consumers
-  -- should define apSubM and derive apSub from it.
+  apSubO :: Subst -> t -> t
+  apSubO s t = fromMaybe t (apSubM s t)
   apSubM :: Subst -> t -> Maybe t
-  apSubM s t = Just (apSub s t)
-  tv    :: t -> [TyVar]
-  {-# MINIMAL (apSub | apSubM), tv #-}
+  apSubM s t = Just (apSubO s t)
+  apSubC :: Subst -> t -> Changed t
+  tv     :: t -> [TyVar]
+  {-# MINIMAL (apSubO | apSubM), apSubC, tv #-}
+
+-- The -apsubc switch: written once, from the decoded flags, before
+-- compilation starts (bsc.hs main'), and read through a function of ()
+-- so that GHC cannot cache the read as a CAF (same pattern as
+-- Classic.isClassic).
+useApSubCVar :: MutableVar Bool
+useApSubCVar = unsafePerformIO $ newVar False
+{-# NOINLINE useApSubCVar #-}
+
+setUseApSubC :: Bool -> IO ()
+setUseApSubC b = writeVar useApSubCVar b
+
+readUseApSubC :: () -> Bool
+readUseApSubC () = unsafePerformIO $ readVar useApSubCVar
+{-# NOINLINE readUseApSubC #-}
+
+apSub :: Types t => Subst -> t -> t
+apSub s t
+  | not (readUseApSubC ()) = apSubO s t
+  | isNullSubst s          = t
+  | otherwise              = changedOr t (apSubC s t)
+{-# INLINE apSub #-}
 
 instance Types Type where
-  apSub s t = fromMaybe t (apSubM s t)
+  apSubO s t = fromMaybe t (apSubM s t)
   apSubM s _ | isNullSubst s = Nothing
   apSubM (S seo _) t0 = go t0
     where
@@ -237,6 +279,26 @@ instance Types Type where
           (ml, mr) -> Just (normTAp (fromMaybe l ml) (fromMaybe r mr))
       go _ = Nothing
 
+  apSubC (S seo _) t0 = go t0
+    where
+      go v@(TVar u) =
+        case slookup u seo of
+        Just t  ->
+            case t of
+            (TGen _ _) -> Changed t -- (kind (TGen _ _)) errors out -- don't check kind
+            _ -> if isKVar (kind v) || kind t == kind v
+                 then Changed t
+                 else internalError ("Subst.Type.apSub: bad kind: " ++
+                                     ppString t ++ "::" ++ ppString (kind t) ++
+                                     "@" ++ ppString (getPosition t) ++
+                                     " / " ++ ppString v ++ "::" ++
+                                     ppString (kind v) ++ "@" ++
+                                     ppString (getPosition v))
+        Nothing -> Unchanged
+      -- normTAp re-runs only when a child actually changed
+      go (TAp l r) = changed2 normTAp l r (go l) (go r)
+      go _ = Unchanged
+
   tv (TVar u)  = [u]
   tv (TAp l r) = tv l `union` tv r
   tv t         = []
@@ -247,11 +309,16 @@ instance Types a => Types [a] where
   -- residual predicate sets) and force only part of the result, so an
   -- eager changed-detection over the whole list here is a large
   -- pessimization.  Element-level sharing still comes from each
-  -- element's own apSub.  Short-list containers that want whole-value
+  -- element's own apSubO.  Short-list containers that want whole-value
   -- sharing (Pred's class args, Qual's context) do their own local
   -- detection.
-  apSub s ts = map (apSub s) ts
-  tv ts      = nub (concatMap tv ts)
+  apSubO s ts = map (apSubO s) ts
+  -- Same policy on the apSubC path (always Changed): an eager
+  -- whole-list detection here (mapChanged) is a measured 2x
+  -- pessimization.  Bounded containers that want whole-value sharing
+  -- use mapChanged directly in their own instances.
+  apSubC s ts = Changed (map (changedOrId (apSubC s)) ts)
+  tv ts       = nub (concatMap tv ts)
 
 slookup :: TyVar -> S_map -> Maybe Type
 slookup v xs = {-if length xs > 1300 then trace ("slookup " ++ unwords [itos x|(_,x,_)<-xs]) slookup' v xs else-} Map.lookup v xs
@@ -276,6 +343,24 @@ substDomainDisjoint :: Subst -> Set.Set TyVar -> Bool
 substDomainDisjoint (S eo _) fvs
   | Map.null eo = True
   | otherwise   = not (any (`Map.member` eo) (Set.toAscList fvs))
+
+-- Incremental free-variable-cache maintenance: Nothing when the
+-- substitution domain is disjoint from the set (the substituted value
+-- is unchanged), otherwise the free variables of the substituted
+-- value, rebuilt from the old set plus the ranges of the entries that
+-- fired.  Sound because substitution is single-pass (range types are
+-- not re-substituted), so tv (apSub s t) = (tv t \\ dom) `union`
+-- tv (ranges hit).  O(|fvs| log n) set work per call -- never a walk
+-- of the substituted structure, so a cache can be kept current across
+-- substitution rounds at probe cost.
+substFVsUpdate :: Subst -> Set.Set TyVar -> Maybe (Set.Set TyVar)
+substFVsUpdate (S eo _) fvs
+  | Map.null eo   = Nothing
+  | Set.null hits = Nothing
+  | otherwise     = Just fvs'
+  where hits = Set.filter (`Map.member` eo) fvs
+        fvs' = Set.union (fvs Set.\\ hits)
+                         (Set.fromList (concatMap (tv . (eo Map.!)) (Set.toList hits)))
 
 getSubstRange :: Subst -> [TyVar]
 getSubstRange (S eo _ ) = concat (map tv (Map.elems eo))

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -53,6 +53,8 @@ import Control.Monad.State(State, StateT, runState, runStateT,
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Maybe(fromMaybe)
+import Changed
+import Eval(NFData(..))
 import Util(headOrErr)
 
 -------
@@ -459,12 +461,32 @@ instance Show VPred where
         showString " " . showsPrec 11 p
 
 instance Types VPred where
-    apSub s vp = fromMaybe vp (apSubM s vp)
+    apSubO s vp = fromMaybe vp (apSubM s vp)
     apSubM s vp@(VPred_ i p fvs)
       | substDomainDisjoint s fvs = Nothing
       | otherwise = case apSubM s p of
                       Nothing -> Nothing
                       Just p' -> Just (VPred i p')
+    -- The fv cache is maintained incrementally (substFVsUpdate): the
+    -- new set comes from the old one plus the substitution ranges
+    -- that fired, never from walking the (lazily substituted)
+    -- predicate.  This keeps all three consumers cheap at once:
+    -- apSub on an untouched pred is Unchanged (full sharing, cache
+    -- included), apSub on a touched pred is small set work plus an
+    -- O(1) pred thunk, and split_rs probes never force a substitution
+    -- tower.  Rebuilding the cache via the VPred builder here instead
+    -- (S.fromList . tv) is a measured ~20% regression on
+    -- proviso-heavy input.
+    -- A rebuilt pred is forced to NF immediately: Changed marks exactly
+    -- the values that would otherwise retain a substitution tower
+    -- across satisfy rounds (Unchanged preds are already in NF from
+    -- their last force), so deep-forcing here bounds residency at
+    -- tip-eager levels while untouched preds still pay nothing.
+    apSubC s (VPred_ i p fvs) =
+      case substFVsUpdate s fvs of
+        Nothing   -> Unchanged
+        Just fvs' -> let p' = changedOrId (apSubC s) p
+                     in rnf p' `seq` Changed (VPred_ i p' fvs')
     tv (VPred_ _ p _) = tv p
 
 instance PPrint VPred where
@@ -489,7 +511,8 @@ expandSynVPred (VPred i (PredWithPositions (IsIn c ts) poss)) = VPred i pwp'
 data EPred = EPred CExpr Pred
 
 instance Types EPred where
-    apSub s (EPred e p) = EPred e (apSub s p)
+    apSubO s (EPred e p) = EPred e (apSubO s p)
+    apSubC s (EPred e p) = changed1 (EPred e) (apSubC s p)
     tv (EPred _ p) = tv p
 
 instance PPrint EPred where

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -147,6 +147,7 @@ import Verilog(VProgram(..), vGetMainModName, getVeriInsts)
 import Depend
 import Version(bscVersionStr, copyright, buildnum)
 import Classic(SyntaxMode(..), setSyntax)
+import Subst(setUseApSubC)
 import ILift(iLift)
 import ACleanup(aCleanup)
 import ATaskSplice(aTaskSplice)
@@ -233,6 +234,9 @@ main' errh flags name =  do
     tStart <- getNow
 
     flags' <- checkSATFlags errh flags
+
+    -- propagate the -apsubc selection to the substitution machinery
+    setUseApSubC (useApSubC flags')
 
     -- check system requirements
     doSystemCheck errh

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -116,6 +116,7 @@ Flags {
 	unsafeAlwaysRdy = False,
 	unSpecTo = "A",
 	updCheck = False,
+	useApSubC = False,
 	useDPI = False,
 	useNegate = True,
 	usePrelude = True,


### PR DESCRIPTION
**What**: `apSubC` change-tracking substitution — substitution results report whether anything changed, so callers stop rebuilding (and re-allocating) structures the substitution didn't touch.

**GATED (rework per Ravi: "apSubC should be gated work because we don't know if it wins yet")**: hidden `-apsubc` toggle, **default off**. Off-path is behaviorally identical to the base: the `Types` class carries both implementations (`apSubO`/`apSubM` restored verbatim from tc/1 alongside `apSubC`); consumer-facing `apSub` is the single dispatch point; old-path recursion never re-consults the flag. Flag reach follows the upstream `Classic.hs` MutableVar precedent (no new flags module); set once in `main'` after flag decode; bluetcl keeps the False default.

**Serialization**: `useApSubC` field in `Flags` → `Bin Flags` arity 134→135, header tag `bsc-ba-20260804-7` (reserved slot, per-PR ledger); `print-flags-raw` golden regolded.

**Verification**: `install-src` exit 0; bsc.typechecker/typeclasses **110/0 with default flags AND 110/0 with `TEST_BSC_OPTIONS=-apsubc`**; bsc.options 71/0 (validates the golden); `-help-hidden` lists the toggle. Benchmarks flag-on vs flag-off pending by design — that is what the gate is for.

**Provenance**: `0d254864` (old #37), re-expressed gated on tc/1-sharing-subst; head `ec100fb9` replaces the ungated `4db94a40`.

Stacks on #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
