### PR TITLE
-no-import-hashes: cut the recompilation cascade at unchanged signatures

### DIFF
--- a/src/comp/BinUtil.hs
+++ b/src/comp/BinUtil.hs
@@ -216,8 +216,8 @@ doImport errh flags hashmap i = do
         let impNames = map fst impHashes
         return (name, bi_sig, bo_sig, ipkg, hash, hashmap', impNames)
 
-mergeHashes :: ErrorHandle -> HashMap -> Id -> String -> [(Id, String)] ->
-               IO HashMap
+mergeHashes :: ErrorHandle -> HashMap -> Id -> String ->
+               [(Id, Maybe String)] -> IO HashMap
 mergeHashes errh hashmap binId binhash impHashes =
   let
       -- a package and its importer disagree about the hash
@@ -256,8 +256,12 @@ mergeHashes errh hashmap binId binhash impHashes =
           internalError ("mergeHashes: " ++ ppReadable new_val)
 
 
+      -- An absent hash records no claim, so there is nothing to merge and
+      -- nothing to disagree with: the producing compile ran with
+      -- -no-import-hashes.  Verification simply does not cover that edge.
       new_pairs = let mkImpPair (i,s) = (i, (s, [binId]))
-                      imp_pairs = map mkImpPair impHashes
+                      imp_pairs = map mkImpPair
+                                      [ (i, s) | (i, Just s) <- impHashes ]
                       bin_pair = (binId, (binhash, [binId]))
                   in  (bin_pair : imp_pairs)
   in

--- a/src/comp/FixupDefs.hs
+++ b/src/comp/FixupDefs.hs
@@ -19,7 +19,8 @@ import ISyntaxUtil(iDefsMap)
 -- (2) Find references to top-level variables and insert the definitions
 --     (to avoid lookups when evaluating the code).  This creates a cyclic
 --     data structure when defs call each other recursively.
-fixupDefs :: IPackage a -> [(IPackage a, String)] -> (IPackage a, [IDef a])
+fixupDefs :: IPackage a -> [(IPackage a, Maybe String)] ->
+             (IPackage a, [IDef a])
 fixupDefs (IPackage mi _ ps ds own_atf_cache) ipkgs =
     let
         (ms, _) = unzip ipkgs
@@ -58,7 +59,7 @@ fixupDefs (IPackage mi _ ps ds own_atf_cache) ipkgs =
 -- Replace the definition for a top-level variable with a new definition.
 -- (This is used to replace the pre-synthesis definition for a module with
 -- the post-synthesis definition.)
-updDef :: IDef a -> IPackage a -> [(IPackage a, String)] -> IPackage a
+updDef :: IDef a -> IPackage a -> [(IPackage a, Maybe String)] -> IPackage a
 updDef d@(IDef i _ _ _) ipkg@(IPackage { ipkg_defs = ds }) ips =
     let
         -- replace the def in the list

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -156,8 +156,18 @@ data Flags = Flags {
         warnMethodUrgency :: Bool,
         warnUndetPred :: Bool,
         -- appended last: the Bin Flags instance in GenABin.hs is
-        -- positional, so new fields go at the end (position a_134)
-        checkOnly :: Bool
+        -- positional, so new fields go at the end (position a_135)
+        checkOnly :: Bool,
+        -- Record the transitive-closure hashes in a package's depends list,
+        -- and run the consistency check they drive.  On by default.
+        --
+        -- Those hashes are what makes a dependent's bytes move when any
+        -- package anywhere in its closure changes signature, so -no-import-
+        -- hashes is what lets an unaffected dependent rebuild byte-identically
+        -- and its own dependents cache-hit.  Turning it off is only safe where
+        -- the build guarantees input consistency: bazel content-addresses its
+        -- inputs, a search path with a stale .bo does not.
+        importHashes :: Bool
         }
 -- don't derive Show -- it causes an optimized ghc build to take a long time
 --        deriving (Show)

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -558,6 +558,7 @@ defaultFlags bluespecdir = Flags {
         dumpAll = Nothing,
         dumps = [],
         checkOnly = False,
+        importHashes = True,
         enablePoisonPills = False,
         entry = Nothing,
         expandATSlimit = 20,
@@ -1235,6 +1236,12 @@ externalFlags = [
         ("I",
          (Arg "path" (\f s -> Left (f {cIncPath = cIncPath f ++ [s]})) (Just (FRTListString cIncPath)),
           "include path for compiling foreign C/C++ source", Visible)),
+
+        ("import-hashes",
+         (Toggle (\f x -> f {importHashes=x}) (showIfTrue importHashes),
+          "record transitive-closure hashes in the depends list and check " ++
+          "them on import (default); -no-import-hashes omits them, which is " ++
+          "only safe when the build guarantees input consistency", Visible)),
 
         ("info-dir",
          (Arg "dir" (\f s -> Left (f {infoDir = Just s})) (Just (FRTMaybeString infoDir)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-2"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,11 +561,11 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134) =
+                a_130 a_131 a_132 a_133 a_134 a_135) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
-          wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
+          wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8; wr_chunk9
       where
-        -- The 135-field serialization is split into NOINLINE chunks so
+        -- The 136-field serialization is split into NOINLINE chunks so
         -- that GHC optimizes bounded pieces: compiling it as a single
         -- monadic chain needs more than 15GB of heap.
         {-# NOINLINE wr_chunk0 #-}
@@ -613,6 +613,9 @@ instance Bin Flags where
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
              toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
+        {-# NOINLINE wr_chunk9 #-}
+        wr_chunk9 =
+          do toBin a_135
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -632,6 +635,7 @@ instance Bin Flags where
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
            a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
+          a_135 <- rd_chunk9
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +650,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134)
+                a_130 a_131 a_132 a_133 a_134 a_135)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -712,6 +716,10 @@ instance Bin Flags where
              a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
                      a_128, a_129, a_130, a_131, a_132, a_133, a_134)
+        {-# NOINLINE rd_chunk9 #-}
+        rd_chunk9 =
+          do a_135 <- fromBin
+             return a_135
 
 -- ----------
 

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -29,7 +29,7 @@ doTrace = elem "-trace-genbin" progArgs
 -- .bo file tag -- change this whenever the .bo format changes
 -- See also GenABin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-2"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-3"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -92,7 +92,7 @@ readBinFile errh nm s =
 -- Its own tag means the S0005 version guard rejects a .bc fed to a compile
 -- that wants definitions, rather than that compile silently finding none.
 bcHeader :: [Byte]
-bcHeader = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bc-20260804-2"
+bcHeader = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bc-20260804-3"
 
 bcHeaderBS :: B.ByteString
 bcHeaderBS = B.pack bcHeader
@@ -101,13 +101,14 @@ bcHeaderBS = B.pack bcHeader
 -- whole transitive closure, topologically sorted, each paired with the hash
 -- of the file it was read from.  It cannot be recovered from the signature's
 -- own import list, which GenSign prunes to direct imports minus the Preludes.
-genBcFile :: ErrorHandle -> String -> [(Id, String)] -> CSignature -> IO ()
+genBcFile :: ErrorHandle -> String -> [(Id, Maybe String)] -> CSignature ->
+             IO ()
 genBcFile errh fn depends bi_sig =
     writeBinaryFileCatch errh fn
         (bcHeader ++ encode (sigHash bi_sig, (depends, bi_sig)))
 
 readBcFile :: ErrorHandle -> String -> B.ByteString ->
-              IO (([(Id, String)], CSignature), String)
+              IO (([(Id, Maybe String)], CSignature), String)
 readBcFile errh nm s =
     let hlen = B.length bcHeaderBS
     in if B.take hlen s == bcHeaderBS

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -130,7 +130,10 @@ data IPackage a
               -- package name
               ipkg_name :: Id,
               -- linked packages (name, signature)
-              ipkg_depends :: [(Id, String)],
+              -- Nothing where the producing compile omitted the hash
+              -- (-no-import-hashes); the name is always present, since
+              -- it is the graph shape that drives the load worklist
+              ipkg_depends :: [(Id, Maybe String)],
               -- pragmas
               ipkg_pragmas :: [Pragma],
               -- definition list
@@ -1028,8 +1031,9 @@ ftVars (IRefT _ _ _ _) = S.empty
 -- ============================================================
 -- PPrint (for those instances not defined alongside the type, above)
 
-pPrintLink :: PDetail -> Int -> (Id, String) -> Doc
-pPrintLink d i (mi, hash) = (ppId d mi) <+> (text hash)
+pPrintLink :: PDetail -> Int -> (Id, Maybe String) -> Doc
+pPrintLink d i (mi, hash) =
+    (ppId d mi) <+> (text (maybe "(no hash)" id hash))
 
 instance PPrint (IPackage a) where
  pPrint d p (IPackage mi lps ps ds _) =

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -306,6 +306,14 @@ compile_no_deps errh flags name = do
 
 -------------------------------------------------------------------------
 
+-- The hash a dependent records for an import, or Nothing under
+-- -no-import-hashes.  The name is recorded either way: it is the graph shape
+-- that drives the load worklist, while the hash only drives the consistency
+-- check -- and carrying the hash of every package in the transitive closure
+-- is what makes a dependent's bytes move when any of them changes signature.
+optHash :: Flags -> String -> Maybe String
+optHash flags h = if importHashes flags then Just h else Nothing
+
 compilePackage ::
     ErrorHandle ->
     Flags ->
@@ -501,7 +509,7 @@ compilePackage
             -- from.  Recomputed here because -check-only exits before fixup.
             findFn s = fromJustOrErr "bsc: binmap (check-only)" $
                            M.lookup s binmap
-            bc_depends = [ (i, h)
+            bc_depends = [ (i, optHash flags h)
                          | CImpSign _ _ (CSignature i _ _ _) <- impsigs
                          , let (_, _, _, _, h) = findFn (getIdString i) ]
         genBcFile errh bc_filename bc_depends bi_sig
@@ -577,7 +585,10 @@ compilePackage
      let
          -- adjust the "raw" packages and then add back their signatures
          -- so they can be put into the current IPackage for linking info
-         binmods = zip (map (adjEnv env) binmods0) pkgsigs
+         -- -no-import-hashes records the graph shape without the hashes:
+         -- the names still drive the load worklist, but a dependent's bytes
+         -- stop moving when an unrelated package in its closure changes
+         binmods = zip (map (adjEnv env) binmods0) (map (optHash flags) pkgsigs)
 
      t <- dump errh flags t DFbinary dumpnames binmods
 

--- a/testsuite/bsc.compile/compile.exp
+++ b/testsuite/bsc.compile/compile.exp
@@ -16,6 +16,11 @@ compile_pass TopRec.bsv
 #   hashes on (the default, and any search-path or make-style build):
 #     a stale .bo genuinely can be sitting there, so it must be
 #     detected.  S0027.
+#   -no-import-hashes (what bazel builds pass): the hashes are omitted
+#     deliberately, because content-addressed action inputs mean the
+#     mismatch cannot arise.  No check, clean compile.
+#
+# Assert both, rather than picking whichever the default happens to be.
 copy FiveA.bs Five.bs
 compile_pass Five.bs
 compile_pass Six.bs
@@ -42,6 +47,18 @@ compile_pass Five.bs
 # would pass while checking nothing.
 setup_xfail $target_triplet
 compile_fail_error Test.bs S0027 1 "" 1
+
+# The same scenario with the hashes deliberately omitted: no detection
+# is the specified behaviour, so the compile must be clean.  This pins
+# that -no-import-hashes really does disable the check, which is the
+# property the bazel build depends on.
+copy FiveA.bs Five.bs
+compile_pass Five.bs "-no-import-hashes"
+compile_pass Six.bs "-no-import-hashes"
+after 1500
+copy FiveB.bs Five.bs
+compile_pass Five.bs "-no-import-hashes"
+compile_pass Test.bs "-no-import-hashes" 1
 
 
 

--- a/testsuite/bsc.options/bsc.help.out.expected
+++ b/testsuite/bsc.options/bsc.help.out.expected
@@ -32,6 +32,7 @@ Compiler flags:
 -g module               generate code for ``module'' (requires -sim or -verilog)
 -help                   generate help message
 -i dir                  override `$BLUESPECDIR'
+-import-hashes          record transitive-closure hashes in the depends list and check them on import (default); -no-import-hashes omits them, which is only safe when the build guarantees input consistency
 -info-dir dir           output directory for informational files
 -keep-fires             preserve CAN_FIRE and WILL_FIRE signals
 -keep-inlined-boundaries preserve inlined register and wire boundaries

--- a/testsuite/bsc.options/bsc.path_dup_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_dup_bdir.out.expected
@@ -13,6 +13,7 @@ Flags:
     -aggressive-conditions
     -bdir bar
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -p foo:bar:baz

--- a/testsuite/bsc.options/bsc.path_dup_no_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_dup_no_bdir.out.expected
@@ -9,6 +9,7 @@ bsc -i BLUESPECDIR -print-flags -p foo::foo:bar:foo:baz:baz:foo
 Flags:
     -aggressive-conditions
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -p foo:bar:baz

--- a/testsuite/bsc.options/bsc.path_nonidentical_dup_no_bdir.out.expected
+++ b/testsuite/bsc.options/bsc.path_nonidentical_dup_no_bdir.out.expected
@@ -16,6 +16,7 @@ bsc -i BLUESPECDIR -print-flags -p foo:foo/:./foo:bar/../foo:./foo/../foo:baz:./
 Flags:
      -aggressive-conditions
      -i   BLUESPECDIR
+     -import-hashes
      -lift
      -o   a.out
      -p   foo:baz

--- a/testsuite/bsc.options/bsc.print-flags.expand-if.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.expand-if.out.expected
@@ -6,6 +6,7 @@ bsc -i BLUESPECDIR -print-flags -expand-if
 Flags:
     -aggressive-conditions
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -parallel-sim-link   1

--- a/testsuite/bsc.options/bsc.print-flags.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.out.expected
@@ -4,6 +4,7 @@ bsc -i BLUESPECDIR -print-flags
 Flags:
     -aggressive-conditions
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -parallel-sim-link   1

--- a/testsuite/bsc.options/bsc.print-flags.split-if.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags.split-if.out.expected
@@ -4,6 +4,7 @@ bsc -i BLUESPECDIR -print-flags -split-if
 Flags:
     -aggressive-conditions
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -parallel-sim-link   1

--- a/testsuite/bsc.options/bsc.simdir_invalid_no_backend.out.expected
+++ b/testsuite/bsc.options/bsc.simdir_invalid_no_backend.out.expected
@@ -10,6 +10,7 @@ bsc -i BLUESPECDIR -print-flags -simdir INVALID
 Flags:
      -aggressive-conditions
      -i   BLUESPECDIR
+     -import-hashes
      -lift
      -o   a.out
      -parallel-sim-link   1

--- a/testsuite/bsc.options/bsc.test_bsc_option.out.expected
+++ b/testsuite/bsc.options/bsc.test_bsc_option.out.expected
@@ -4,6 +4,7 @@ bsc -print-flags -vsearch foo -steps 12345678 -i BLUESPECDIR
 Flags:
     -aggressive-conditions
     -i BLUESPECDIR
+    -import-hashes
     -lift
     -o a.out
     -parallel-sim-link   1

--- a/testsuite/bsc.options/bsc.vdir_invalid_no_backend.out.expected
+++ b/testsuite/bsc.options/bsc.vdir_invalid_no_backend.out.expected
@@ -17,6 +17,7 @@ bsc -i BLUESPECDIR -print-flags -vdir INVALID
 Flags:
      -aggressive-conditions
      -i   BLUESPECDIR
+     -import-hashes
      -lift
      -o   a.out
      -parallel-sim-link   1

--- a/testsuite/bsc.options/messages/flag-test.out.expected
+++ b/testsuite/bsc.options/messages/flag-test.out.expected
@@ -4,6 +4,7 @@ bsc -i BLUESPECDIR -print-flags -suppress-warnings G0001:G0002 -suppress-warning
 Flags:
      -aggressive-conditions
      -i   BLUESPECDIR
+     -import-hashes
      -lift
      -o   a.out
      -parallel-sim-link   1

--- a/testsuite/bsc.options/messages/flag-test2.out.expected
+++ b/testsuite/bsc.options/messages/flag-test2.out.expected
@@ -4,6 +4,7 @@ bsc -i BLUESPECDIR -print-flags -suppress-warnings G0001:G0002 -suppress-warning
 Flags:
      -aggressive-conditions
      -i   BLUESPECDIR
+     -import-hashes
      -lift
      -o   a.out
      -parallel-sim-link   1


### PR DESCRIPTION
Serialization window 4/5 (II-20). Includes the .ba arity bump the original omitted (bsc-ba-20260804-2, disclosed). bsc-bo-20260804-3, bsc-bc-20260804-3. Builds; bsc.compile 11P+1XF; bsc.options 71P.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt