### PR TITLE
typecheck: declaration-level import-use tracking

### DIFF
--- a/src/comp/CtxRed.hs
+++ b/src/comp/CtxRed.hs
@@ -35,7 +35,7 @@ doTraceCtxReduce = "-trace-ctxreduce" `elem` progArgs
 --    while solving contexts (merged with the cache from typecheck in
 --    bsc.hs and threaded through iConvPackage into elaboration)
 cCtxReduceIO :: ErrorHandle -> Flags -> SymTab -> CPackage ->
-               IO (CPackage, S.Set Id, CATFCache)
+               IO (CPackage, S.Set Id, S.Set (Id, Id), CATFCache)
 cCtxReduceIO errh flags s (CPackage mi exps imps impsigs fixs ds includes) = do
     -- The False argument to 'runTI' indicates that incoherent instances should not be matched at this time
     -- We want to preserve those contexts to be handled in typecheck (XXX why?)
@@ -44,7 +44,8 @@ cCtxReduceIO errh flags s (CPackage mi exps imps impsigs fixs ds includes) = do
     case tiResult ti_res of
       Left emsgs -> bsError errh emsgs
       Right ds' -> return (CPackage mi exps imps impsigs fixs ds' includes,
-                           tiUsedPackages ti_res, tiATFCache ti_res)
+                           tiUsedPackages ti_res,
+                           tiUsedDecls ti_res, tiATFCache ti_res)
 
 cCtxReduceDef :: Flags -> SymTab -> CDefn -> Either [EMsg] CDefn
 cCtxReduceDef flags s def =

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -466,6 +466,7 @@ traceflags = [
           "trace-atf-cache-miss",
           "trace-ctxreduce",
           "trace-debug",
+          "dump-usage",
           "trace-eval-steps",
           "trace-eval-types",
           "trace-eval-if",

--- a/src/comp/GenSign.hs
+++ b/src/comp/GenSign.hs
@@ -1,4 +1,4 @@
-module GenSign(genUserSign, genEverythingSign) where
+module GenSign(genUserSign, genEverythingSign, getDeclsUsedByExports) where
 import Data.List((\\), sortBy, unionBy, groupBy, partition)
 import Data.Maybe(mapMaybe)
 import qualified Data.Map as M
@@ -734,21 +734,29 @@ classToIClass i k (Class { csig=tvs, super=ps, funDeps2=bss2,
 -- tracked during type checking (Phase 2). For re-exports, only record the package
 -- of the item itself, not types within its definition.
 getPackagesUsedByExports :: Id -> CSignature -> S.Set Id
-getPackagesUsedByExports currentPkg (CSignature _ _ _ defns) =
-    let allPkgs = mapMaybe getPackageFromDefn defns
-        externalPkgs = filter (/= currentPkg) allPkgs
-    in  S.fromList externalPkgs
+getPackagesUsedByExports currentPkg sig =
+    S.map fst (getDeclsUsedByExports currentPkg sig)
+
+-- As getPackagesUsedByExports, but keeping the declaration.  Re-exporting a
+-- declaration is a dependency on it: this package's own interface changes
+-- when it does.  Recording only the package would leave a cutoff hole --
+-- nothing else in the re-exporting package need mention the declaration at
+-- all, so no other usage source sees it.
+getDeclsUsedByExports :: Id -> CSignature -> S.Set (Id, Id)
+getDeclsUsedByExports currentPkg (CSignature _ _ _ defns) =
+    S.fromList [ pd | Just pd <- map getPackageFromDefn defns
+                    , fst pd /= currentPkg ]
   where
-    -- Get the package qualifier from a qualified Id
-    getIdPackage :: Id -> Maybe Id
+    -- Get the package qualifier from a qualified Id, with the Id itself
+    getIdPackage :: Id -> Maybe (Id, Id)
     getIdPackage i =
         let qual = getIdQual i
         in  if qual == fsEmpty
             then Nothing
-            else Just (mk_no qual)
+            else Just (mk_no qual, i)
 
     -- Get the package of the item being exported (not types within its definition)
-    getPackageFromDefn :: CDefn -> Maybe Id
+    getPackageFromDefn :: CDefn -> Maybe (Id, Id)
     getPackageFromDefn (Ctype (IdKind i _) _ _) = getIdPackage i
     getPackageFromDefn (CItype (IdKind i _) _ _) = getIdPackage i
     getPackageFromDefn (Cdata { cd_name = IdKind i _ }) = getIdPackage i

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -3,6 +3,7 @@
 module MakeSymTab(
                   mkSymTab,
                   getPackagesUsedInTypes,
+                  getDeclsUsedInTypes,
                   cConvInst,
                   convCQType, convCQTypeWithAssumps,
                   convCType,
@@ -236,6 +237,25 @@ getPackagesUsedInTypes :: SymTab -> CPackage -> S.Set Id
 getPackagesUsedInTypes symtab (CPackage _ _ _ _ _ ds _) =
     let directTyCons = S.unions (map getFTCDn ds)
     in  S.unions (map (getPackagesForType symtab) (S.toList directTyCons))
+
+-- As getPackagesUsedInTypes, but keeping the type constructor alongside its
+-- package.  The package-level set can only say "something from here was
+-- used"; cutoff needs to know which declaration, so that a change to an
+-- unused one does not invalidate this package.
+getDeclsUsedInTypes :: SymTab -> CPackage -> S.Set (Id, Id)
+getDeclsUsedInTypes symtab (CPackage _ _ _ _ _ ds _) =
+    let directTyCons = S.unions (map getFTCDn ds)
+    in  S.unions (map (getDeclsForType symtab) (S.toList directTyCons))
+
+getDeclsForType :: SymTab -> Id -> S.Set (Id, Id)
+getDeclsForType symtab tycon =
+    case findType symtab tycon of
+        Just (TypeInfo { ti_pkg = Just pkg, ti_sort = TItype _ rhs }) ->
+            let rhsTyCons = getFTyCons rhs
+                rec' = S.unions (map (getDeclsForType symtab) (S.toList rhsTyCons))
+            in  S.insert (pkg, tycon) rec'
+        Just (TypeInfo { ti_pkg = Just pkg }) -> S.singleton (pkg, tycon)
+        _ -> S.empty
 
 -- For a type constructor, get its source package and recursively expand
 -- if it's a type synonym. Non-synonym types (data, struct, abstract) are

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -836,7 +836,7 @@ findAssump i as =
         case findVar s i of
          Nothing -> errorAtId EUnboundVar i
          Just (VarInfo _ a d pkg) -> do
-            recordPackageUse pkg
+            recordDeclUse pkg i
             case d of
                 Nothing -> return ()
                 Just str -> twarn (getPosition i,

--- a/src/comp/TIMonad.hs
+++ b/src/comp/TIMonad.hs
@@ -18,7 +18,7 @@ module TIMonad(
         literalCls, realLiteralCls, sizedLiteralCls, stringLiteralCls,
         numEqCls,
         updAssumpPos,
-        recordPackageUse, recordATFResult,
+        recordPackageUse, recordDeclUse, recordATFResult,
         incrementSatStack, decrementSatStack, getSatStack, mkTSSatElement, TSSatElement,
               pushSatStackContext, popSatStackContext
         , tiRecoveringFromError
@@ -77,6 +77,10 @@ data TStatePersistent = TStatePersistent {
    tsAllowIncoherent :: Bool,
    tsWarns :: [WMsg], -- accumulated warning messages
    tsUsedPackages :: S.Set Id, -- packages from which symbols were used
+   -- the individual declarations resolved from imported packages; the
+   -- per-package set above cannot support cutoff, since any change to
+   -- any declaration of an import invalidates every dependent
+   tsUsedDecls :: S.Set (Id, Id),
    tsATFCache :: CATFCache
 }
 
@@ -155,6 +159,7 @@ initPersistentState flags ai s = TStatePersistent {
     tsAllowIncoherent = ai,
     tsRecoveredErrors = [],
     tsUsedPackages = S.empty,
+    tsUsedDecls = S.empty,
     tsATFCache = M.empty
   }
 
@@ -170,6 +175,7 @@ data TIResult a = TIResult {
     tiResult       :: Either [EMsg] a,
     tiWarnings     :: [WMsg],
     tiUsedPackages :: S.Set Id,
+    tiUsedDecls    :: S.Set (Id, Id),
     tiATFCache     :: CATFCache
   }
 
@@ -178,6 +184,7 @@ runTI flags ai s m = TIResult {
     tiResult       = mkFinalResult result rec_errors,
     tiWarnings     = tsWarns pState,
     tiUsedPackages = tsUsedPackages pState,
+    tiUsedDecls    = tsUsedDecls pState,
     tiATFCache     = tsATFCache pState
   }
   where (result, pState) = runTIState flags ai s m
@@ -274,6 +281,16 @@ recordPackageUse :: Maybe Id -> TI ()
 recordPackageUse Nothing = return ()  -- no package to record
 recordPackageUse (Just pkg) = lift (modify (addPackage pkg))
   where addPackage pkg s = s { tsUsedPackages = S.insert pkg (tsUsedPackages s) }
+
+-- Record both the package and the specific declaration resolved from it.
+-- Instance resolution has no named declaration to record and keeps using
+-- recordPackageUse: an instance applies without being mentioned, so it can
+-- only ever be tracked conservatively.
+recordDeclUse :: Maybe Id -> Id -> TI ()
+recordDeclUse Nothing _ = return ()
+recordDeclUse (Just pkg) d = lift (modify add)
+  where add s = s { tsUsedPackages = S.insert pkg (tsUsedPackages s)
+                  , tsUsedDecls    = S.insert (pkg, d) (tsUsedDecls s) }
 
 recordATFResult :: Id -> [Type] -> Type -> TI ()
 recordATFResult atfId args result =
@@ -480,7 +497,7 @@ findCons ct i = do
     r <- getSymTab
     case findConVis r i of
      Just [ConInfo { ci_id = ti, ci_assump = a, ci_pkg = pkg }] -> do
-        recordPackageUse pkg
+        recordDeclUse pkg ti
         return (updAssumpPos i a, ti)
      Just cs -> do
         s <- getSubst
@@ -489,7 +506,7 @@ findCons ct i = do
          Nothing -> errorAtId (EConstrAmb (pfpString ct')) i
          Just di -> case [ (a, pkg) | ConInfo {ci_id = i', ci_assump = a, ci_pkg = pkg} <- cs, qualEq di i'] of
                    [(a, pkg)] -> do
-                       recordPackageUse pkg
+                       recordDeclUse pkg di
                        return (updAssumpPos i a, di)
                    []  -> errSuggest r i
                    _   -> internalError "findCons ambig"
@@ -508,7 +525,7 @@ findTyCon i = do
     r <- getSymTab
     case findType r i of
      Just (TypeInfo (Just i') k _ ts@(TItype _ t) pkg) -> do
-        recordPackageUse pkg
+        recordDeclUse pkg i'
         -- It's a type alias.  If the left element of the alias is a
         -- constructor, find the type of that constructor; otherwise,
         -- give up and return the info that's available.
@@ -516,7 +533,7 @@ findTyCon i = do
             Just aliased_i -> findTyCon aliased_i
             Nothing -> return (TyCon i' (Just k) ts)
      Just (TypeInfo (Just i') k _ ts pkg) -> do
-        recordPackageUse pkg
+        recordDeclUse pkg i'
         return (TyCon i' (Just k) ts)
      Just (TypeInfo Nothing _ _ _ _) ->
         internalError ("findTyCon: unexpected numeric or string type: " ++ ppReadable i)
@@ -527,7 +544,7 @@ findCls i = do
     r <- getSymTab
     case findSClass r i of
      Just cl -> do
-        recordPackageUse (pkg_src cl)
+        recordDeclUse (pkg_src cl) (typeclassId i)
         return cl
      Nothing -> errorAtId EUnboundTyCon (typeclassId i)
 
@@ -671,7 +688,7 @@ findFields struct_ty0 field_id = do
                                                       fi_pkg = pkg }) <- fs,
                                         i == qtc ] of
                   [(_, a, n, pkg)] -> do
-                      recordPackageUse pkg
+                      recordDeclUse pkg qtc
                       return (updAssumpPos field_id a, qtc, n)
                   [] -> errorAtId (ENotField (pfpString qtc)) field_id
                   xs -> internalError ("findFields ambig: " ++
@@ -686,7 +703,7 @@ findFields struct_ty0 field_id = do
                 -- there is only one struct with this field
                 -- if the expression is not that type, the user will get a
                 -- mismatch error later
-                recordPackageUse pkg
+                recordDeclUse pkg qtc
                 return (updAssumpPos field_id a, qtc, n)
             Just fs ->
                 let tis = map (pfpString . fi_id) fs

--- a/src/comp/TypeCheck.hs
+++ b/src/comp/TypeCheck.hs
@@ -33,9 +33,10 @@ import CFreeVars(getFVC, getFTCC)
 import Util(separate, apFst, quote)
 
 cTypeCheck :: ErrorHandle -> Flags -> SymTab -> CPackage ->
-             IO (CPackage, Bool, S.Set Id, CATFCache)
+             IO (CPackage, Bool, S.Set Id, S.Set (Id, Id), CATFCache)
 cTypeCheck errh flags symtab (CPackage name exports imports impsigs fixs defns includes) = do
-    (typecheckedDefns, typeWarns, usedPkgs, haveErrors, atfCache) <- tiDefns errh symtab flags defns
+    (typecheckedDefns, typeWarns, usedPkgs, usedDecls, haveErrors, atfCache)
+        <- tiDefns errh symtab flags defns
 
     -- Issue type warnings
     when (not (null typeWarns)) $ bsWarning errh typeWarns
@@ -43,21 +44,23 @@ cTypeCheck errh flags symtab (CPackage name exports imports impsigs fixs defns i
     return (CPackage name exports imports impsigs fixs typecheckedDefns includes,
             haveErrors,
             usedPkgs,
+            usedDecls,
             atfCache)
 
 
 -- type check top-level definitions in parallel (since they are independent)
 tiDefns :: ErrorHandle -> SymTab -> Flags -> [CDefn] ->
-           IO ([CDefn], [WMsg], S.Set Id, Bool, CATFCache)
+           IO ([CDefn], [WMsg], S.Set Id, S.Set (Id, Id), Bool, CATFCache)
 tiDefns errh s flags ds = do
   let ai = allowIncoherentMatches flags
-  let checkDef d = (defErr, warns, usedPkgs, atfCache)
+  let checkDef d = (defErr, warns, usedPkgs, usedDecls, atfCache)
         where ti_res = runTI flags ai s $ tiOneDef d
               (warns, usedPkgs, atfCache) = (tiWarnings ti_res, tiUsedPackages ti_res, tiATFCache ti_res)
+              usedDecls = tiUsedDecls ti_res
               defErr = case tiResult ti_res of
                           (Left emsgs)  -> Left emsgs
                           (Right cdefn) -> rmFreeTypeVars cdefn
-  let (checks, wss, pkgss, atfCaches) = unzip4 (map checkDef ds)
+  let (checks, wss, pkgss, declss, atfCaches) = unzip5 (map checkDef ds)
   let (errors, ds') = apFst concat $ separate checks
   let have_errors = not (null errors)
   let mkErrorDef (Left _)  (CValueSign (CDef i t _)) = Just (mkPoisonedCDefn i t)
@@ -67,15 +70,16 @@ tiDefns errh s flags ds = do
       mkErrorDef (Right _) _ = Nothing
   let error_defs = catMaybes (zipWith mkErrorDef checks ds)
   let (double_error_msgs, error_defs') =
-          apFst concat $ separate $ map (\(x,_,_,_) -> x) (map checkDef error_defs)
+          apFst concat $ separate $ map (\(x,_,_,_,_) -> x) (map checkDef error_defs)
   -- Accumulate all used packages (only from the first round, poison pills don't use new symbols)
   let allUsedPkgs = S.unions pkgss
+  let allUsedDecls = S.unions declss
   let mergedATFCache = foldl mergeCATFCaches M.empty atfCaches
   -- XXX: we give up - some type signatures are bogus
   when ((not (null double_error_msgs)) || (have_errors && not (enablePoisonPills flags))) $
       bsError errh (nub errors) -- the underyling error should be in errors
   when (have_errors && enablePoisonPills flags) $ bsErrorNoExit errh errors
-  return (ds' ++ error_defs', concat wss, allUsedPkgs, have_errors, mergedATFCache)
+  return (ds' ++ error_defs', concat wss, allUsedPkgs, allUsedDecls, have_errors, mergedATFCache)
 
 nullAssump :: [Assump]
 nullAssump = []

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -85,7 +85,7 @@ import MakeSymTab(mkSymTab, cConvInst,
                   getPackagesUsedInTypes, getDeclsUsedInTypes)
 import TypeCheck(cCtxReduceIO, cTypeCheck, mergeCATFCaches)
 import PoisonUtils(mkPoisonedCDefn)
-import GenSign(genUserSign, genEverythingSign)
+import GenSign(genUserSign, genEverythingSign, getDeclsUsedByExports)
 import Simplify(simplify)
 import ISyntax(IPackage(..), IModule(..), IATFCache, mergeIATFCaches,
                IEFace(..), IDef(..), IExpr(..), fdVars)
@@ -444,11 +444,13 @@ compilePackage
     -- transitive closure, so any interface change anywhere invalidates it.
     -- Instances and fixities apply without being named and are absent here
     -- by construction; they can only ever be tracked per-package.
-    let dumpUsage =
+    let dumpUsage bi_sig =
           when (elem "-dump-usage" progArgs) $
-            let used = S.unions [declsUsedInCode, declsUsedInCtxReduce,
-                                 declsUsedInTypes]
-                self = let (CPackage sp _ _ _ _ _ _) = mctx in getIdString sp
+            let selfId = let (CPackage sp _ _ _ _ _ _) = mctx in sp
+                used = S.unions [declsUsedInCode, declsUsedInCtxReduce,
+                                 declsUsedInTypes,
+                                 getDeclsUsedByExports selfId bi_sig]
+                self = getIdString selfId
             in  mapM_ (\(p, d) -> putStrLnF ("USEDECL " ++ self ++ " " ++
                                              getIdString p ++ " " ++
                                              getIdBaseString d))
@@ -491,7 +493,7 @@ compilePackage
         checkForeignFuncDuplicates errh mod
         (bi_sig, pkgsUsedInExports) <- genUserSign errh symt mctx
         warnUnusedImports pkgsUsedInExports
-        dumpUsage
+        dumpUsage bi_sig
         let bc_filename = putInDir (bdir flags) name bcSuffix
             -- The same list "fixupDefs" would put in ipkg_depends, built the
             -- same way the .bo path builds "binmods": every package in the
@@ -718,7 +720,7 @@ compilePackage
 
      -- Check for unused imports by combining packages from all three sources
      warnUnusedImports pkgsUsedInExports
-     dumpUsage
+     dumpUsage bi_sig
 
      -- Generate binary version of the internal tree .bo file
      let bin_filename = putInDir (bdir flags) name binSuffix

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -17,7 +17,7 @@ import Data.Char(isSpace, toLower, ord)
 import Data.List(intersect, nub, partition, intersperse, sort,
             isPrefixOf, isSuffixOf, unzip5, intercalate, foldl')
 import Data.Time.Clock.POSIX(getPOSIXTime)
-import Data.Maybe(isJust, isNothing)
+import Data.Maybe(isJust, isNothing, mapMaybe)
 import Numeric(showOct)
 
 import Control.Monad(when, unless, filterM, liftM, foldM)
@@ -50,7 +50,7 @@ import FileIOUtil(writeFileCatch, readFileMaybe, removeFileCatch,
 import TopUtils
 import SystemCheck(doSystemCheck)
 import BuildSystem
-import IOUtil(getEnvDef)
+import IOUtil(getEnvDef, progArgs)
 
 -- compiler libs
 --import FStringCompat
@@ -81,7 +81,8 @@ import Pragma
 import VModInfo(VPathInfo, VPort)
 import Deriving(derive)
 import SymTab
-import MakeSymTab(mkSymTab, cConvInst, getPackagesUsedInTypes)
+import MakeSymTab(mkSymTab, cConvInst,
+                  getPackagesUsedInTypes, getDeclsUsedInTypes)
 import TypeCheck(cCtxReduceIO, cTypeCheck, mergeCATFCaches)
 import PoisonUtils(mkPoisonedCDefn)
 import GenSign(genUserSign, genEverythingSign)
@@ -407,10 +408,12 @@ compilePackage
     -- Extract packages used in type constructors from the parsed package
     -- (before any transformations that might expand synonyms or change types)
     let pkgsUsedInTypes = getPackagesUsedInTypes symt11 mder
+    let declsUsedInTypes = getDeclsUsedInTypes symt11 mder
 
     -- Reduce the contexts as far as possible
     start flags DFctxreduce
-    (mctx, pkgsUsedInCtxReduce, atfCacheFromCtxReduce) <- cCtxReduceIO errh flags symt11 mder
+    (mctx, pkgsUsedInCtxReduce, declsUsedInCtxReduce, atfCacheFromCtxReduce)
+        <- cCtxReduceIO errh flags symt11 mder
     t <- dump errh flags t DFctxreduce dumpnames mctx
 
     -- Rebuild the symbol table because CtxReduce has possibly changed
@@ -426,7 +429,8 @@ compilePackage
 
     -- Type check and insert dictionaries
     start flags DFtypecheck
-    (mod, tcErrors, pkgsUsedInCode, ctypeATFCache) <- cTypeCheck errh flags symt minst
+    (mod, tcErrors, pkgsUsedInCode, declsUsedInCode, ctypeATFCache)
+        <- cTypeCheck errh flags symt minst
     --putStr (ppReadable mod)
     t <- dump errh flags t DFtypecheck dumpnames mod
 
@@ -434,6 +438,22 @@ compilePackage
     -- definition body is still a use (pkgsUsedInCode), so this must run on
     -- the check path too or -check-only reports a clean package that the
     -- real build warns about.
+    -- Declaration-level usage, for cutoff analysis: which declarations of
+    -- each import this package actually resolved.  The per-package sets
+    -- feeding T0157 cannot support cutoff -- a dependent records the whole
+    -- transitive closure, so any interface change anywhere invalidates it.
+    -- Instances and fixities apply without being named and are absent here
+    -- by construction; they can only ever be tracked per-package.
+    let dumpUsage =
+          when (elem "-dump-usage" progArgs) $
+            let used = S.unions [declsUsedInCode, declsUsedInCtxReduce,
+                                 declsUsedInTypes]
+                self = let (CPackage sp _ _ _ _ _ _) = mctx in getIdString sp
+            in  mapM_ (\(p, d) -> putStrLnF ("USEDECL " ++ self ++ " " ++
+                                             getIdString p ++ " " ++
+                                             getIdBaseString d))
+                      (sort (nub [ (p, d) | (p, d) <- S.toList used ]))
+
     let warnUnusedImports pkgsUsedInExports =
           let (CPackage _ _ imports _ _ _ _) = mctx
               allUsedPkgs = S.unions [pkgsUsedInTypes, pkgsUsedInCtxReduce,
@@ -471,6 +491,7 @@ compilePackage
         checkForeignFuncDuplicates errh mod
         (bi_sig, pkgsUsedInExports) <- genUserSign errh symt mctx
         warnUnusedImports pkgsUsedInExports
+        dumpUsage
         let bc_filename = putInDir (bdir flags) name bcSuffix
             -- The same list "fixupDefs" would put in ipkg_depends, built the
             -- same way the .bo path builds "binmods": every package in the
@@ -697,6 +718,7 @@ compilePackage
 
      -- Check for unused imports by combining packages from all three sources
      warnUnusedImports pkgsUsedInExports
+     dumpUsage
 
      -- Generate binary version of the internal tree .bo file
      let bin_filename = putInDir (bdir flags) name binSuffix
@@ -2252,11 +2274,12 @@ compileCDefToIDef errh flags dumpnames symt ipkg def =
     t <- getNow
 
     start flags DFwrapper_ctxreduce
-    (cpkg_ctx, _, _) <- cCtxReduceIO errh flags symt cpkg0
+    (cpkg_ctx, _, _, _) <- cCtxReduceIO errh flags symt cpkg0
     t <- dump errh flags t DFwrapper_ctxreduce dumpnames cpkg_ctx
 
     start flags DFwrapper_typecheck
-    (cpkg_chk, tcErrors, _usedPkgs, _wrapperATFCache) <- cTypeCheck errh flags symt cpkg_ctx
+    (cpkg_chk, tcErrors, _usedPkgs, _usedDecls, _wrapperATFCache)
+        <- cTypeCheck errh flags symt cpkg_ctx
     t <- dump errh flags t DFwrapper_typecheck dumpnames cpkg_chk
 
     start flags DFwrapper_simplified


### PR DESCRIPTION
Serialization window 3/5 (II-19). Ground-pool contamination stripped (tsUsedDecls threads beside upstream's ATF cache). No format change, no tags. Builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt