### PR TITLE
ctype: intern ground normal forms behind TAp/TCon pattern synonyms

### DIFF
--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, PatternGuards, DeriveDataTypeable #-}
+{-# LANGUAGE PatternSynonyms #-}
 -- | The CType package defines the concrete representation of types and kinds.
 module CType(
   -- * Types
-  Type(..), CType, TyVar(..), TyCon(..), TISort(..), StructSubType(..),
+  -- TAp and TCon are bidirectional pattern synonyms over the hidden
+  -- real constructors (the IType idiom); see the consing note below.
+  Type(TVar, TCon, TAp, TGen, TDefMonad),
+  CType, TyVar(..), TyCon(..), TISort(..), StructSubType(..),
+  isCanonType, typeCanonId, consCTypeEnabled, cTypeConsStats,
 
   -- ** Examining Types
   getTyVarId, getTypeKind,
@@ -60,6 +65,16 @@ import Data.Char(isDigit, chr)
 import Data.List(union)
 import Data.Maybe
 import qualified Data.Generics as Generic
+import qualified Data.Map.Strict as M
+import qualified Data.IntMap.Strict as IM
+import qualified Data.IntSet as IS
+import Data.IORef(IORef, newIORef, readIORef, modifyIORef', atomicModifyIORef')
+import Control.Exception(SomeException, SomeAsyncException(..),
+                         fromException, throwIO, try, evaluate)
+import Control.Monad(when)
+import Data.Bits(finiteBitSize)
+import System.IO.Unsafe(unsafePerformIO, unsafeDupablePerformIO)
+import IOUtil(progArgs)
 
 import Eval
 import PPrint
@@ -68,7 +83,7 @@ import Id
 import IdPrint
 import PreIds(idArrow, idPrimPair, idPrimUnit, idBit, idString,
               idPrimAction, idAction, idActionValue_, idActionValue,
-              idTNumToStr)
+              idTNumToStr, idId)
 import Util(itos)
 import ErrorUtil
 import Pragma(IfcPragma)
@@ -79,12 +94,68 @@ import FStringCompat
 -- Data structures
 
 -- | Representation of types
-data Type = TVar TyVar         -- ^ type variable
-          | TCon TyCon         -- ^ type constructor
-          | TAp Type Type      -- ^ type-level application
-          | TGen Position Int  -- ^ quantified type variable used in type schemes
-          | TDefMonad Position -- ^ not used after CVParserImperative
-    deriving (Show, Generic.Data, Generic.Typeable)
+--
+-- TCon_ and TAp_ carry a canonical-node id slot (the IType idiom):
+-- -1 means a raw node with no canonicality claim; >= 0 means THIS
+-- OBJECT is the unique intern-table representative of its structure,
+-- with every child transitively canonical -- and therefore ground
+-- (no TVar/TGen/TDefMonad anywhere inside).  Ids are assigned only by
+-- the intern machinery below; every other construction site must use
+-- -1.  The slot makes the child-membership groundness test a field
+-- read, and equal ids mean the same heap object.
+data Type = TVar TyVar          -- ^ type variable
+          | TCon_ {-# UNPACK #-} !Int TyCon
+                                -- ^ type constructor (build via 'TCon')
+          | TAp_ {-# UNPACK #-} !Int Type Type
+                                -- ^ type-level application (build via 'TAp')
+          | TGen Position Int   -- ^ quantified type variable used in type schemes
+          | TDefMonad Position  -- ^ not used after CVParserImperative
+    deriving (Generic.Typeable)
+
+-- The construction choke points: every out-of-module (and in-module)
+-- TCon/TAp goes through the smart constructors, which count and
+-- hash-cons ground nodes at construction.
+pattern TCon :: TyCon -> Type
+pattern TCon c <- TCon_ _ c
+  where TCon c = mkTCon c
+
+pattern TAp :: Type -> Type -> Type
+pattern TAp f a <- TAp_ _ f a
+  where TAp f a = mkTAp f a
+
+{-# COMPLETE TVar, TCon, TAp, TGen, TDefMonad #-}
+
+-- | The canonical-node id of a type: -1 unless this object is the
+-- unique canonical (hence ground) intern-table node for its structure.
+typeCanonId :: Type -> Int
+typeCanonId (TAp_ i _ _) = i
+typeCanonId (TCon_ i _)  = i
+typeCanonId _            = -1
+
+-- | Canonical implies ground: no TVar/TGen/TDefMonad anywhere inside,
+-- so substitution and zonking are identities and tv is empty.
+isCanonType :: Type -> Bool
+isCanonType t = typeCanonId t >= 0
+
+-- Derived Show would print the slots and the underscored names; this
+-- reproduces the original derived format over the public constructors.
+instance Show Type where
+    showsPrec d (TVar v) = showParen (d > 10) $
+        showString "TVar " . showsPrec 11 v
+    showsPrec d (TCon c) = showParen (d > 10) $
+        showString "TCon " . showsPrec 11 c
+    showsPrec d (TAp f a) = showParen (d > 10) $
+        showString "TAp " . showsPrec 11 f . showString " " . showsPrec 11 a
+    showsPrec d (TGen p i) = showParen (d > 10) $
+        showString "TGen " . showsPrec 11 p . showString " " . showsPrec 11 i
+    showsPrec d (TDefMonad p) = showParen (d > 10) $
+        showString "TDefMonad " . showsPrec 11 p
+
+-- No Data instance for Type: the pre-slot deriving was vestigial (syb
+-- traversals in the compiler are confined to the Verilog AST, and no
+-- Data-deriving container embeds a Type), and its absence closes the
+-- one generic-rebuild path that could have fabricated an id slot.
+-- TISort's and TyCon's Data derivings go with it -- they embed Type.
 
 -- | Representation of a type variable
 data TyVar = TyVar { tv_name :: Id    -- ^ name of the type variable
@@ -108,7 +179,7 @@ data TyCon = -- | A constructor for a type of value kind
            | TyStr { tystr_value :: FString  -- ^ type-level string value
                    , tystr_pos   :: Position -- ^ position of introduction
                    }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show, Generic.Typeable)
 
 data TISort
         = -- type synonym
@@ -128,7 +199,7 @@ data TISort
                 , atf_param_idxs :: [Int]  -- index of each ATF param in the class param list
                 , atf_target_idx :: Int    -- index of the result param in the class param list
                 }
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Typeable)
 
 
 data StructSubType
@@ -145,6 +216,308 @@ data StructSubType
         deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
 
 type CType = Type
+
+-- =====
+-- Construction-time consing of ground type nodes, behind the TAp/TCon
+-- pattern synonyms.
+--
+-- Disabled (narrow-Int platforms only): the smart constructors build
+-- a raw node (id -1) and count it (the construction "firehose").
+-- Enabled: ground nodes are hash-consed at construction.  Groundness
+-- is inductive and O(1):
+-- a node conses only if both children carry canonical ids -- a field
+-- read -- so a non-ground child refuses the parent for the cost of a
+-- constructor-tag check, with no table traffic at all (v1 paid a
+-- StableName registration per probe; that was the measured loss).
+-- TVar/TGen/TDefMonad never carry ids, and canonical leaves seed the
+-- induction.
+--
+-- Unlike GroundCType (the boundary interner), consing is RAW
+-- STRUCTURAL: no synonym expansion and no type-function evaluation,
+-- because construction must preserve the structure the caller wrote.
+-- This table is therefore separate from GroundCType's normalizing
+-- table (unifying them is the production design; the prototype keeps
+-- the audited boundary semantics untouched).
+--
+-- Leaf policy: TyCon leaves key on (qualifier, base) like Eq TyCon --
+-- qualified names only -- but additionally on the kind and a sort
+-- tag: construction-time put-back runs from the parser onward, where
+-- a same-named TyCon can temporarily carry an unresolved payload
+-- (kind Nothing / TIabstract), and payload variants must never
+-- conflate.  TNum/TStr leaves key on value alone; their positions
+-- conflate exactly as bsc's type equality (and the audited
+-- GroundCType leaf policy) already conflate them.  setTypePosition
+-- builds raw nodes: it explicitly writes positions, which put-back
+-- would undo.
+--
+-- Because equal canonical ids mean the same heap object, cmp answers
+-- EQ on id equality without descending, and structural descents on
+-- unequal canonical trees prune to the differing paths: comparisons
+-- over exponentially shared (DAG) ground types stay polynomial.
+--
+-- Conflation and lifetime (review-audited, measurement-accepted):
+-- canonical leaves carry FIRST-ARRIVAL positions, IdProps, and sort
+-- payloads -- the key deliberately covers only what Eq TyCon's
+-- qualified-name regime distinguishes (plus kind and sort tag),
+-- because keying the sort PAYLOAD would force synonym bodies at
+-- construction, which the symtab knot cannot tolerate, and keying
+-- positions would zero the sharing.  Soundness rests on the same
+-- one-tycon-per-qualified-name invariant Eq TyCon rests on.  The
+-- tables are process-global and never reset, so in a multi-package
+-- process .bo BYTES (positions of shared leaves) depend on compile
+-- order within the process -- semantically identical, but not
+-- byte-reproducible per input (the GroundCType boundary tables share
+-- this property).  A known follow-up: add a per-compilation-session
+-- table reset (also the fix for stale synonym bodies under a
+-- bluetcl-style in-process package reload), or make canonical nodes
+-- carry the caller's payload and share by id only.
+--
+-- Such a reset must cover ALL the process-global tables of this
+-- sharing machinery, most critically any NAME-keyed memos, which go
+-- stale with wrong SEMANTICS (not just positions) if a package is
+-- redefined and reloaded in one process: today CType.ccState,
+-- CType.ctRnfSeen and GroundCType.gcTable/ptrTable (id/unique-keyed:
+-- stable identities, growth-only), plus every later memo keyed on
+-- type names or intern identities.
+
+-- Fused ap keys need ids to fit two base-2^31 digits in an Int, so
+-- consing requires a 64-bit Int (bsc's supported platforms; on a
+-- narrower one consing is off rather than silently dead per-node).
+{-# NOINLINE consCTypeEnabled #-}
+consCTypeEnabled :: Bool
+consCTypeEnabled = finiteBitSize (0 :: Int) >= 64
+
+-- counters are recorded only under -trace-ctype-stats, so default
+-- builds pay no IORef traffic on the construction path
+{-# NOINLINE ctypeStatsEnabled #-}
+ctypeStatsEnabled :: Bool
+ctypeStatsEnabled = "-trace-ctype-stats" `elem` progArgs
+
+-- construction counters (approximate under GHC sharing; NOINLINE on
+-- the smart constructors keeps every construction a real call)
+{-# NOINLINE cnTApBuild #-}
+cnTApBuild :: IORef Int
+cnTApBuild = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnTConBuild #-}
+cnTConBuild :: IORef Int
+cnTConBuild = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnConsApHit #-}
+cnConsApHit :: IORef Int
+cnConsApHit = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnConsApNew #-}
+cnConsApNew :: IORef Int
+cnConsApNew = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnConsConHit #-}
+cnConsConHit :: IORef Int
+cnConsConHit = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnConsConNew #-}
+cnConsConNew :: IORef Int
+cnConsConNew = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnRefuseChild #-}
+cnRefuseChild :: IORef Int
+cnRefuseChild = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnRefuseLeaf #-}
+cnRefuseLeaf :: IORef Int
+cnRefuseLeaf = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnRefuseKeyErr #-}
+cnRefuseKeyErr :: IORef Int
+cnRefuseKeyErr = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnRefuseRedex #-}
+cnRefuseRedex :: IORef Int
+cnRefuseRedex = unsafePerformIO $ newIORef 0
+
+bump :: IORef Int -> IO ()
+bump r = when ctypeStatsEnabled (modifyIORef' r (+1))
+
+-- count a construction on the pure (non-consing) path; the IO result
+-- depends on both arguments, so it cannot be floated or shared
+{-# NOINLINE bumpRet #-}
+bumpRet :: IORef Int -> a -> a
+bumpRet r x
+  | ctypeStatsEnabled = unsafeDupablePerformIO (modifyIORef' r (+1) >> return x)
+  | otherwise = x
+
+-- The identity of a leaf inside the table key: normalized name or
+-- value (cf. GroundCType.GCKey), plus the kind/sort-tag fields per
+-- the leaf policy above.  Interior (ap) nodes key on their children's
+-- ids, fused into one Int.
+data CCKey
+        = CCCon !FString !FString !(Maybe Kind) {-# UNPACK #-} !Int
+        | CCNum !Integer
+        | CCStr !FString
+        deriving (Eq, Ord)
+
+ccSortTag :: TISort -> Int
+ccSortTag (TItype {})    = 0
+ccSortTag (TIdata {})    = 1
+ccSortTag (TIstruct {})  = 2
+ccSortTag (TIabstract)   = 3
+ccSortTag (TIatf {})     = 4
+
+-- ap-node keys fuse the two child ids into one Int (ids stay far
+-- below 2^31 in practice; the guard refuses consing rather than
+-- overflowing the fusion)
+ccFuse :: Int -> Int -> Int
+ccFuse fi ai = fi * 0x80000000 + ai
+
+ccFusable :: Int -> Bool
+ccFusable i = i < 0x80000000
+
+-- the intern state: canonical ap nodes by fused child ids, canonical
+-- leaves by CCKey, and the next id.  Ids are arrival-order and must
+-- never influence anything observable; they may only be used for
+-- identity (equal ids = the same heap object).
+data CCState = CCState !(IM.IntMap Type) !(M.Map CCKey Type)
+                       {-# UNPACK #-} !Int
+
+{-# NOINLINE ccState #-}
+ccState :: IORef CCState
+ccState = unsafePerformIO $ newIORef (CCState IM.empty M.empty 0)
+
+-- normTAp's redex shapes (CType.normTAp below): a prim type-function
+-- head over literal children.  These must never cons: apSub rebuilds
+-- interior nodes through normTAp, which REDUCES such redexes, and the
+-- ground short-circuit (apSub = identity on canonical nodes) is only
+-- sound if canonical implies normTAp-normal.  Refusing here keeps the
+-- invariant inductively -- a refused redex is raw, so no ancestor
+-- conses either.
+ccIsRedex :: Type -> Type -> Bool
+ccIsRedex (TAp_ _ (TCon_ _ (TyCon op _ _)) (TCon_ _ (TyNum x _))) (TCon_ _ (TyNum y _))
+    = isJust (opNumT op [x, y])
+ccIsRedex (TCon_ _ (TyCon op _ _)) (TCon_ _ (TyNum x _))
+    = isJust (opNumT op [x]) || op == idTNumToStr
+ccIsRedex (TAp_ _ (TCon_ _ (TyCon op _ _)) (TCon_ _ (TyStr x _))) (TCon_ _ (TyStr y _))
+    = isJust (opStrT op [x, y])
+ccIsRedex _ _ = False
+
+-- | The smart constructor behind the TAp pattern synonym.  The
+-- children's slots decide membership: a raw child (id -1) refuses for
+-- the cost of a field read.
+{-# NOINLINE mkTAp #-}
+mkTAp :: Type -> Type -> Type
+mkTAp f a
+  | not consCTypeEnabled = bumpRet cnTApBuild (TAp_ (-1) f a)
+  | otherwise = unsafeDupablePerformIO $ do
+      bump cnTApBuild
+      let fi = typeCanonId f
+          ai = typeCanonId a
+      if fi < 0 || ai < 0 || not (ccFusable fi) || not (ccFusable ai)
+        then do bump cnRefuseChild; return (TAp_ (-1) f a)
+      else if ccIsRedex f a
+        then do bump cnRefuseRedex; return (TAp_ (-1) f a)
+        else do
+          let key = ccFuse fi ai
+          CCState apm _ _ <- readIORef ccState
+          case IM.lookup key apm of
+            Just canon -> do bump cnConsApHit; return canon
+            Nothing -> do
+              (canon, isNew) <- atomicModifyIORef' ccState (insAp key)
+              bump (if isNew then cnConsApNew else cnConsApHit)
+              return canon
+  where
+    -- f and a carry ids, so they ARE the canonical table nodes:
+    -- store them directly
+    insAp key st@(CCState apm lm n) =
+        case IM.lookup key apm of
+          Just c  -> (st, (c, False))
+          Nothing -> let c = TAp_ n f a
+                     in  (CCState (IM.insert key c apm) lm (n+1), (c, True))
+
+-- deep-force a leaf key via its own Ord (kind and sort tag included)
+ccForceKey :: Maybe CCKey -> Maybe CCKey
+ccForceKey Nothing = Nothing
+ccForceKey (Just k) = (k `compare` k) `seq` Just k
+
+-- | The smart constructor behind the TCon pattern synonym.
+{-# NOINLINE mkTCon #-}
+mkTCon :: TyCon -> Type
+mkTCon tc
+  | not consCTypeEnabled = bumpRet cnTConBuild (TCon_ (-1) tc)
+  | otherwise = unsafeDupablePerformIO $ do
+      bump cnTConBuild
+      -- the whole key computation runs inside the guard: computing
+      -- ccConKey forces the TyCon and its Id, and forcing the key
+      -- forces the kind and the sort tag -- any of which may be a
+      -- latent error thunk the lazy baseline would never have forced.
+      -- Refuse the leaf on any synchronous exception (asynchronous
+      -- ones are rethrown).  bsc's internalError prints its banner
+      -- before throwing ExitCode -- an unrecoverable side effect --
+      -- but no stored kind/sort holds such a thunk today (audited).
+      mkey <- try (evaluate (ccForceKey (ccConKey tc)))
+      case (mkey :: Either SomeException (Maybe CCKey)) of
+        Left e -> case fromException e of
+          Just (SomeAsyncException _) -> throwIO e
+          Nothing -> do bump cnRefuseKeyErr; return (TCon_ (-1) tc)
+        Right Nothing -> do bump cnRefuseLeaf; return (TCon_ (-1) tc)
+        Right (Just key) -> do
+          CCState _ lm _ <- readIORef ccState
+          case M.lookup key lm of
+            Just canon -> do bump cnConsConHit; return canon
+            Nothing -> do
+              (canon, isNew) <- atomicModifyIORef' ccState (insLeaf key)
+              bump (if isNew then cnConsConNew else cnConsConHit)
+              return canon
+  where
+    insLeaf key st@(CCState apm lm n) =
+        case M.lookup key lm of
+          Just c  -> (st, (c, False))
+          Nothing -> let c = TCon_ n tc
+                     in  (CCState apm (M.insert key c lm) (n+1), (c, True))
+
+ccConKey :: TyCon -> Maybe CCKey
+ccConKey (TyNum n _) = Just (CCNum n)
+ccConKey (TyStr s _) = Just (CCStr s)
+ccConKey (TyCon i mk sort)
+  | isUnqualId i = Nothing
+  -- the identity type constructor is eliminated by expTFun like a
+  -- redex; refusing it keeps "canonical => nothing to reduce" exact
+  -- (it also lets the badCon scans skip canonical types wholesale)
+  | i == idId = Nothing
+  | otherwise = case sort of
+      -- synonyms and associated type functions are refused, like
+      -- normTAp redexes: the certificate means GROUND NORMAL FORM
+      -- (the space the ground-dict pool and the IType-conversion memo
+      -- key), so expandSyn is the identity on canonical nodes and no
+      -- walker can find anything to reduce inside one
+      TItype {} -> Nothing
+      TIatf {}  -> Nothing
+      _ -> Just (CCCon (getIdQual i) (getIdBase i) mk (ccSortTag sort))
+
+-- | Counter/table snapshot for the -trace-ctype-stats dump.
+cTypeConsStats :: IO [(String, Int)]
+cTypeConsStats = do
+    tap <- readIORef cnTApBuild
+    tcon <- readIORef cnTConBuild
+    aphit <- readIORef cnConsApHit
+    apnew <- readIORef cnConsApNew
+    chit <- readIORef cnConsConHit
+    cnew <- readIORef cnConsConNew
+    rchild <- readIORef cnRefuseChild
+    rleaf <- readIORef cnRefuseLeaf
+    rkey <- readIORef cnRefuseKeyErr
+    rredex <- readIORef cnRefuseRedex
+    CCState _ _ n <- readIORef ccState
+    return [ ("ctype.tap_built", tap)
+           , ("ctype.tcon_built", tcon)
+           , ("ctype.cons_ap_hit", aphit)
+           , ("ctype.cons_ap_new", apnew)
+           , ("ctype.cons_con_hit", chit)
+           , ("ctype.cons_con_new", cnew)
+           , ("ctype.refuse_child_not_canon", rchild)
+           , ("ctype.refuse_leaf", rleaf)
+           , ("ctype.refuse_key_err", rkey)
+           , ("ctype.refuse_redex", rredex)
+           , ("ctype.cons_table_nodes", n)
+           ]
 
 -- | Representation of kinds
 data Kind = KStar           -- ^ kind of a simple value type
@@ -180,6 +553,13 @@ data CPred = CPred { cpred_tc   :: CTypeclass  -- ^ constraint class, e.g., "Eq"
 -- TAp first because it brings forward instances with larger structure
 -- see the Has_tpl_n instances in the Prelude
 cmp :: Type -> Type -> Ordering
+-- equal canonical ids = the same heap object: answer EQ without
+-- descending.  (Only an EQ shortcut -- the order stays structural, so
+-- container iteration order is unchanged.)  On unequal canonical
+-- trees the recursion below prunes to the differing paths, keeping
+-- comparisons over exponentially shared ground types polynomial.
+cmp x y | i >= 0, i == typeCanonId y = EQ
+  where i = typeCanonId x
 cmp (TAp f1 a1) (TAp f2 a2) = compare (f1, a1) (f2, a2)
 cmp (TAp _  _)  _           = LT
 cmp (TCon c1) (TCon c2) = compare c1 c2
@@ -247,7 +627,28 @@ instance PPrint Type where
     pPrint d p (TDefMonad _) = text ("TDefMonad")
     pPrint d p (TGen _ n) = pparen True (text "TGen" <+> pPrint d p n)
 
+-- canonical nodes deep-force once per cons id (cf. itRnfOnce in
+-- IType.hs): identical semantics to the plain walk -- everything is
+-- forced, once per node -- but linear on exponentially shared DAGs.
+-- Raw nodes have no identity to key and keep the plain walk (the
+-- default path is untouched: ids are always -1 there).
+{-# NOINLINE ctRnfSeen #-}
+ctRnfSeen :: IORef IS.IntSet
+ctRnfSeen = unsafePerformIO $ newIORef IS.empty
+
+ctRnfOnce :: Int -> () -> ()
+ctRnfOnce i force = unsafeDupablePerformIO $ do
+    s <- readIORef ctRnfSeen
+    if IS.member i s
+      then return ()
+      else do -- force BEFORE marking (cf. itRnfOnce)
+              _ <- return $! force
+              atomicModifyIORef' ctRnfSeen (\ ss -> (IS.insert i ss, ()))
+              return ()
+
 instance NFData Type where
+    rnf (TCon_ i c) | i >= 0 = ctRnfOnce i (rnf c)
+    rnf (TAp_ i t1 t2) | i >= 0 = ctRnfOnce i (rnf2 t1 t2)
     rnf (TVar v) = rnf v
     rnf (TCon c) = rnf c
     rnf (TAp t1 t2) = rnf2 t1 t2
@@ -654,6 +1055,10 @@ instance NFData StructSubType where
 
 -- Force evaluation of a Ctype
 seqCType :: CType -> CType
+-- a canonical node was forced when it was interned (children
+-- recursively canonical), and its spine may be exponentially shared:
+-- do not re-walk it
+seqCType t | isCanonType t = t
 seqCType t@(TVar v) = seq v t
 seqCType t@(TCon c) = t
 seqCType t@(TAp t1 t2) = seq (seqCType t1) (seq (seqCType t2) t)
@@ -661,11 +1066,27 @@ seqCType t@(TGen _ _) = t
 seqCType t@(TDefMonad _) = t
 
 ----
+-- builds raw (non-canonical) nodes: it explicitly writes positions,
+-- which the consing put-back would replace with first-arrival ones.
+--
+-- CONTRACT: never called on a canonical (ground) type.  Positions on
+-- canonical nodes are first-arrival-conflated representatives by
+-- policy -- stamping one is meaningless, and honoring the stamp would
+-- either mutate a shared node (unsound) or copy it raw (silently
+-- defeating the sharing).  Callers must skip ground types (see
+-- Pred.expandSyn and MakeSymTab.chkTAp, the only callers); the guard
+-- makes a violating new caller fail loudly.  Canonical SUBTREES of a
+-- non-ground type are likewise kept shared, unstamped -- they are
+-- ground, so the same policy applies per node.
 setTypePosition :: Position -> Type -> Type
+setTypePosition pos t | isCanonType t =
+    internalError "CType.setTypePosition: canonical ground type"
 setTypePosition pos (TVar (TyVar id n k)) = (TVar (TyVar (setIdPosition pos id) n k))
-setTypePosition pos (TCon (TyCon id k s)) = (TCon (TyCon (setIdPosition pos id) k s))
-setTypePosition pos (TCon (TyNum n _)) = (TCon (TyNum n pos))
-setTypePosition pos (TCon (TyStr s _)) = (TCon (TyStr s pos))
-setTypePosition pos (TAp f a) = (TAp (setTypePosition pos f) (setTypePosition pos a))
+setTypePosition pos (TCon (TyCon id k s)) = (TCon_ (-1) (TyCon (setIdPosition pos id) k s))
+setTypePosition pos (TCon (TyNum n _)) = (TCon_ (-1) (TyNum n pos))
+setTypePosition pos (TCon (TyStr s _)) = (TCon_ (-1) (TyStr s pos))
+setTypePosition pos (TAp f a) = (TAp_ (-1) (setSub f) (setSub a))
+  where setSub s | isCanonType s = s
+                 | otherwise     = setTypePosition pos s
 setTypePosition pos (TGen _ n)    = (TGen pos n)
 setTypePosition pos (TDefMonad _) = (TDefMonad pos)

--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -363,6 +363,44 @@ ccSortTag (TIstruct {})  = 2
 ccSortTag (TIabstract)   = 3
 ccSortTag (TIatf {})     = 4
 
+-- Canonicalize a leaf's sort payload before consing, exactly as
+-- IType.tidySort canonicalizes an ITCon payload: the payload's ENTITY
+-- Ids -- constructors, fields, wrapper names, all entities of the
+-- tycon's own package -- are re-qualified to the owning tycon, and
+-- lose positions and props.
+--
+-- Without this the leaf table conflates two spellings of one payload.
+-- A .bo carries constructors as the source package wrote them (local,
+-- so unqualified); MakeSymTab and IType.ownedId re-qualify them to the
+-- owner.  Same entity either way, but the leaf key deliberately
+-- excludes the payload, so whichever TyCon reached the table first won
+-- and the other caller silently got its payload -- which is what
+-- tconcheck's 8 Type-side DRIFT entries were reporting.  The IType
+-- side already normalizes and its 32 entries always passed.
+--
+-- Local names (PIArgNames dummies) and references to OTHER packages'
+-- entities keep their own qualification, as on the IType side.
+-- TItype and TIatf never reach here (ccConKey refuses both), so no
+-- synonym body is ever forced.
+ccTidySort :: FString -> TISort -> TISort
+ccTidySort q (TIdata cs enc)  = TIdata (map (ccOwnedId q) cs) enc
+ccTidySort q (TIstruct ss fs) = TIstruct (ccTidySST q ss) (map (ccOwnedId q) fs)
+ccTidySort _ s                = s
+
+ccTidySST :: FString -> StructSubType -> StructSubType
+ccTidySST q (SDataCon i nf)     = SDataCon (ccOwnedId q i) nf
+ccTidySST q (SPolyWrap a mc f)  = SPolyWrap (ccOwnedId q a) (fmap (ccOwnedId q) mc)
+                                            (ccOwnedId q f)
+ccTidySST _ ss                  = ss
+
+-- the owner is always qualified (ccConKey refuses unqualified tycons)
+ccOwnedId :: FString -> Id -> Id
+ccOwnedId q i = setIdQual (setIdPosition noPosition (setIdProps i [])) q
+
+ccTidyTyCon :: TyCon -> TyCon
+ccTidyTyCon (TyCon i mk sort) = TyCon i mk (ccTidySort (getIdQual i) sort)
+ccTidyTyCon tc                = tc
+
 -- ap-node keys fuse the two child ids into one Int (ids stay far
 -- below 2^31 in practice; the guard refuses consing rather than
 -- overflowing the fusion)
@@ -470,7 +508,11 @@ mkTCon tc
     insLeaf key st@(CCState apm lm n) =
         case M.lookup key lm of
           Just c  -> (st, (c, False))
-          Nothing -> let c = TCon_ n tc
+          -- the canonical node carries the NORMALIZED payload, so the
+          -- two spellings of one payload (source-form from a .bo,
+          -- re-qualified from the symtab) become the same value and
+          -- there is nothing left for the payload-free key to conflate
+          Nothing -> let c = TCon_ n (ccTidyTyCon tc)
                      in  (CCState apm (M.insert key c lm) (n+1), (c, True))
 
 ccConKey :: TyCon -> Maybe CCKey

--- a/src/comp/CType.hs
+++ b/src/comp/CType.hs
@@ -499,11 +499,11 @@ mkTCon tc
         Right (Just key) -> do
           CCState _ lm _ <- readIORef ccState
           case M.lookup key lm of
-            Just canon -> do bump cnConsConHit; return canon
+            Just canon -> do bump cnConsConHit; return (ccAtCaller canon tc)
             Nothing -> do
               (canon, isNew) <- atomicModifyIORef' ccState (insLeaf key)
               bump (if isNew then cnConsConNew else cnConsConHit)
-              return canon
+              return (ccAtCaller canon tc)
   where
     insLeaf key st@(CCState apm lm n) =
         case M.lookup key lm of
@@ -514,6 +514,28 @@ mkTCon tc
           -- there is nothing left for the payload-free key to conflate
           Nothing -> let c = TCon_ n (ccTidyTyCon tc)
                      in  (CCState apm (M.insert key c lm) (n+1), (c, True))
+
+-- Share by id, but hand back the CALLER's position.  A canonical leaf is
+-- one VALUE, not one occurrence: the key covers the value (and kind and
+-- sort tag) precisely because Eq TyCon does, and Eq ignores positions.
+-- Diagnostics do not -- they ask a type where it came from, and the
+-- first-arrival position answers for whichever occurrence happened to
+-- reach the table first.  That is how a kind error on one line came to
+-- name another, and an unused-import warning came to name another FILE.
+--
+-- The id and the normalized sort survive, so cmp's id shortcut, the
+-- groundness induction (typeCanonId >= 0) and the payload canonicality
+-- above are all unaffected; only "equal ids mean the same heap object"
+-- weakens to "equal ids mean the same value", which is what every
+-- consumer of an id actually relies on.
+ccAtCaller :: Type -> TyCon -> Type
+ccAtCaller (TCon_ n c) tc = TCon_ n (ccSetTyConPos c (getPosition tc))
+ccAtCaller t _ = t
+
+ccSetTyConPos :: TyCon -> Position -> TyCon
+ccSetTyConPos (TyCon i k s) p = TyCon (setIdPosition p i) k s
+ccSetTyConPos (TyNum v _)   p = TyNum v p
+ccSetTyConPos (TyStr v _)   p = TyStr v p
 
 ccConKey :: TyCon -> Maybe CCKey
 ccConKey (TyNum n _) = Just (CCNum n)

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -462,6 +462,7 @@ traceflags = [
           "trace-inst-tree",
           "trace-instance-overlap",
           "legacy-inst-index",
+          "trace-ctype-stats",
           "trace-kind-inference",
           "trace-lift",
           "trace-mergesched",

--- a/src/comp/IExpand.hs
+++ b/src/comp/IExpand.hs
@@ -28,7 +28,6 @@ import Control.Monad.Fix(mfix)
 --import Control.Monad.Fix
 import Control.Monad.State(State, evalState, liftIO, get, put)
 import Data.Graph
-import qualified Data.Generics as Generic
 import System.IO(Handle, BufferMode(..), IOMode(..), stdout, stderr,
                  hSetBuffering, hIsOpen, hIsClosed)
 import System.FilePath(isRelative)
@@ -532,14 +531,115 @@ unpack_method_call' _ e =
   -- trace ("unpack_method_call unable to match " ++ show e) $
   --[(mk_homeless_id "NOSTATE", mk_homeless_id "NOMETHOD")]
 
+-- Apply 'removeIdInlinedPositions' to the Id of every ICon reachable
+-- in the IModule.  Heap references are leaves: IRefT payloads and the
+-- cells of ICLazyArray sit behind IORefs and are not traversed.
+-- Clock, reset and inout wires can be cyclic (a state variable's
+-- output clock selects from the state variable itself), so the
+-- rebuilding must stay lazy; consumers only force finite prefixes of
+-- such wires.  Subtrees that cannot contain an ICon are returned
+-- unchanged, rather than reallocated.
 removeInlinedPositions :: Flags -> IModule HeapData -> IModule HeapData
 removeInlinedPositions flags imod0 | (not (methodConditions flags)) = imod0
 removeInlinedPositions flags imod0 =
-    let removeFn :: HExpr -> HExpr
-        removeFn (ICon i ic) = (ICon (removeIdInlinedPositions i) ic)
-        -- XXX do we need a recursive branch for IAps?
-        removeFn e = e
-    in  Generic.everywhere (Generic.mkT removeFn) imod0
+    imod0 { imod_clock_domains =
+                [ (d, map rmClock cs) | (d, cs) <- imod_clock_domains imod0 ],
+            imod_resets = map rmReset (imod_resets imod0),
+            imod_state_insts =
+                [ (i, rmStateVar sv) | (i, sv) <- imod_state_insts imod0 ],
+            imod_local_defs = map rmDef (imod_local_defs imod0),
+            imod_rules = rmRules (imod_rules imod0),
+            imod_interface = map rmIFace (imod_interface imod0)
+          }
+  where
+    rmExpr :: HExpr -> HExpr
+    rmExpr (ILam i t e) = ILam i t (rmExpr e)
+    rmExpr (IAps f ts es) = IAps (rmExpr f) ts (map rmExpr es)
+    rmExpr e@(IVar _) = e
+    rmExpr (ILAM i k e) = ILAM i k (rmExpr e)
+    rmExpr (ICon i ic) = ICon (removeIdInlinedPositions i) (rmConInfo ic)
+    rmExpr e@(IRefT _ _ _ _) = e
+
+    -- only the payloads that can carry an IExpr are rebuilt;
+    -- all other constructors are returned unchanged
+    rmConInfo :: IConInfo HeapData -> IConInfo HeapData
+    rmConInfo (ICDef t d) = ICDef t (rmExpr d)
+    rmConInfo (ICUndet t k mv) = ICUndet t k (fmap rmExpr mv)
+    rmConInfo (ICStateVar t sv) = ICStateVar t (rmStateVar sv)
+    rmConInfo (ICValue t d) = ICValue t (rmExpr d)
+    rmConInfo (ICMethod t ins outs m) = ICMethod t ins outs (rmExpr m)
+    rmConInfo (ICClock t c) = ICClock t (rmClock c)
+    rmConInfo (ICReset t r) = ICReset t (rmReset r)
+    rmConInfo (ICInout t io) = ICInout t (rmInout io)
+    rmConInfo (ICLazyArray t arr mu) =
+        -- the array cells are heap references, thus leaves
+        ICLazyArray t arr (fmap (\ (e1, e2) -> (rmExpr e1, rmExpr e2)) mu)
+    rmConInfo (ICPred t p) = ICPred t (rmPred p)
+    rmConInfo ic@(ICPrim {}) = ic
+    rmConInfo ic@(ICForeign {}) = ic
+    rmConInfo ic@(ICCon {}) = ic
+    rmConInfo ic@(ICIs {}) = ic
+    rmConInfo ic@(ICOut {}) = ic
+    rmConInfo ic@(ICTuple {}) = ic
+    rmConInfo ic@(ICSel {}) = ic
+    rmConInfo ic@(ICVerilog {}) = ic
+    rmConInfo ic@(ICInt {}) = ic
+    rmConInfo ic@(ICReal {}) = ic
+    rmConInfo ic@(ICString {}) = ic
+    rmConInfo ic@(ICChar {}) = ic
+    rmConInfo ic@(ICHandle {}) = ic
+    rmConInfo ic@(ICMethArg {}) = ic
+    rmConInfo ic@(ICModPort {}) = ic
+    rmConInfo ic@(ICModParam {}) = ic
+    rmConInfo ic@(ICIFace {}) = ic
+    rmConInfo ic@(ICRuleAssert {}) = ic
+    rmConInfo ic@(ICSchedPragmas {}) = ic
+    rmConInfo ic@(ICName {}) = ic
+    rmConInfo ic@(ICAttrib {}) = ic
+    rmConInfo ic@(ICPosition {}) = ic
+    rmConInfo ic@(ICType {}) = ic
+
+    rmClock :: HClock -> HClock
+    rmClock c = c { ic_wires = rmExpr (ic_wires c) }
+
+    rmReset :: HReset -> HReset
+    rmReset r = r { ir_clock = rmClock (ir_clock r),
+                    ir_wire = rmExpr (ir_wire r) }
+
+    rmInout :: HInout -> HInout
+    rmInout io = io { io_clock = rmClock (io_clock io),
+                      io_reset = rmReset (io_reset io),
+                      io_wire = rmExpr (io_wire io) }
+
+    rmStateVar :: HStateVar -> HStateVar
+    rmStateVar sv =
+        sv { isv_iargs = map rmExpr (isv_iargs sv),
+             isv_clocks = [ (i, rmClock c) | (i, c) <- isv_clocks sv ],
+             isv_resets = [ (i, rmReset r) | (i, r) <- isv_resets sv ] }
+
+    rmPred :: HPred -> HPred
+    rmPred (PConj ps) = PConj (S.map rmPTerm ps)
+
+    rmPTerm :: PTerm HeapData -> PTerm HeapData
+    rmPTerm (PAtom e) = PAtom (rmExpr e)
+    rmPTerm (PIf c t e) = PIf (rmExpr c) (rmPred t) (rmPred e)
+    rmPTerm (PSel idx sz ps) = PSel (rmExpr idx) sz (map rmPred ps)
+
+    rmDef :: HDef -> HDef
+    rmDef (IDef i t e p) = IDef i t (rmExpr e) p
+
+    rmRules :: HRules -> HRules
+    rmRules (IRules sps rs) = IRules sps (map rmRule rs)
+
+    rmRule :: HRule -> HRule
+    rmRule r = r { irule_pred = rmExpr (irule_pred r),
+                   irule_body = rmExpr (irule_body r) }
+
+    rmIFace :: HEFace -> HEFace
+    rmIFace ief =
+        ief { ief_value = fmap (\ (e, t) -> (rmExpr e, t)) (ief_value ief),
+              ief_body = fmap rmRules (ief_body ief) }
+
 
 -- -----
 

--- a/src/comp/IExpandUtils.hs
+++ b/src/comp/IExpandUtils.hs
@@ -273,7 +273,7 @@ pTermToIExpr (PSel idx idx_sz es) =
 
 -- An expression with an implicit condition.
 data PExpr = P !HPred HExpr
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Typeable)
 
 instance PPrint PExpr where
     pPrint d prec (P p e) = pPrint d prec (iePrimWhen (iGetType e) (predToIExpr p) e)
@@ -413,7 +413,7 @@ data HeapCell = HUnev { hc_hexpr :: HExpr, hc_name :: NameInfo }
               | HNF { hc_pexpr :: PExpr, hc_wire_set :: HWireSet,
                       hc_name :: NameInfo }
               | HLoop { hc_name :: NameInfo }
-        deriving (Show, Eq, Ord, Generic.Data, Generic.Typeable)
+        deriving (Show, Eq, Ord, Generic.Typeable)
 
 -- should I drop the predicate for better printing of error messages?
 heapCellToHExpr :: HeapCell -> HExpr
@@ -442,7 +442,7 @@ instance PPrint HeapCell where
             text "HLoop" <+> pPrint d 0 name
 
 newtype HeapData = HeapData (IORef (HeapCell))
-  deriving (Generic.Data, Generic.Typeable)
+  deriving (Generic.Typeable)
 
 {-
 instance Eq HeapData where

--- a/src/comp/IStateLoc.hs
+++ b/src/comp/IStateLoc.hs
@@ -20,7 +20,6 @@ module IStateLoc (
 
 import IType
 import Id
-import qualified Data.Generics as Generic
 import Eval
 import Data.Char(isAlphaNum)
 
@@ -71,7 +70,7 @@ data IStateLocPathComponent = IStateLocPathComponent {
   -- Name generation
   isl_prefix                 :: NameGenerate, -- currently computed hierarchical prefix
   isl_loop_suffix         :: NameGenerate  -- loop indexes to add once a "real" name is found.
-  } deriving (Eq, Show, Generic.Data, Generic.Typeable)
+  } deriving (Eq, Show)
 
 
 -- ---------------------------------------
@@ -124,7 +123,7 @@ mkISLPC inst_id ifc_id ifc_type = islpc
 data NameGenerate = NameEmpty             -- No name so far
                     | NameIndex [Integer] -- loop indexes
                     | Name Id             -- a real name
-                    deriving (Eq, Show, Generic.Data, Generic.Typeable)
+                    deriving (Eq, Show)
 
 --
 instance NFData NameGenerate where

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -138,7 +138,7 @@ data IPackage a
               -- cache of resolved associated type function applications
               ipkg_atf_cache :: IATFCache
           }
-     deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+     deriving (Eq, Ord, Show, Generic.Typeable)
 
 type IATFCache = M.Map (Id, [IType]) IType
 
@@ -171,7 +171,7 @@ data IModule a
                 -- comments on submodule instantiations
                 imod_instance_comments :: [(Id, [String])]
           }
-         deriving (Show, Generic.Data, Generic.Typeable)
+         deriving (Show, Generic.Typeable)
 
 getWireInfo :: IModule a -> VWireInfo
 getWireInfo = imod_external_wires
@@ -182,7 +182,7 @@ getWireInfo = imod_external_wires
 type PortTypeMap = M.Map (Maybe Id) (M.Map VName IType)
 
 data IDef a = IDef Id IType (IExpr a) [DefProp]
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Typeable)
 
 data IAbstractInput =
         -- simple input using one port
@@ -193,7 +193,7 @@ data IAbstractInput =
         IAI_Inout Id Integer
         -- room to add other types here, like:
         --   IAI_Struct [(Id, IType)]
-    deriving (Eq, Show, Generic.Data, Generic.Typeable)
+    deriving (Eq, Show, Generic.Typeable)
 
 -- One method argument, decomposed into the ports it occupies (one port for an
 -- unsplit argument, several for a split struct/tuple).  A method's arguments
@@ -218,7 +218,7 @@ data IEFace a = IEFace {
         ief_wireprops :: WireProps,
         ief_fieldinfo :: VFieldInfo
      }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show, Generic.Typeable)
 
 
 -- ---------------
@@ -239,7 +239,7 @@ data IStateVar a = IStateVar {
     isv_resets :: [(Id, IReset a)], -- named resets
     isv_isloc :: IStateLoc        -- instantiation path
 }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show, Generic.Typeable)
 
 getResetMap :: IStateVar a -> [(Id, IReset a)]
 getResetMap = isv_resets
@@ -280,7 +280,7 @@ data IRule a =
       -- Instantiation hierarchy
       irule_state_loc :: IStateLoc
       }
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show, Generic.Typeable)
 
 instance NFData (IRule a) where
     rnf (IRule i ps s wp r1 r2 orig isl) = rnf8 i ps s wp r1 r2 orig isl
@@ -292,7 +292,7 @@ getIRuleStateLoc :: IRule a -> IStateLoc
 getIRuleStateLoc = irule_state_loc
 
 data IRules a = IRules [ISchedulePragma] [IRule a]
-    deriving (Show, Generic.Data, Generic.Typeable)
+    deriving (Show, Generic.Typeable)
 
 instance NFData (IRules a) where
     rnf (IRules sps rs) = rnf2 sps rs
@@ -473,7 +473,7 @@ data IExpr a
         | ICon Id (IConInfo a)
         -- IRef is only used during reduction, it refers to a "heap" cell
         | IRefT IType !Int (S.Set Position) a -- vanishes after IExpand
-          deriving (Generic.Data, Generic.Typeable)
+          deriving (Generic.Typeable)
 
 instance Show (IExpr a) where
   show (ILam i t e)   = "(ILam " ++ show i ++ " " ++ show t ++ " " ++ show e ++ ")"
@@ -565,7 +565,7 @@ data IClock a = IClock { ic_id      :: ClockId,      -- unique id
                          ic_wires   :: IExpr a       -- expression for clock wires
                                               -- will be ICSel of (ICStateVar) or ICTuple of ICModPorts / ICInt (1) for ungated clocks
                                               -- theoretically ICTuple (ICInt (0), ICInt (0)) for noClock, but should  not appear
-                     } deriving (Generic.Data, Generic.Typeable)
+                     } deriving (Generic.Typeable)
 
 -- break recursion of wires so that showing a clock does not loop
 instance Show (IClock a) where
@@ -625,7 +625,7 @@ data IReset a = IReset { ir_id   :: ResetId, -- unique id
                          ir_wire :: IExpr a  -- expression for reset wire
                                              -- currently must be an ICModPort or 0,
                                              -- since we do not support reset output
-                       } deriving (Generic.Data, Generic.Typeable)
+                       } deriving (Generic.Typeable)
 
 -- must break recursion of wire so showing a reset output does not loop
 instance Show (IReset a) where
@@ -671,7 +671,7 @@ data IInout a =
     IInout { io_clock :: IClock a, -- associated clock (may be noClock)
              io_reset :: IReset a, -- associated reset (may be noReset)
              io_wire :: IExpr a  -- expression for inout wire
-           } deriving (Generic.Data, Generic.Typeable)
+           } deriving (Generic.Typeable)
 
 instance Show (IInout a) where
   show (IInout clock reset wire) =
@@ -707,7 +707,7 @@ getInoutWire = io_wire
 -- into application of PrimBuildArray to the element expressions.
 --
 data ArrayCell a = ArrayCell { ac_ptr :: Int, ac_ref :: a }
-                   deriving (Generic.Data, Generic.Typeable)
+                   deriving (Generic.Typeable)
 
 instance Show (ArrayCell a) where
   show (ArrayCell i _) = "_" ++ show i
@@ -725,7 +725,7 @@ type ILazyArray a = Array.Array Integer (ArrayCell a)
 -- Predicates used for implicit conditions.
 -- most utility functions in IExpandUtils
 newtype Pred a = PConj (PSet (PTerm a))
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Typeable)
 
 instance PPrint (Pred a) where
     pPrint d p (PConj ps) = pPrint d p (S.toList ps)
@@ -745,7 +745,7 @@ type PSet a = S.Set a
 data PTerm a = PAtom (IExpr a)
              | PIf (IExpr a) (Pred a) (Pred a)
              | PSel (IExpr a) Integer [Pred a]
-        deriving (Eq, Ord, Show, Generic.Data, Generic.Typeable)
+        deriving (Eq, Ord, Show, Generic.Typeable)
 
 -- ==============================
 -- IConInfo
@@ -855,7 +855,7 @@ data IConInfo a =
         | ICPosition { iConType :: IType, iPosition :: [Position] }
         | ICType { iConType :: IType, iType :: IType }
         | ICPred { iConType :: IType, iPred :: Pred a }
-        deriving (Show, Generic.Data, Generic.Typeable)
+        deriving (Show, Generic.Typeable)
 
 ordC :: IConInfo a -> Int
 -- XXX This definition would be nice, but it imposes a (Data a) context

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -45,7 +45,7 @@ data IType
         | ITCon Id IKind TISort
         | ITNum Integer
         | ITStr FString
-        deriving (Show, Generic.Data, Generic.Typeable)
+        deriving (Show, Generic.Typeable)
 
 -- --------------------------------
 -- NFData Instances

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -1125,7 +1125,10 @@ chkTAp = uncurry (chkTAp' [])  . splitTAp
           | let numArgs = genericLength as,
             numArgs < n = K.err (getPosition i, EPartialTypeApp (pfpString i) n numArgs)
           | otherwise = let (as1, as2) = genericSplitAt n as
-                            t' = setTypePosition (getIdPosition i) t
+                            -- canonical ground bodies stay shared and
+                            -- unstamped (cf. Pred.expandSyn)
+                            t' = if isCanonType t then t
+                                 else setTypePosition (getIdPosition i) t
                             (f', as') = splitTAp $ inst as1 t'
                         in chkTAp' (i:syns) f' (as' ++ as2)
         chkTAp' _ f as = do

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -259,7 +259,13 @@ expandSyn t0 = exp [] f as
             numArgs < n = bsErrorReallyUnsafe [(getPosition i, EPartialTypeApp (pfpString i) n numArgs)]
           -- We have a synonym we can expand, so do so.
           | otherwise = let (as1, as2) = genericSplitAt n as
-                            t' = setTypePosition (getIdPosition i) t
+                            -- a canonical (ground) body stays shared and
+                            -- unstamped: its positions are conflated by
+                            -- policy, and no new error can anchor inside
+                            -- it (it kind-checked at its definition);
+                            -- setTypePosition rejects canonical input
+                            t' = if isCanonType t then t
+                                 else setTypePosition (getIdPosition i) t
                             (f', as') = splitTAp $ inst as1 t'
                         in exp (i:syns) f' (as' ++ as2)
         -- Type functions (TIatf) are NOT expanded here; they are handled by

--- a/src/comp/TypeAnalysis.hs
+++ b/src/comp/TypeAnalysis.hs
@@ -145,7 +145,7 @@ analyzeType' flags symtab unqual_ty primpair_is_interface = doRight analyze (kin
              -- need more context
              Right Variable  -- Unknown?
          (TGen {}, as) -> internalError "analyzeType': found TGen"
-         (TAp {}, as)  -> internalError "analyzeType': found TAp"
+         (TAp _ _, as) -> internalError "analyzeType': found TAp"
          (TCon (TyNum n pos), as) ->
              if (null as)
              then Right Numeric

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -29,7 +29,6 @@ import System.Environment(getEnv)
 import System.Mem(performGC)
 import System.Posix.Signals
 import Text.Regex
-import Data.Generics (listify)
 import qualified Data.Map as M
 
 -- Bluespec imports
@@ -4204,12 +4203,27 @@ tclDepend ["recomp",fname]= do
 
 tclDepend xs = internalError $ "tclDepend: grammar mismatch: " ++ (show xs)
 
+-- VModInfo reaches an IPackage only through ICVerilog: the synthesis
+-- boundary re-abstracts every synthesized module as a Verilog wrapper
+-- (the same representation as a hand-written import "BVI"), and the
+-- richer elaboration products (ICStateVar, ICClock, ICReset, ...)
+-- flow to the .ba and never re-enter package vocabulary.
 find_vmodinfo :: (IPackage Id) -> [VModInfo]
-find_vmodinfo = listify
-                (let
-                    tagVMI :: VModInfo -> Bool
-                    tagVMI _ = True
-                 in tagVMI)
+find_vmodinfo ipkg = concatMap defVMIs (ipkg_defs ipkg)
+  where
+    defVMIs :: IDef Id -> [VModInfo]
+    defVMIs (IDef _ _ dbody _) = exprVMIs dbody
+
+    exprVMIs :: IExpr Id -> [VModInfo]
+    exprVMIs (ILam _ _ body) = exprVMIs body
+    exprVMIs (IAps fun _ args) = concatMap exprVMIs (fun:args)
+    exprVMIs (IVar _) = []
+    exprVMIs (ILAM _ _ body) = exprVMIs body
+    exprVMIs (ICon _ (ICVerilog { vInfo = vmi })) = [vmi]
+    exprVMIs (ICon _ (ICDef { iConDef = body })) = exprVMIs body
+    exprVMIs (ICon _ (ICUndet { imVal = Just body })) = exprVMIs body
+    exprVMIs (ICon _ _) = []
+    exprVMIs (IRefT {}) = []
 
 package_vsignals :: TclP -> [(Id,String)]
 package_vsignals tclp =


### PR DESCRIPTION
ctype line 3: the cons-interning core (e36c07da), hardwired always-on (64-bit platform guard kept), plus two fixes its own flip commit documented as live-only-when-on and which must therefore ship with a hardwired-on core: leaf sort-payload normalization before consing (ac3a1dba) and caller-position stamping for canonical leaves (edc499d9). Carve also retired the Data-deriving/syb users this machinery obsoletes (walkers taken verbatim from atf/2 so the later join collapses them). Builds; typeclasses green at line tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt