### PR TITLE
thin .ba: drop derivable data; varint share-refs; Builder output

### DIFF
--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 module ASchedule(
                  aSchedule,
+                 aScheduleDenseRuleRelationDB,
                  extractCFPairsSP,
                  extractMEPairsSP,
                  errAction,
@@ -461,6 +462,35 @@ aSchedule errh flags prefix urgency_pairs pps amod = do
                          return (Right (schedule_info, amod'))
               _ -> internalError "aSchedule: missing info"
 
+
+-- Rederive the dense halves of the RuleRelationDB -- the disjointness
+-- set and the cf/sc conflict entries -- that writeABin omits from the
+-- default (thin) .ba.  Reruns the conflict analysis on the APackage
+-- exactly as the original scheduling run did; the analysis is
+-- deterministic, so the result matches what -ba-debug-info would have
+-- serialized.  The result carries no byproduct entries (those are
+-- always in the .ba); graft it onto the serialized DB with
+-- rrdbGraftDenseHalves.  Returns Nothing if the analysis reports
+-- errors (a module whose schedule already failed at compile time);
+-- the byproduct entries are all that is knowable then.
+aScheduleDenseRuleRelationDB :: ErrorHandle -> Flags -> APackage
+                             -> IO (Maybe RuleRelationDB)
+aScheduleDenseRuleRelationDB errh flags amod = do
+    let -- rederivation must not re-dump schedule DOT files
+        flags' = flags { schedDOT = False }
+        f = aSchedule_step1 errh flags' "" () amod
+    (result, _) <- runStateT (runExceptT f) initSState
+    case result of
+      Left _ -> return Nothing
+      Right ( scConflictMap0, cfConflictMap0, _, _, _
+            , _, _, userARules, _, _
+            , rule_disjoint, _, _, _, _
+            , _, _, _, _, _
+            , _, _, _ ) ->
+          let ruleNames = map ruleName (concatMap cvtIfc (apkg_interface amod))
+                          ++ map aRuleName userARules
+          in  return $ Just $ mkRuleRelationDB ruleNames rule_disjoint
+                                  cfConflictMap0 scConflictMap0 [] [] [] []
 
 aSchedule' :: ErrorHandle -> Flags ->
               String -> PathUrgencyPairs -> [PProp] -> APackage ->

--- a/src/comp/ASchedule.hs
+++ b/src/comp/ASchedule.hs
@@ -3830,9 +3830,27 @@ mkRuleRelationDB rule_names rule_disjoint cf_map sc_map
                       else Nothing
           in ((rule1,rule2), rule1 `rule_disjoint` rule2, minfo)
 
-      infos = [ getPairInfo r1 r2 | r1 <- rule_names, r2 <- rule_names ]
+      -- the byproduct pairs are the scheduling run's own outcomes;
+      -- build their (complete) entries eagerly and WITHOUT touching
+      -- the all-pairs enumeration, so that serializing them never
+      -- forces the dense halves below
+      byproduct_keys =
+          S.fromList ( [ (r1,r2) | (r1,r2,_) <- res_drops ]
+                    ++ [ (r1,r2) | (r1,r2,_) <- cycle_drops ]
+                    ++ [ (r1,r2) | (r1,r2,_) <- sched_pragma_drops ]
+                    ++ M.keys arb_map )
+      byp_map = M.fromList [ (p, rri) | p@(r1,r2) <- S.toList byproduct_keys
+                                      , let (_, _, minfo) = getPairInfo r1 r2
+                                      , Just rri <- [minfo] ]
 
-  in rrdbFromList infos
+      -- dense halves: lazy, quadratic, and only ever forced by a
+      -- -ba-debug-info write or an explicit relation query (bluetcl)
+      infos = [ getPairInfo r1 r2 | r1 <- rule_names, r2 <- rule_names ]
+      dset = S.fromList [ p | (p, True, _) <- infos ]
+      dense_map = M.fromList [ (p, rri) | (p, _, Just rri) <- infos
+                                        , not (p `S.member` byproduct_keys) ]
+
+  in RuleRelationDB dset dense_map byp_map
 
 doQueries :: ErrorHandle -> Flags -> [ARuleId] -> RuleRelationDB -> IO ()
 doQueries errh flags rule_names relationDB =

--- a/src/comp/AScheduleInfo.hs
+++ b/src/comp/AScheduleInfo.hs
@@ -18,6 +18,9 @@ module AScheduleInfo (
     isSchedNode,
     printRuleRelationInfo,
     rrdbFromList,
+    rrdbFromSerialized,
+    rrdbSerializedConflicts,
+    thinRuleRelationDB,
     unionRuleRelationInfo
 ) where
 
@@ -27,7 +30,8 @@ import Prelude hiding ((<>))
 
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Data.List(intersperse)
+import Data.List(intersperse, partition)
+import Data.Maybe(isJust)
 import Util(thd)
 import Eval
 
@@ -262,12 +266,26 @@ instance Ord FastSchedNode where
 --   - If a pair is not in the map, then the rules have no conflicts
 --   - If a pair maps to a RuleRelationInfo value, then the breakdown
 --     of conflicts is given in the RuleRelationInfo structure.
+-- The dense halves (disjointness set; conflict entries whose only
+-- content is the cf/sc analysis) are quadratic in rules, derivable
+-- from (flags, apkg), and kept as never-forced lazy fields: nothing
+-- in a normal compile consumes them, and .ba writing omits them
+-- unless -ba-debug-info asks for the fat form.  The byproduct map
+-- holds the complete relation for exactly those pairs where the
+-- scheduling run recorded an outcome (resource/cycle/pragma/arb
+-- drop); it is small and always serialized -- and it is the only
+-- part the Bluesim path reads (its lookup treats a missing pair and
+-- a cf/sc-only pair identically).
 data RuleRelationDB =
-    RuleRelationDB (S.Set (ARuleId,ARuleId))                  -- disjointness
-                   (M.Map (ARuleId,ARuleId) RuleRelationInfo) -- conflicts
+    RuleRelationDB (S.Set (ARuleId,ARuleId))                  -- disjointness (dense, lazy)
+                   (M.Map (ARuleId,ARuleId) RuleRelationInfo) -- cf/sc-only conflicts (dense, lazy)
+                   (M.Map (ARuleId,ARuleId) RuleRelationInfo) -- byproduct pairs (complete)
 
 instance NFData RuleRelationDB where
-  rnf (RuleRelationDB s m) = rnf2 s m
+  -- deliberately NOT forcing the dense halves: rnf here (dump calls
+  -- deepseq unconditionally) would materialize the quadratic maps and
+  -- reintroduce the writeABin heap blowup this split exists to fix
+  rnf (RuleRelationDB _ _ byp) = rnf byp
 
 data RuleRelationInfo = RuleRelationInfo { mCF :: Maybe Conflicts
                                          , mSC :: Maybe Conflicts
@@ -291,26 +309,59 @@ defaultRuleRelationship = RuleRelationInfo { mCF     = Nothing
                                            }
 
 
+-- a byproduct entry records an outcome of the scheduling run itself
+isByproductRRI :: RuleRelationInfo -> Bool
+isByproductRRI rri =
+    isJust (mRes rri) || isJust (mCycle rri) ||
+    isJust (mPragma rri) || isJust (mArb rri)
+
 rrdbToList :: RuleRelationDB ->
               [((ARuleId,ARuleId),Bool,(Maybe RuleRelationInfo))]
-rrdbToList (RuleRelationDB dset cmap) =
-    let all_pairs = dset `S.union` (M.keysSet cmap)
+rrdbToList (RuleRelationDB dset dense byp) =
+    let cmap = M.union byp dense
+        all_pairs = dset `S.union` (M.keysSet cmap)
     in [ (k, k `S.member` dset, M.lookup k cmap) | k <- S.toList all_pairs ]
 
 rrdbFromList :: [((ARuleId,ARuleId),Bool,(Maybe RuleRelationInfo))] ->
                 RuleRelationDB
 rrdbFromList xs =
     let dset = S.fromList [ k | (k,True,_) <- xs ]
-        cmap = M.fromList [ (k,rri) | (k,_,(Just rri)) <- xs ]
-    in RuleRelationDB dset cmap
+        cmap = [ (k,rri) | (k,_,(Just rri)) <- xs ]
+        (byp, dense) = partition (isByproductRRI . snd) cmap
+    in RuleRelationDB dset (M.fromList dense) (M.fromList byp)
+
+-- reconstruct from the serialized form (a thin file carries an empty
+-- set and only byproduct entries; a -ba-debug-info file carries all)
+rrdbFromSerialized :: [(ARuleId,ARuleId)]
+                   -> [((ARuleId,ARuleId), RuleRelationInfo)]
+                   -> RuleRelationDB
+rrdbFromSerialized dset_list cmap_list =
+    let (byp, dense) = partition (isByproductRRI . snd) cmap_list
+    in RuleRelationDB (S.fromList dset_list)
+                      (M.fromList dense) (M.fromList byp)
+
+-- the conflict entries as a single map, the wire representation
+-- (forces the dense half only when it is non-empty, i.e. fat writes)
+rrdbSerializedConflicts :: RuleRelationDB
+                        -> [((ARuleId,ARuleId), RuleRelationInfo)]
+rrdbSerializedConflicts (RuleRelationDB _ dense byp) =
+    M.toList (M.union byp dense)
+
+-- drop the dense halves before serialization (the default .ba form)
+thinRuleRelationDB :: RuleRelationDB -> RuleRelationDB
+thinRuleRelationDB (RuleRelationDB _ _ byp) =
+    RuleRelationDB S.empty M.empty byp
 
 instance Show RuleRelationDB where
     show rrdb = show (rrdbToList rrdb)
 
 getRuleRelation :: RuleRelationDB -> ARuleId -> ARuleId -> (Bool,RuleRelationInfo)
-getRuleRelation (RuleRelationDB dset cmap) r1 r2 =
+getRuleRelation (RuleRelationDB dset dense byp) r1 r2 =
     let disj = S.member (r1,r2) dset
-        rri  = M.findWithDefault defaultRuleRelationship (r1,r2) cmap
+        rri  = case M.lookup (r1,r2) byp of
+                 Just i  -> i
+                 Nothing -> M.findWithDefault defaultRuleRelationship
+                                              (r1,r2) dense
     in (disj,rri)
 
 -- -----

--- a/src/comp/AScheduleInfo.hs
+++ b/src/comp/AScheduleInfo.hs
@@ -19,6 +19,8 @@ module AScheduleInfo (
     printRuleRelationInfo,
     rrdbFromList,
     rrdbFromSerialized,
+    rrdbGraftDenseHalves,
+    rrdbIsThin,
     rrdbSerializedConflicts,
     thinRuleRelationDB,
     unionRuleRelationInfo
@@ -351,6 +353,19 @@ rrdbSerializedConflicts (RuleRelationDB _ dense byp) =
 thinRuleRelationDB :: RuleRelationDB -> RuleRelationDB
 thinRuleRelationDB (RuleRelationDB _ _ byp) =
     RuleRelationDB S.empty M.empty byp
+
+-- whether the dense halves are absent, i.e. the DB came from a thin
+-- .ba and a reader wanting complete relations must rederive them
+-- (see ASchedule.aScheduleDenseRuleRelationDB).  Only meaningful on
+-- a deserialized DB: on a freshly computed one, the null tests would
+-- force the lazy dense halves.
+rrdbIsThin :: RuleRelationDB -> Bool
+rrdbIsThin (RuleRelationDB dset dense _) = S.null dset && M.null dense
+
+-- attach rederived dense halves to the byproduct entries of a thin DB
+rrdbGraftDenseHalves :: RuleRelationDB -> RuleRelationDB -> RuleRelationDB
+rrdbGraftDenseHalves (RuleRelationDB dset dense _) (RuleRelationDB _ _ byp) =
+    RuleRelationDB dset dense byp
 
 instance Show RuleRelationDB where
     show rrdb = show (rrdbToList rrdb)

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -364,6 +364,21 @@ getB = In $ \(IS bc bs off) ->
 getI :: In Int
 getI = do { b <- getB; return (fromEnum b) }
 
+-- LEB128: little-endian 7-bit groups, high bit set on all but the last.
+-- Values below 128 cost one byte, below 16384 two, and so on.
+putVarint :: Int -> Out ()
+putVarint n
+    | n < 0     = internalError $ "BinData.putVarint: negative: " ++ show n
+    | n < 0x80  = putB (toEnum n)
+    | otherwise = do putB (toEnum ((n .&. 0x7f) .|. 0x80))
+                     putVarint (n `shiftR` 7)
+
+getVarint :: In Int
+getVarint = go 0 0
+  where go acc sh = do b <- getB
+                       let acc' = acc .|. ((fromEnum b .&. 0x7f) `shiftL` sh)
+                       if b < 0x80 then return acc' else go acc' (sh + 7)
+
 {-
 getBytesRead :: In Integer
 getBytesRead = In $ \is@(IS _ _ _ n) -> (n,is)
@@ -452,15 +467,13 @@ mkLookupIdx get idx =
 -- indexes are assigned in the same top-down order as they are assigned
 -- during writing.  This particularly affects recursive types.
 readShared :: (Bin a, Shared k a) => In a
-readShared = do tag <- getI
+readShared = do tag <- getVarint
                 case tag of
                   0 -> do (idx, dummy) <- newVal
                           v <- readBytes
                           recordVal idx (v `asTypeOf` dummy)
                           return v
-                  1 -> do idx <- readBytes
-                          lookupIdx idx
-                  n -> internalError $ "BinData.readShared: invalid tag " ++ (show tag)
+                  n -> lookupIdx (n - 1)
 
 -- actual Shared instance definitions
 
@@ -1494,11 +1507,16 @@ share (IT t)  bc = share' (itype_key t) t bc
 -- share (ASL l) bc = share' l l bc
 share be      bc = ([be], bc)
 
+-- A shared value is either new (payload follows) or a backreference.
+-- One varint carries both: 0 = new, v = a backref to index v-1.
+-- Interned values repeat constantly, so backref width dominates the
+-- stream: indices below 127 cost a single byte (the old encoding spent
+-- a discriminator byte plus a terminated base-254 integer, 2-4 bytes).
 share' :: (Bin v, Shared k v) => k -> v -> BinCache -> ([BinElem], BinCache)
 share' k x bc =
           case (knownAs k x bc) of
-            (Just idx) -> (out_data $ do { putI 1; writeBytes idx }, bc)
-            Nothing    -> (out_data $ do { putI 0; writeBytes x },
+            (Just idx) -> (out_data $ putVarint (idx + 1), bc)
+            Nothing    -> (out_data $ do { putVarint 0; writeBytes x },
                            addKey k x bc)
 
 

--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE PatternSynonyms, OverloadedLists, TypeFamilies #-}
 {-# OPTIONS_GHC -Werror -fwarn-incomplete-patterns #-}
 module BinData ( Byte
-               , putBs, putB, putI
-               , getN, getB, getI -- , getBytesRead
+               , putBs, putB, putI, putChunk
+               , getN, getB, getI, getBS -- , getBytesRead
                , Bin(..)
                , section
-               , encode, decode, decodeWithHash
+               , encode, encodeLazy, decode, decodeWithHash
                ) where
 
 {- Routines for converting structures to/from byte strings.
@@ -60,6 +60,7 @@ import Data.Bits
 import Data.Word
 import GHC.Exts(IsList(..))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as TE
@@ -116,6 +117,7 @@ type Byte = Word8
 -}
 
 data BinElem = B [Byte]
+             | BC !BS.ByteString  -- a pre-packed chunk of plain bytes
              -- shared types
              | S FString
              | I Id
@@ -131,6 +133,9 @@ data BinElem = B [Byte]
 instance Show BinElem where
   show (B bs)    = "[" ++
                    (intercalate "," [showHex b "" | b <- bs]) ++
+                   "]"
+  show (BC bs)   = "[" ++
+                   (intercalate "," [showHex b "" | b <- BS.unpack bs]) ++
                    "]"
   show (S s)     = getFString s
   show (I i)     = show i
@@ -302,6 +307,11 @@ putBs bs = Out [B bs] ()
 putB :: Byte -> Out ()
 putB b = putBs [b]
 
+-- Insert a pre-packed chunk of bytes (avoids the [Byte] detour for
+-- payloads that already exist as a ByteString)
+putChunk :: BS.ByteString -> Out ()
+putChunk bs = Out [BC bs] ()
+
 -- Insert an Int value (between 0 and 255) into the byte stream
 putI :: Int -> Out ()
 putI n = if (n >= 0) && (n < 256)
@@ -352,6 +362,15 @@ instance Applicative In where
 
 getN :: Int -> In [Byte]
 getN n = replicateM n getB
+
+-- Read n bytes as one slice of the input (no per-byte list cells).
+getBS :: Int -> In BS.ByteString
+getBS n = In $ \(IS bc bs off) ->
+  if off + n > BS.length bs
+  then internalError "BinData.getBS: unexpected end of byte stream"
+  else let sl = BS.take n (BS.drop off bs)
+           !off' = off + n
+       in (sl, IS bc bs off')
 
 getB :: In Byte
 getB = In $ \(IS bc bs off) ->
@@ -674,10 +693,10 @@ instance Bin FString where
 instance {-# OVERLAPPABLE #-} Bin String where
     writeBytes fs = do let bs = TE.encodeUtf8 $ T.pack fs
                        toBin $ toInteger $ B.length bs
-                       putBs $ B.unpack bs
+                       putChunk $ B.toStrict bs
     readBytes     = do len <- fromBin
-                       bs <- getN len
-                       return (T.unpack $ TE.decodeUtf8 $ B.pack bs)
+                       bs <- getBS len
+                       return (T.unpack $ TE.decodeUtf8 $ B.fromStrict bs)
 
 instance Bin Position where
     writeBytes (Position fs l c is_stdlib) = section "Position" $ do
@@ -1484,6 +1503,8 @@ buildHistogram bes = snd (foldl build (["<UNCLAIMED>"], M.empty) bes)
   where build ([], _) _ = internalError "unbalanced accounting marks"
         build (sec, hist) (B b) =
           (sec, updateBytes sec (toInteger (length b)) hist)
+        build (sec, hist) (BC b) =
+          (sec, updateBytes sec (toInteger (BS.length b)) hist)
         build (sec, hist) (Start s) = ((s:sec), incrSection s hist)
         build ((_:sec), hist) End   = (sec, hist)
         build _ x = internalError $ "unexpected BinElem: " ++ (show x)
@@ -1523,6 +1544,7 @@ share' k x bc =
 compress :: [BinElem] -> [BinElem]
 compress bes = compress' (bes, unknownCache)
   where compress' ((x@(B _):xs), cache) = x:(compress' (xs, cache))
+        compress' ((x@(BC _):xs), cache) = x:(compress' (xs, cache))
         compress' ((x@(Start _):xs), cache) = x:(compress' (xs, cache))
         compress' ((x@(End):xs), cache) = x:(compress' (xs, cache))
         compress' ((x:xs), cache) =
@@ -1537,16 +1559,39 @@ compress bes = compress' (bes, unknownCache)
 
 runOut :: Out () -> [Byte]
 runOut (Out xs _) = let bes   = compress $ toList xs
-                        bytes = concat [ bs | B bs <- bes ]
+                        bytes = concat [ elemBytes e | e <- bes ]
+                        elemBytes (B bs)  = bs
+                        elemBytes (BC bs) = BS.unpack bs
+                        elemBytes _       = []
                     in -- trace ("xs = " ++ (show xs)) $
                        -- trace ("bytes = " ++ (show bytes)) $
                        if trace_bindata
                        then trace (showHist (buildHistogram bes)) $ bytes
                        else bytes
 
+-- Builder-backed variant of the same pipeline: the compressed element
+-- stream folds straight into Builder buffers (adjacent byte runs
+-- coalesce into ~4k chunks) instead of materializing a [Byte].  The
+-- element stream is consumed lazily exactly as above, so production
+-- stays demand-driven: nothing is forced that the traversal does not
+-- visit.
+runOutBuilder :: Out () -> BB.Builder
+runOutBuilder (Out xs _) =
+    let bes = compress $ toList xs
+        toB (B bs)  = foldMap BB.word8 bs
+        toB (BC bs) = BB.byteString bs
+        toB _       = mempty
+    in if trace_bindata
+       then trace (showHist (buildHistogram bes)) $ foldMap toB bes
+       else foldMap toB bes
+
 -- Convenience function for encoding structures in the Bin typeclass
 encode :: (Bin a) => a -> [Byte]
 encode x = runOut (toBin x)
+
+-- lazy-ByteString encode: chunks stream to the consumer as they fill
+encodeLazy :: (Bin a) => a -> B.ByteString
+encodeLazy x = BB.toLazyByteString (runOutBuilder (toBin x))
 
 runIn :: In a -> BS.ByteString -> (a, Int)
 runIn (In f) bs =

--- a/src/comp/FileIOUtil.hs
+++ b/src/comp/FileIOUtil.hs
@@ -10,6 +10,7 @@ module FileIOUtil
     ,readBinaryFileCatch
     ,writeFileCatch
     ,writeBinaryFileCatch
+    ,writeBinaryFileLazyCatch
     ,appendFileCatch
     ,removeFileCatch
     ,copyFileCatch
@@ -248,6 +249,14 @@ writeBinaryFileCatch errh fname content = do
     checkDirectory fname (fileWriteError errh emptyContext noPosition fname)
     -- try to write the file
     catchIO (B.writeFile fname $ B.pack content)
+            (fileWriteError errh emptyContext noPosition fname)
+
+-- variant taking an already-chunked lazy ByteString (streams to disk
+-- without the per-byte pack)
+writeBinaryFileLazyCatch :: ErrorHandle -> FilePath -> B.ByteString -> IO ()
+writeBinaryFileLazyCatch errh fname content = do
+    checkDirectory fname (fileWriteError errh emptyContext noPosition fname)
+    catchIO (B.writeFile fname content)
             (fileWriteError errh emptyContext noPosition fname)
 
 appendFileCatch :: ErrorHandle -> FilePath -> String -> IO ()

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -156,7 +156,7 @@ data Flags = Flags {
         warnMethodUrgency :: Bool,
         warnUndetPred :: Bool,
         -- appended last: the Bin Flags instance in GenABin.hs is
-        -- positional, so new fields go at the end (position a_135)
+        -- positional, so new fields go at the end (position a_136)
         checkOnly :: Bool,
         -- Record the transitive-closure hashes in a package's depends list,
         -- and run the consistency check they drive.  On by default.
@@ -167,7 +167,8 @@ data Flags = Flags {
         -- and its own dependents cache-hit.  Turning it off is only safe where
         -- the build guarantees input consistency: bazel content-addresses its
         -- inputs, a search path with a stale .bo does not.
-        importHashes :: Bool
+        importHashes :: Bool,
+        baDebugInfo :: Bool
         }
 -- don't derive Show -- it causes an optimized ghc build to take a long time
 --        deriving (Show)

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -561,6 +561,7 @@ defaultFlags bluespecdir = Flags {
         importHashes = True,
         enablePoisonPills = False,
         entry = Nothing,
+        baDebugInfo = False,
         expandATSlimit = 20,
         expandIf = False,
         fdir = Nothing,
@@ -1121,6 +1122,10 @@ externalFlags = [
         ("aggressive-conditions",
          (Toggle (\f x -> f {aggImpConds=x}) (showIfTrue aggImpConds),
           "construct implicit conditions aggressively", Visible)),
+
+        ("ba-debug-info",
+         (Toggle (\f x -> f {baDebugInfo=x}) (showIfTrue baDebugInfo),
+          "serialize full debug info into .ba files (all pairwise rule relations and the method-conflict dump); without it .ba files carry only what code generation needs", Visible)),
 
         ("bdir",
          (Arg "dir" (\f s -> Left (f {bdir = Just s}))
@@ -1883,6 +1888,7 @@ showFlagsRaw flags =
           ("extraVerbose", show (extraVerbose flags)),
           ("fdir", show (fdir flags)),
           ("finalcleanup", show (finalcleanup flags)),
+          ("baDebugInfo", show (baDebugInfo flags)),
           ("genABin", show (genABin flags)),
           ("genABinVerilog", show (genABinVerilog flags)),
           ("genName", show (genName flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -37,7 +37,9 @@ import Data.Word(Word8)
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-5"
+-- when a BinData-layer change bumps .bo and .ba together, move both
+-- format tags (see GenBin.hs)
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-6"
 
 headerBS :: B.ByteString
 headerBS = B.pack header

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -21,7 +21,8 @@ import Verilog
 
 import ABin
 import BinData
-import FileIOUtil(writeBinaryFileCatch)
+import qualified Data.ByteString.Lazy as BL
+import FileIOUtil(writeBinaryFileLazyCatch)
 
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -46,7 +47,8 @@ headerBS = B.pack header
 
 genABinFile :: ErrorHandle -> String -> ABin -> IO ()
 genABinFile errh fn abin =
-    writeBinaryFileCatch errh fn (header ++ encode abin)
+    writeBinaryFileLazyCatch errh fn
+        (BL.fromStrict headerBS `BL.append` encodeLazy abin)
 
 readABinFile :: ErrorHandle -> String -> B.ByteString -> (ABin, String)
 readABinFile errh nm s =

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -33,7 +33,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-3"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-4"
 
 headerBS :: B.ByteString
 headerBS = B.pack header

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -24,7 +24,6 @@ import BinData
 import FileIOUtil(writeBinaryFileCatch)
 
 import qualified Data.Set as S
-import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
@@ -34,7 +33,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-2"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-3"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -421,15 +420,16 @@ instance Bin ExclusiveRulesDB where
     writeBytes erdb = section "ExclusiveRulesDB" $ toBin (erdbToList erdb)
     readBytes = do es <- fromBin; return (erdbFromList es)
 
+-- wire form is unchanged (a set and one merged conflict list); a thin
+-- db (the default -- see thinRuleRelationDB in writeABin) has an empty
+-- set and byproduct entries only, so writing it forces nothing dense
 instance Bin RuleRelationDB where
-    writeBytes (RuleRelationDB dset cmap) =
+    writeBytes rrdb@(RuleRelationDB dset _ _) =
         section "RuleRelationDB" $ do toBin (S.toList dset)
-                                      toBin (M.toList cmap)
+                                      toBin (rrdbSerializedConflicts rrdb)
     readBytes = do dset_list <- fromBin
                    cmap_list <- fromBin
-                   let dset = S.fromList dset_list
-                       cmap = M.fromList cmap_list
-                   return (RuleRelationDB dset cmap)
+                   return (rrdbFromSerialized dset_list cmap_list)
 
 instance Bin RuleRelationInfo where
     writeBytes (RuleRelationInfo mCF mSC mRes mCycle mPragma mArb) =
@@ -561,11 +561,11 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135) =
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8; wr_chunk9
       where
-        -- The 136-field serialization is split into NOINLINE chunks so
+        -- The 137-field serialization is split into NOINLINE chunks so
         -- that GHC optimizes bounded pieces: compiling it as a single
         -- monadic chain needs more than 15GB of heap.
         {-# NOINLINE wr_chunk0 #-}
@@ -615,7 +615,7 @@ instance Bin Flags where
              toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
         {-# NOINLINE wr_chunk9 #-}
         wr_chunk9 =
-          do toBin a_135
+          do toBin a_135; toBin a_136
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -635,7 +635,7 @@ instance Bin Flags where
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
            a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
-          a_135 <- rd_chunk9
+          (a_135, a_136) <- rd_chunk9
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -650,7 +650,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134 a_135)
+                a_130 a_131 a_132 a_133 a_134 a_135 a_136)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -718,8 +718,8 @@ instance Bin Flags where
                      a_128, a_129, a_130, a_131, a_132, a_133, a_134)
         {-# NOINLINE rd_chunk9 #-}
         rd_chunk9 =
-          do a_135 <- fromBin
-             return a_135
+          do a_135 <- fromBin; a_136 <- fromBin
+             return (a_135, a_136)
 
 -- ----------
 

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -23,17 +23,21 @@ import ABin
 import BinData
 import FileIOUtil(writeBinaryFileCatch)
 
+import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
+import Data.Bits((.&.), shiftR, shiftL, (.|.))
+import Data.List(sort)
+import Data.Word(Word8)
 
 -- import Debug.Trace
 
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-4"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260804-5"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -416,9 +420,68 @@ instance Bin RuleUses where
     readBytes = do pus <- fromBin; rus <- fromBin; wus <- fromBin
                    return (RuleUses pus rus wus)
 
+-- The exclusive-rules db is pairwise-dense: every disjoint-and-state-
+-- sharing rule pair appears in two adjacency sets, and the generic
+-- per-element list encoding (a tag byte plus an interned-Id reference
+-- per member) costs ~10 bytes per pair.  Instead emit the rule table
+-- once and each adjacency set as one raw blob of varint-encoded deltas
+-- over sorted table indices (~1 byte per member for dense relations).
 instance Bin ExclusiveRulesDB where
-    writeBytes erdb = section "ExclusiveRulesDB" $ toBin (erdbToList erdb)
-    readBytes = do es <- fromBin; return (erdbFromList es)
+    writeBytes (ExclusiveRulesDB emap) =
+        section "ExclusiveRulesDB" $ do
+            let keys  = M.keys emap
+                extra = S.toList
+                            (S.unions [ S.union s1 s2
+                                      | (s1, s2) <- M.elems emap ]
+                             `S.difference` S.fromList keys)
+                table = keys ++ extra
+                idx   = M.fromList (zip table [0 :: Int ..])
+                packSet s = packVarintDeltas
+                                (sort [ idx M.! r | r <- S.toList s ])
+                writeBlob bs = do toBin (length bs); putBs bs
+            toBin table
+            toBin (length keys)
+            mapM_ (\ (s1, s2) -> do writeBlob (packSet s1)
+                                    writeBlob (packSet s2))
+                  (M.elems emap)
+    readBytes =
+        do table <- fromBin
+           nkeys <- fromBin
+           let tmap = M.fromList (zip [0 :: Int ..] (table :: [ARuleId]))
+               readBlob = do n <- fromBin; getN n
+               readSet = do bs <- readBlob
+                            return (S.fromList
+                                        [ tmap M.! i
+                                        | i <- unpackVarintDeltas bs ])
+           entries <- mapM (\ k -> do s1 <- readSet
+                                      s2 <- readSet
+                                      return (k, (s1, s2)))
+                           (take nkeys table)
+           return (ExclusiveRulesDB (M.fromList entries))
+
+-- sorted distinct non-negative ints -> little-endian 7-bit varints of
+-- the successive gaps (first element as-is, then x_i - x_{i-1} - 1)
+packVarintDeltas :: [Int] -> [Word8]
+packVarintDeltas xs =
+    let ds = zipWith (\ prev x -> x - prev - 1) ((-1) : xs) xs
+        varint n | n < 0x80  = [fromIntegral n]
+                 | otherwise = (fromIntegral (n .&. 0x7f) .|. 0x80)
+                               : varint (n `shiftR` 7)
+    in  concatMap varint ds
+
+unpackVarintDeltas :: [Word8] -> [Int]
+unpackVarintDeltas = go (-1)
+  where
+    go _ [] = []
+    go prev bs =
+        let (d, rest) = varint 0 0 bs
+            x = prev + d + 1
+        in  x : go x rest
+    varint acc sh (b:bs)
+        | b < 0x80  = (acc .|. (fromIntegral b `shiftL` sh), bs)
+        | otherwise = varint (acc .|. (fromIntegral (b .&. 0x7f) `shiftL` sh))
+                             (sh + 7) bs
+    varint _ _ [] = internalError "GenABin.unpackVarintDeltas: truncated"
 
 -- wire form is unchanged (a set and one merged conflict list); a thin
 -- db (the default -- see thinRuleRelationDB in writeABin) has an empty

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -29,7 +29,9 @@ doTrace = elem "-trace-genbin" progArgs
 -- .bo file tag -- change this whenever the .bo format changes
 -- See also GenABin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-3"
+-- when a BinData-layer change bumps .bo and .ba together, move both
+-- format tags (see GenABin.hs)
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-4"
 
 headerBS :: B.ByteString
 headerBS = B.pack header

--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -3,7 +3,6 @@
 module GenBin(genBinFile, readBinFile, genBcFile, readBcFile) where
 
 import Control.Monad(when)
-import Data.List(foldl')
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString as B
@@ -17,7 +16,8 @@ import ISyntaxUtil(icUndet, pkgHasPoisonPill)
 import CSyntax
 import Undefined(UndefKind(UNoMatch))
 import BinData
-import FileIOUtil(writeBinaryFileCatch)
+import qualified Data.ByteString.Lazy as BL
+import FileIOUtil(writeBinaryFileLazyCatch)
 import PFPrint
 
 import Debug.Trace
@@ -59,14 +59,15 @@ pillByte p = if p then 1 else 0
 -- longer moves it, and fixupDefs does rewrite a package's defs against
 -- imported def bodies -- rebuild ordering (make/bazel) is what covers that.
 sigHash :: CSignature -> String
-sigHash sig = showHash (foldl' nextHashByte hashInit (encode sig))
+sigHash sig = showHash (BL.foldl' nextHashByte hashInit (encodeLazy sig))
 
 genBinFile :: ErrorHandle ->
               String -> CSignature -> CSignature -> IPackage a -> IO ()
 genBinFile errh fn bi_sig bo_sig ipkg =
-    writeBinaryFileCatch errh fn
-        (header ++ pillByte (pkgHasPoisonPill ipkg) :
-             encode (sigHash bi_sig, (bi_sig, bo_sig, ipkg)))
+    writeBinaryFileLazyCatch errh fn
+        (BL.fromStrict headerBS `BL.append`
+         BL.singleton (pillByte (pkgHasPoisonPill ipkg)) `BL.append`
+             encodeLazy (sigHash bi_sig, (bi_sig, bo_sig, ipkg)))
 
 readBinFile :: ErrorHandle -> String -> B.ByteString ->
                IO (CSignature, CSignature, IPackage a, String, Bool)
@@ -106,8 +107,9 @@ bcHeaderBS = B.pack bcHeader
 genBcFile :: ErrorHandle -> String -> [(Id, Maybe String)] -> CSignature ->
              IO ()
 genBcFile errh fn depends bi_sig =
-    writeBinaryFileCatch errh fn
-        (bcHeader ++ encode (sigHash bi_sig, (depends, bi_sig)))
+    writeBinaryFileLazyCatch errh fn
+        (BL.fromStrict bcHeaderBS `BL.append`
+         encodeLazy (sigHash bi_sig, (depends, bi_sig)))
 
 readBcFile :: ErrorHandle -> String -> B.ByteString ->
               IO (([(Id, Maybe String)], CSignature), String)

--- a/src/comp/SimExpand.hs
+++ b/src/comp/SimExpand.hs
@@ -978,7 +978,11 @@ makeCSIForModule curmod_abi =
         curmod_drdb = exclRulesDBToDisjRulesDB $
                           asi_exclusive_rules_db curmod_aschedinfo
 
-        (RuleRelationDB _ curmod_rule_rel_map)
+        -- only the byproduct entries: the sole read (isFFuncEdge's
+        -- exact all-Nothing-but-mArb pattern) treats a missing pair
+        -- and a cf/sc-only dense pair identically, so the dense map
+        -- (absent from thin .ba files) is not consulted at all
+        (RuleRelationDB _ _ curmod_rule_rel_map)
             = asi_rule_relation_db curmod_aschedinfo
 
         curmod_apkg    = abmi_apkg            curmod_abi

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -68,6 +68,7 @@ import ISyntaxUtil(itBool, itClock, itReset)
 import ASyntax
 import ASyntaxUtil
 import Pragma
+import ASchedule(aScheduleDenseRuleRelationDB)
 import AScheduleInfo
 import AUses(MethodId(..))
 import VModInfo
@@ -173,6 +174,10 @@ data TclP = TclP { tp_flags    :: Flags
                  , tp_symtab   :: !SymTab
                  , tp_cpack    :: !CPackage
                  , tp_mods     :: !(Maybe ModInfo)
+                   -- per-module rule-relation DBs completed with dense
+                   -- halves rederived from the APackage (the default
+                   -- .ba omits them); cleared whenever tp_mods changes
+                 , tp_rrdbCache :: !(M.Map String RuleRelationDB)
                  , tp_packView :: !(ExpandInfoBag BPackView)
                  , tp_modView  :: !(ExpandInfoBag BModView)
                  , tp_typeView :: !( [(CType, TypeAnalysis)]
@@ -196,6 +201,7 @@ initState =
             , tp_symtab   = emptySymtab
             , tp_cpack    = (CPackage pid (Right []) [] [] [] [] [])
             , tp_mods     = Nothing
+            , tp_rrdbCache = M.empty
             , tp_packView = initExpandInfoBag
             , tp_modView  = initExpandInfoBag
             , tp_typeView = ([], initExpandInfoBag)
@@ -1046,7 +1052,8 @@ tclModule ["load",topname] = do
   let modnames = map fst abmis_by_name
   let res = (topmodId, hierMap, instModMap, ffuncMap, foreign_mods,
              [(n,mi) | (n,(mi,_)) <- abmis_by_name])
-  modifyIORef globalVar (\gv -> gv { tp_mods = Just res })
+  modifyIORef globalVar (\gv -> gv { tp_mods = Just res
+                                   , tp_rrdbCache = M.empty })
 
   -- now load the package in which the module was defined
   -- (so that its interface types are available)
@@ -1068,7 +1075,8 @@ tclModule ["list"] = do
 
 ------
 tclModule ["clear"] = do
-  modifyIORef globalVar (\gv -> gv { tp_mods = Nothing })
+  modifyIORef globalVar (\gv -> gv { tp_mods = Nothing
+                                   , tp_rrdbCache = M.empty })
   return $ TLst []
 ------
 tclModule ["submods",modname] = do
@@ -1225,6 +1233,34 @@ tclModule ("flags":modname:ss) = do
 ------
 tclModule xs = internalError $ "tclModule: grmap (TStr . pfpString) grammar mismatch: " ++ (show xs)
 
+
+-- The default .ba stores only the byproduct entries of the
+-- rule-relation DB; the dense halves (the disjointness set and the
+-- cf/sc conflict entries) are omitted and must be rederived from the
+-- APackage for 'rule rel' to report complete relations (see
+-- thinRuleRelationDB).  The rederivation reruns the schedule conflict
+-- analysis (quadratic in rules, with SAT calls for disjointness), so
+-- cache the completed DB per module; the cache is cleared whenever
+-- tp_mods changes.  A DB that already has its dense halves (from a
+-- -ba-debug-info .ba) is used as is.
+getFullRuleRelationDB :: String -> ABinEitherModInfo -> RuleRelationDB
+                      -> IO RuleRelationDB
+getFullRuleRelationDB modname abmi rrdb
+  | not (rrdbIsThin rrdb) = return rrdb
+  | otherwise = do
+      g <- readIORef globalVar
+      case (M.lookup modname (tp_rrdbCache g)) of
+        Just full -> return full
+        Nothing -> do
+          mdense <- aScheduleDenseRuleRelationDB globalErrHandle
+                        (abemi_flags abmi) (abemi_apkg abmi)
+          let full = case mdense of
+                       Just dense -> rrdbGraftDenseHalves dense rrdb
+                       Nothing    -> rrdb
+          modifyIORef globalVar
+              (\gv -> gv { tp_rrdbCache =
+                               M.insert modname full (tp_rrdbCache gv) })
+          return full
 
 findModule :: String -> IO (Maybe ABinEitherModInfo)
 findModule modname =
@@ -1586,7 +1622,8 @@ tclRule ["rel", modname, rule1, rule2] =
            case (abemi_rule_relation_db abmi) of
              Nothing -> return $
                             TStr "Rule relationship information not available"
-             Just rrdb -> do
+             Just rrdb0 -> do
+                 rrdb <- getFullRuleRelationDB modname abmi rrdb0
                  let apkg = abemi_apkg abmi
                      user_rule_names = map arule_id (apkg_rules apkg)
                      ifc_rule_names = concatMap aIfaceSchedNames

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -117,6 +117,7 @@ import ARankMethCalls(aRankMethCalls)
 import AState(aState)
 import ARenameIO(aRenameIO)
 import ASchedule(AScheduleInfo(..), AScheduleErrInfo(..), aSchedule)
+import AScheduleInfo(thinRuleRelationDB)
 import AAddScheduleDefs(aAddScheduleDefs)
 import APaths(aPathsPreSched, aPathsPostSched)
 import AProofs(aCheckProofs)
@@ -1103,15 +1104,28 @@ writeABin errh pps flags dumpnames t prefix modstr srcName oqt
                   Nothing -> "Elaborated module file created: "
                   Just be ->
                       "Elaborated " ++ ppString be ++ " module file created: "
+           -- by default the .ba carries only what code generation
+           -- consumes: the dense pairwise rule relations (quadratic in
+           -- rules, derivable from the apkg) and the method-conflict
+           -- dump are debug data -- -ba-debug-info serializes them
+           sched_info_ba
+               | baDebugInfo flags = sched_info
+               | otherwise =
+                   sched_info { asi_rule_relation_db =
+                                    thinRuleRelationDB
+                                        (asi_rule_relation_db sched_info) }
+           method_dump_ba
+               | baDebugInfo flags = methodConflict
+               | otherwise         = []
            modinfo = ABinModInfo {
                           abmi_path = prefix,
                           abmi_src_name = srcName,
                           --abmi_time = now,
                           abmi_apkg        = amod_for_abin,
-                          abmi_aschedinfo  = sched_info,
+                          abmi_aschedinfo  = sched_info_ba,
                           abmi_pps         = pps,
                           abmi_oqt         = oqt,
-                          abmi_method_dump = methodConflict,
+                          abmi_method_dump = method_dump_ba,
                           abmi_pathinfo = vPathInfo,
                           abmi_flags       = flags,
                           abmi_vprogram    = if (genABinVerilog flags)

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1104,16 +1104,26 @@ writeABin errh pps flags dumpnames t prefix modstr srcName oqt
                   Nothing -> "Elaborated module file created: "
                   Just be ->
                       "Elaborated " ++ ppString be ++ " module file created: "
+           -- asi_sched_order has no reader anywhere (not codegen, not
+           -- Bluesim, not bluetcl, and PPrint omits it so dumpba can't
+           -- show it) -- drop it unconditionally.  Bluesim rederives
+           -- the order it needs by flattening the merged sched graph.
+           sched_info_dead = sched_info { asi_sched_order = [] }
            -- by default the .ba carries only what code generation
            -- consumes: the dense pairwise rule relations (quadratic in
-           -- rules, derivable from the apkg) and the method-conflict
-           -- dump are debug data -- -ba-debug-info serializes them
+           -- rules, derivable from the apkg), the rule-uses map (no .ba
+           -- reader -- its compile-time users run before writeABin, and
+           -- the method-uses map codegen needs is derived from it), and
+           -- the method-conflict dump are debug data -- -ba-debug-info
+           -- serializes them
            sched_info_ba
-               | baDebugInfo flags = sched_info
+               | baDebugInfo flags = sched_info_dead
                | otherwise =
-                   sched_info { asi_rule_relation_db =
-                                    thinRuleRelationDB
-                                        (asi_rule_relation_db sched_info) }
+                   sched_info_dead
+                       { asi_rule_relation_db =
+                             thinRuleRelationDB
+                                 (asi_rule_relation_db sched_info_dead)
+                       , asi_rule_uses_map = M.empty }
            method_dump_ba
                | baDebugInfo flags = methodConflict
                | otherwise         = []

--- a/testsuite/bsc.options/bsc.help.out.expected
+++ b/testsuite/bsc.options/bsc.help.out.expected
@@ -20,6 +20,7 @@ Compiler flags:
 -Xl arg                 pass argument to the C/C++ linker
 -Xv arg                 pass argument to the Verilog link process
 -aggressive-conditions  construct implicit conditions aggressively
+-ba-debug-info          serialize full debug info into .ba files (all pairwise rule relations and the method-conflict dump); without it .ba files carry only what code generation needs
 -bdir dir               output directory for .bo and .ba files
 -check-assert           test assertions with the Assert library
 -check-only             stop after typechecking and write a signature-only .bc file; imports prefer .bc and fall back to .bo

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -27,6 +27,7 @@ Flags {
 	extraVerbose = False,
 	fdir = Nothing,
 	finalcleanup = 1,
+	baDebugInfo = False,
 	genABin = False,
 	genABinVerilog = False,
 	genName = [],


### PR DESCRIPTION
Serialization window 5/5 (II-21), 6 commits incl. the REQUIRED bluetcl rederivation half (rule rel verified from a thin .ba) and -ba-debug-info escape hatch. Tags: bsc-ba-20260804-3..6, bsc-bo-20260804-4. Builds; bluetcl dirs 193/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt