### PR TITLE
bindata: hash raw .bo bytes; record poison-pill-ness in the header

### DIFF
--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -50,7 +50,7 @@ import IntLit
 import Undefined
 import Prim hiding(PrimArg(..))
 
-import Util(Hash, hashInit, nextHashByte, showHash)
+import Util(hashInit, nextHashByte, showHash)
 
 import Data.List(sort, intercalate)
 import Control.Monad(replicateM, liftM, ap)
@@ -323,10 +323,16 @@ section s action = do { beginSection s; action; endSection }
 -- The In monad makes it easy to parse a byte stream
 
 -- The In monad state keeps tables for shared structures
--- in addition to unconsumed bytes and an optional hash of
--- consumed bytes.
+-- in addition to unconsumed bytes.
+--
+-- The .bo hash is deliberately NOT threaded through here.  The decoder
+-- consumes the stream strictly sequentially and decodeWithHash proves it
+-- consumed all of it, so folding over the raw bytes gives the identical
+-- value without a Maybe test and a box allocation on every getB.  .ba
+-- reads never hashed at all (GenABin.readABinFile), so they only ever
+-- paid the extra constructor width.
 
-data IS = IS !BinTable !BS.ByteString !Int !(Maybe Hash)
+data IS = IS !BinTable !BS.ByteString !Int
 
 -- In monad is a state transformer type monad
 newtype In a = In (IS -> (a,IS))
@@ -348,14 +354,11 @@ getN :: Int -> In [Byte]
 getN n = replicateM n getB
 
 getB :: In Byte
-getB = In $ \(IS bc bs off mh) ->
+getB = In $ \(IS bc bs off) ->
   case BS.indexMaybe bs off of
     Nothing -> internalError "BinData.getB: unexpected end of byte stream"
     Just b -> let !off' = off + 1
-              in case mh of
-                   Just h -> let !h' = nextHashByte h b
-                             in (b, IS bc bs off' (Just h'))
-                   Nothing -> (b, IS bc bs off' Nothing)
+              in (b, IS bc bs off')
 
 -- get an Int value (between 0 and 255)
 getI :: In Int
@@ -408,10 +411,10 @@ mkNewVal :: (BinTable -> (Table v)) ->
             (BinTable -> (Table v) -> BinTable) ->
             In (Int,v)
 mkNewVal get set =
-  In $ \(IS bt bs off h) ->
+  In $ \(IS bt bs off) ->
           let (Known n m) = get bt
               bt' = set bt (Known (n+1) m)
-          in ((n, undefined), (IS bt' bs off h))
+          in ((n, undefined), (IS bt' bs off))
 
 -- get the right table, add a mapping from the index to the value,
 -- and put back the updated table while returning ()
@@ -419,17 +422,17 @@ mkRecordVal ::(BinTable -> (Table v)) ->
               (BinTable -> (Table v) -> BinTable) ->
               (Int -> v -> In ())
 mkRecordVal get set idx v =
-  In $ \(IS bt bs off h) ->
+  In $ \(IS bt bs off) ->
           let (Known n m) = get bt
               bt' = v `seq` set bt (Known n (M.insert idx v m))
-          in ((), (IS bt' bs off h))
+          in ((), (IS bt' bs off))
 
 
 -- get the right table and look up the value for the given index
 mkLookupIdx ::(BinTable -> (Table v)) ->
               (Int -> In v)
 mkLookupIdx get idx =
-  In $ \is@(IS bt _ _ _) ->
+  In $ \is@(IS bt _ _) ->
           let (Known _ m) = get bt
           in case (M.lookup idx m) of
                (Just v) -> (v, is)
@@ -1527,21 +1530,24 @@ runOut (Out xs _) = let bes   = compress $ toList xs
 encode :: (Bin a) => a -> [Byte]
 encode x = runOut (toBin x)
 
-runIn :: In a -> BS.ByteString -> Bool -> (a, Int, String)
-runIn (In f) bs do_hash =
-  let h0 = if do_hash then (Just hashInit) else Nothing
-      (x,(IS _ _ off h)) = f (IS unknownTable bs 0 h0)
-      hstr = maybe "" showHash h
-  in (x, off, hstr)
+runIn :: In a -> BS.ByteString -> (a, Int)
+runIn (In f) bs =
+  let (x,(IS _ _ off)) = f (IS unknownTable bs 0)
+  in (x, off)
 
 decode :: (Bin a) => BS.ByteString -> a
-decode s = let (x, off, _) = runIn fromBin s False
+decode s = let (x, off) = runIn fromBin s
            in if off == BS.length s
               then x
               else internalError "BinData.decode: unused trailing bytes"
 
+-- The hash is a fold over the byte stream in consumption order.  getB
+-- advances strictly forward and never revisits a byte (shared structures are
+-- table indices, not byte offsets), and the offset check proves the decoder
+-- consumed exactly s -- so this is the same value the old
+-- threaded-through-IS hash produced, for every existing .bo.
 decodeWithHash :: (Bin a) => BS.ByteString -> (a,String)
-decodeWithHash s = let (x, off, hstr) = runIn fromBin s True
+decodeWithHash s = let (x, off) = runIn fromBin s
                    in if off == BS.length s
-                      then (x, hstr)
+                      then (x, showHash (BS.foldl' nextHashByte hashInit s))
                       else internalError "BinData.decodeWithHash: unused trailing bytes"

--- a/src/comp/BinUtil.hs
+++ b/src/comp/BinUtil.hs
@@ -181,23 +181,19 @@ doImport errh flags hashmap i = do
     (file, name) <- fromMaybeM (bsError errh [missingErr]) $
                       readBinFilePath errh (getIdPosition i)
                           (verbose flags) binname (ifcPath flags)
-    (bi_sig, bo_sig, ipkg@(IPackage pi impHashes _ _ _), hash)
+    (bi_sig, bo_sig, ipkg@(IPackage pi impHashes _ _ _), hash, pill)
         <- readBinFile errh name file
     when (pi /= i) $
         bsError errh [(noPosition, EBinFilePkgNameMismatch name
                                        (pfpString i) (pfpString pi))]
-    when (any hasPoisonPill [ e | IDef _ _ e _ <- ipkg_defs ipkg ]) $
+    -- The writer recorded this in the header (GenBin.pillByte); the severity
+    -- is still the importer's call.  The message never named the offending
+    -- def, so the flag reproduces the old diagnostic exactly.
+    when pill $
         pillMsg [(getIdPosition pi, WPoisonedDefFile binname)]
     hashmap' <- mergeHashes errh hashmap pi hash impHashes
     let impNames = map fst impHashes
     return (name, bi_sig, bo_sig, ipkg, hash, hashmap', impNames)
-
-hasPoisonPill :: IExpr a -> Bool
-hasPoisonPill (ILam _ _ e)  = hasPoisonPill e
-hasPoisonPill (ILAM _ _ e)  = hasPoisonPill e
-hasPoisonPill (IAps f _ es) = any hasPoisonPill (f:es)
-hasPoisonPill (ICon _ (ICPrim _ p)) = p == PrimPoisonedDef
-hasPoisonPill _ = False
 
 mergeHashes :: ErrorHandle -> HashMap -> Id -> String -> [(Id, String)] ->
                IO HashMap

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -10,7 +10,7 @@ import Position
 import Pragma
 import Error(internalError, ErrMsg(..), ErrorHandle, bsError)
 import ISyntax
-import ISyntaxUtil(icUndet)
+import ISyntaxUtil(icUndet, pkgHasPoisonPill)
 import CSyntax
 import Undefined(UndefKind(UNoMatch))
 import BinData
@@ -26,24 +26,35 @@ doTrace = elem "-trace-genbin" progArgs
 -- .bo file tag -- change this whenever the .bo format changes
 -- See also GenABin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260714-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-1"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
 
+-- One flag byte follows the tag, ahead of the payload: does this package
+-- contain a poisoned definition?  Importers used to answer that by walking
+-- every IExpr of every def (BinUtil.doImport), on every import of every
+-- package in the transitive closure, to compute something the writer already
+-- knew.  Keeping it outside the payload means an importer can answer without
+-- decoding anything -- which is also what lets ipkg_defs be read lazily.
+pillByte :: Bool -> Byte
+pillByte p = if p then 1 else 0
+
 genBinFile :: ErrorHandle ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()
 genBinFile errh fn bi_sig bo_sig ipkg =
-    writeBinaryFileCatch errh fn (header ++ encode (bi_sig, bo_sig, ipkg))
+    writeBinaryFileCatch errh fn
+        (header ++ pillByte (pkgHasPoisonPill ipkg) : encode (bi_sig, bo_sig, ipkg))
 
 readBinFile :: ErrorHandle -> String -> B.ByteString ->
-               IO (CSignature, CSignature, IPackage a, String)
+               IO (CSignature, CSignature, IPackage a, String, Bool)
 readBinFile errh nm s =
     let hlen = B.length headerBS
-    in if B.take hlen s == headerBS
-       then let ((bi_sig, bo_sig, ipkg), hash) =
-                    decodeWithHash $ B.drop hlen s
-            in return (bi_sig, bo_sig, ipkg, hash)
+    in if B.take hlen s == headerBS && B.length s > hlen
+       then let pill = B.index s hlen /= 0
+                ((bi_sig, bo_sig, ipkg), hash) =
+                    decodeWithHash $ B.drop (hlen + 1) s
+            in return (bi_sig, bo_sig, ipkg, hash, pill)
        else bsError errh [(noPosition, EBinFileVerMismatch nm)]
 
 -- ----------

--- a/src/comp/ISyntaxUtil.hs
+++ b/src/comp/ISyntaxUtil.hs
@@ -1170,3 +1170,21 @@ emptyFmt = (IAps (ICon idFormat (ICForeign {fName    = getIdString(unQualId(idFo
    where e = iMkString ""
          t = iGetType e
          tt = (t `itFun` itFmt)
+
+-- Does an expression contain a poisoned definition?  A .bo carrying one was
+-- written by a compile that failed and continued under -enable-poison-pills,
+-- so importing it is an error unless the importer opted in too.  Computed at
+-- write time and recorded in the .bo header (GenBin) rather than rediscovered
+-- by every importer: the scan walks every IExpr of every package in the
+-- transitive closure, and with pills disabled -- the default, and MatX never
+-- enables them -- it can only ever return False.
+hasPoisonPill :: IExpr a -> Bool
+hasPoisonPill (ILam _ _ e)  = hasPoisonPill e
+hasPoisonPill (ILAM _ _ e)  = hasPoisonPill e
+hasPoisonPill (IAps f _ es) = any hasPoisonPill (f:es)
+hasPoisonPill (ICon _ (ICPrim _ p)) = p == PrimPoisonedDef
+hasPoisonPill _ = False
+
+-- Does any definition in the package carry a poison pill?
+pkgHasPoisonPill :: IPackage a -> Bool
+pkgHasPoisonPill ipkg = any hasPoisonPill [ e | IDef _ _ e _ <- ipkg_defs ipkg ]

--- a/src/comp/dumpbo.hs
+++ b/src/comp/dumpbo.hs
@@ -21,7 +21,7 @@ main = do
                        _ -> do putStr ("Usage: dumpbo [-bi] mod-id\n")
                                exitWith (ExitFailure 1)
     file <- BS.readFile fname
-    (bi_sig, bo_sig, ipkg, hash) <- readBinFile errh fname file
+    (bi_sig, bo_sig, ipkg, hash, _pill) <- readBinFile errh fname file
     hSetEncoding stdout utf8
     if (isBI)
        then do putStr (ppReadable bi_sig)


### PR DESCRIPTION
Serialization window 1/5 (II-17). Re-expressed strict-encode (no Builder yet — arrives in 5/5). .bo tags: bsc-bo-20260804-1. Builds; bsc.binary clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt