### PR TITLE
typecheck: read groundness and normality off the canonical certificate

### DIFF
--- a/src/comp/GroundCType.hs
+++ b/src/comp/GroundCType.hs
@@ -1,9 +1,10 @@
 module GroundCType(groundCTypeEnabled, internGroundCType,
-                   isGroundNodeId) where
+                   isGroundNodeId, groundCTypeStats) where
 
 import qualified Data.Map.Strict as M
 import qualified Data.IntMap.Strict as IM
-import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
+import Data.IORef(IORef, newIORef, readIORef, modifyIORef',
+                  atomicModifyIORef')
 import Data.List(genericLength, genericSplitAt)
 import Control.Monad(foldM, when)
 import System.IO.Unsafe(unsafePerformIO)
@@ -112,6 +113,43 @@ import PreStrings(fsEmpty)
 -- here.)
 groundCTypeEnabled :: Bool
 groundCTypeEnabled = True
+
+-- measurement counters for the -trace-ctype-stats dump: consultation
+-- count, pointer-fast-path hits (root and in-walk), and nodes walked
+-- (the "walk bytes" the lever-3 decision needs)
+{-# NOINLINE cnGCIntern #-}
+cnGCIntern :: IORef Int
+cnGCIntern = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnGCRootPtrHit #-}
+cnGCRootPtrHit :: IORef Int
+cnGCRootPtrHit = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnGCWalkPtrHit #-}
+cnGCWalkPtrHit :: IORef Int
+cnGCWalkPtrHit = unsafePerformIO $ newIORef 0
+
+{-# NOINLINE cnGCWalkNodes #-}
+cnGCWalkNodes :: IORef Int
+cnGCWalkNodes = unsafePerformIO $ newIORef 0
+
+gcBump :: IORef Int -> IO ()
+gcBump r = modifyIORef' r (+1)
+
+-- | Counter/table snapshot for the -trace-ctype-stats dump.
+groundCTypeStats :: IO [(String, Int)]
+groundCTypeStats = do
+    n1 <- readIORef cnGCIntern
+    n2 <- readIORef cnGCRootPtrHit
+    n3 <- readIORef cnGCWalkPtrHit
+    n4 <- readIORef cnGCWalkNodes
+    GCTable _ n <- readIORef gcTable
+    return [ ("gctype.intern_calls", n1)
+           , ("gctype.root_ptr_hit", n2)
+           , ("gctype.walk_ptr_hit", n3)
+           , ("gctype.walk_nodes", n4)
+           , ("gctype.table_nodes", n)
+           ]
 
 -- The identity of a child inside a table key: interior applications
 -- by their node ids, leaves by normalized name or value (positions,
@@ -235,9 +273,11 @@ viewOf _ = GVOther
 {-# NOINLINE internGroundCType #-}
 internGroundCType :: Type -> Maybe (Int, Type)
 internGroundCType t = unsafePerformIO $ do
+    gcBump cnGCIntern
     hit <- ptrLookup t
     case hit of
-      Just e -> return (Just e)
+      Just e -> do gcBump cnGCRootPtrHit
+                   return (Just e)
       Nothing -> do
         r <- walk [] t
         case r of
@@ -249,11 +289,23 @@ walk :: [Id] -> Type -> IO (Maybe (Int, Type))
 walk syns t0 = do
     hit <- ptrLookup t0
     case hit of
-      Just e -> return (Just e)
-      Nothing -> walk' syns t0
+      Just e -> do gcBump cnGCWalkPtrHit
+                   return (Just e)
+      Nothing -> do
+        r <- walk' syns t0
+        -- memoize every successfully walked OBJECT, not only interned
+        -- roots: a duplicating synonym body puts the same raw node in
+        -- both slots, and without this the walk re-expands it once
+        -- per path (exponential on synonym towers).  Refusals are not
+        -- cached: a refusal under a non-empty synonym stack (rec
+        -- detection) does not transfer to other contexts.
+        case r of
+          Just e  -> ptrInsert t0 e
+          Nothing -> return ()
+        return r
 
 walk' :: [Id] -> Type -> IO (Maybe (Int, Type))
-walk' syns t0 =
+walk' syns t0 = gcBump cnGCWalkNodes >>
     let (f, as) = splitTAp t0
     in  case f of
           TCon (TyCon i _ (TItype n body))

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -20,7 +20,9 @@ import qualified Data.Map as M
 
 import Data.Either(partitionEithers)
 import PredTrie
-import FStringCompat(concatFString)
+import FStringCompat(concatFString, FString)
+import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
+import System.IO.Unsafe(unsafePerformIO)
 import PFPrint
 import PreStrings(fsTilde)
 import PreIds
@@ -1116,14 +1118,49 @@ trCType' _ _ t@(TDefMonad _) = internalError "trCTypeN: TDefMonad"
 -- Check type synonym applications in the input type.
 -- The tricky thing is that we have to expand synonyms before checking
 -- to implement LiberalTypeSynonyms correctly.
+-- Nullary synonyms that kind-checked clean are remembered process-wide
+-- by qualified name: chkTAp re-expands synonym applications per PATH
+-- (exponential on synonym towers) and runs once per symbol-table
+-- construction (four per compile).  The check is context-free (bodies
+-- travel in the sort; kinds are resolved on the nodes) and pure
+-- validation, so a clean name never needs re-checking; a failing name
+-- is never recorded and re-errors at every occurrence, as before.
+-- Gated on consing being available (64-bit platforms), like
+-- Pred.expandNullaryMemo.
+-- (Recursive nullary synonyms are rejected earlier in mkSymTab.)
+{-# NOINLINE chkSynSeen #-}
+chkSynSeen :: IORef (S.Set (FString, FString))
+chkSynSeen = unsafePerformIO $ newIORef S.empty
+
 chkTAp :: Type -> K.KI ()
-chkTAp = uncurry (chkTAp' [])  . splitTAp
+-- a canonical node is a ground NORMAL FORM (no synonym anywhere
+-- inside, by the cons leaf policy), so every clause of this walk is
+-- vacuous on it: skip, don't descend (the node may be exponentially
+-- shared)
+chkTAp t | isCanonType t = return ()
+chkTAp t = (uncurry (chkTAp' []) . splitTAp) t
   where -- f and as should be the outputs of splitTAp, so there should be no remaining TAps
         chkTAp' _ f@(TAp _ _) as = internalError $ "chkTAp' unexpected TAp: " ++ ppReadable (f, as)
         chkTAp' syns (TCon (TyCon i _ (TItype n t))) as
           | i `elem` syns = K.err (getPosition syns, ETypeSynRecursive (map pfpString syns))
           | let numArgs = genericLength as,
             numArgs < n = K.err (getPosition i, EPartialTypeApp (pfpString i) n numArgs)
+          | n == 0, null as, consCTypeEnabled, not (isUnqualId i) =
+              let key = (getIdQual i, getIdBase i)
+              in if unsafePerformIO (S.member key <$> readIORef chkSynSeen)
+                 then return ()
+                 else do -- the body check keeps the (i:syns) recursion
+                         -- stack, so ETypeSynRecursive still fires on
+                         -- anything past the SCC gate
+                         let t' = if isCanonType t then t
+                                  else setTypePosition (getIdPosition i) t
+                             (f', as') = splitTAp t'
+                         chkTAp' (i:syns) f' as'
+                         -- reached only when the check succeeded
+                         unsafePerformIO
+                           (atomicModifyIORef' chkSynSeen
+                              (\ s -> (S.insert key s, ())))
+                           `seq` return ()
           | otherwise = let (as1, as2) = genericSplitAt n as
                             -- canonical ground bodies stay shared and
                             -- unstamped (cf. Pred.expandSyn)

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -14,6 +14,11 @@ import Prelude hiding ((<>))
 #endif
 
 import Data.List(union, genericSplitAt, genericLength)
+import qualified Data.Map.Strict as M
+import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
+import System.IO.Unsafe(unsafePerformIO)
+import Control.Monad(when)
+import FStringCompat(FString)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -239,7 +244,46 @@ instance PVPrint Inst where
 
 -----------------------------------------------------------------------------
 
+-- A canonical (cons-interned) node is a GROUND NORMAL FORM -- the
+-- leaf policy refuses synonym and ATF tycons, and mkTAp refuses
+-- normTAp redexes -- so expansion is the identity, read off the slot.
+--
+-- Nullary ground synonym expansions are memoized process-wide by
+-- qualified name: expansion is context-free (the body travels inside
+-- the TItype sort) and name-determined (one tycon per qualified
+-- name), and without the memo a duplicating body -- (a, a) holding
+-- the same synonym leaf in both slots -- re-expands that leaf once
+-- per PATH, exponentially on synonym towers.  Ground results cons,
+-- so their use-site stamps conflate to first-arrival, the policy for
+-- ground normal forms; non-ground and applied synonyms take the
+-- plain stamping walk.  (Recursive nullary synonyms are rejected at
+-- symbol-table construction, before this memo can see one.)
+{-# NOINLINE expandSynNameMemo #-}
+expandSynNameMemo :: IORef (M.Map (FString, FString) Type)
+expandSynNameMemo = unsafePerformIO $ newIORef M.empty
+
+-- The recursion argument (the walk under the memo) is supplied by the
+-- caller WITH ITS SYNONYM STACK INTACT, so the ETypeSynRecursive
+-- backstop still fires on (mutually) recursive synonyms that slip
+-- past the symbol table's SCC rejection -- the memo must never reset
+-- that defense.  Only canonical results are memoized: a raw residue
+-- carries per-occurrence position stamps that first-arrival caching
+-- would conflate outside the documented (ground-normal-form) policy.
+expandNullaryMemo :: Id -> Type -> Type
+expandNullaryMemo i walk = unsafePerformIO $ do
+    let key = (getIdQual i, getIdBase i)
+    m0 <- readIORef expandSynNameMemo
+    case M.lookup key m0 of
+      Just r -> return r
+      Nothing -> do
+        let r = walk
+        _ <- return $! r
+        when (isCanonType r) $
+          atomicModifyIORef' expandSynNameMemo (\ m -> (M.insert key r m, ()))
+        return r
+
 expandSyn :: Type -> Type
+expandSyn t0 | isCanonType t0 = t0
 expandSyn t0 = exp [] f as
   where (f, as) = splitTAp t0
         -- All type applications should be split before entering exp
@@ -257,6 +301,19 @@ expandSyn t0 = exp [] f as
           -- context (which includes the eventual return from exp), it is an error.
           | let numArgs = genericLength as,
             numArgs < n = bsErrorReallyUnsafe [(getPosition i, EPartialTypeApp (pfpString i) n numArgs)]
+          -- Nullary QUALIFIED synonyms expand once process-wide (see
+          -- expandNullaryMemo): the name determines the expansion, and
+          -- per-path re-expansion is exponential on synonym towers.
+          -- The walk keeps the (i:syns) recursion stack.  Gated on
+          -- consing being available (64-bit platforms): the memo
+          -- returns first-arrival stamps, which the raw path must
+          -- not observe.
+          | n == 0, null as, consCTypeEnabled, not (isUnqualId i) =
+              expandNullaryMemo i $
+                let t' = if isCanonType t then t
+                         else setTypePosition (getIdPosition i) t
+                    (f', as') = splitTAp t'
+                in exp (i:syns) f' as'
           -- We have a synonym we can expand, so do so.
           | otherwise = let (as1, as2) = genericSplitAt n as
                             -- a canonical (ground) body stays shared and
@@ -297,6 +354,9 @@ class Instantiate t where
     inst  :: [Type] -> t -> t
 
 instance Instantiate Type where
+    -- canonical nodes are ground (no TGen), so instantiation is the
+    -- identity: don't re-walk (and re-cons) the shared structure
+    inst ts t | isCanonType t = t
     inst ts (TAp l r) = TAp (inst ts l) (inst ts r)
     inst ts (TGen _ n)  = ts !! n
     inst ts t         = t

--- a/src/comp/Subst.hs
+++ b/src/comp/Subst.hs
@@ -201,6 +201,11 @@ class Types t where
   tv    :: t -> [TyVar]
 
 instance Types Type where
+  -- canonical (cons-interned) nodes are ground -- no TVar anywhere --
+  -- and normTAp-normal (mkTAp refuses redexes), so substitution is
+  -- the identity and there are no free variables; both answers are
+  -- O(1) where the walk over a huge ground dictionary type dominated
+  apSub _ t | isCanonType t = t
   apSub (S seo _) v@(TVar u) =
         case slookup u seo of
         Just t  ->
@@ -218,6 +223,7 @@ instance Types Type where
   apSub s (TAp l r) = normTAp (apSub s l) (apSub s r)
   apSub s t         = t
 
+  tv t | isCanonType t = []
   tv (TVar u)  = [u]
   tv (TAp l r) = tv l `union` tv r
   tv t         = []

--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -256,6 +256,11 @@ warnTransitiveIncoherent sbs = do
 expTFun :: Type -> TI ([VPred], Type)
 -- Type function application: try to generate a class constraint so
 -- the result gets bound when the class is resolved.
+-- a canonical node is a ground normal form with no TIatf heads, no
+-- prim-tfun redexes, and no idId applications (all refused at cons
+-- time), so there is nothing here to expand -- and the node may be an
+-- exponentially shared DAG that the rebuild below would unroll
+expTFun t0 | isCanonType t0 = return ([], t0)
 expTFun t0
   | let (f, as) = splitTAp t0,
     TCon (TyCon _ _ (TIatf { atf_class_id = clsId
@@ -559,7 +564,11 @@ reducePredsAggressive' dvs es sbs1 s1 vps1 = do
   -- performance of type checking.
   (vps2, sbs2, s2) <- maskAllowIncoherent $ satMany' dvs es [] emptySBs s1 vps1
   checkJoinCtxs "reducePredsAggressive 2" vps1 s2 vps2
-  let allPredTyCons = concat [ concatMap allTyCons ts | IsIn _ ts <- map toPred vps2 ]
+  -- canonical types cannot contain a badCon (TItype/TIatf/idId are
+  -- all refused at cons time) and may be exponentially shared: skip
+  -- them instead of unrolling their DAGs through allTyCons
+  let allPredTyCons = concat [ concatMap allTyCons (filter (not . isCanonType) ts)
+                             | IsIn _ ts <- map toPred vps2 ]
   let badCon (TyCon _ _ (TItype _ _)) = True
       badCon (TyCon _ _ (TIatf {})) = True
       badCon (TyCon i _ _) | i == idId = True
@@ -923,6 +932,11 @@ rmQualLit (CQGen i p e) = do
 -- will substitute in fresh variables for all type variables in the input type
 -- to avoid variable capture
 expandSynN :: Flags -> SymTab -> Type -> Type
+-- a canonical node is a ground normal form -- synonym-free AND
+-- ATF-free by the cons leaf policy -- so the whole normalization
+-- (expandSyn + ATF resolution) is the identity; skip the per-call
+-- runTI setup and the walk
+expandSynN _ _ t | isCanonType t = t
 expandSynN flags s t =
    -- should only need to match instances for coherent typeclasses
    -- XXX user code corner-case?

--- a/src/comp/TypeCheck.hs
+++ b/src/comp/TypeCheck.hs
@@ -18,6 +18,7 @@ import Error(internalError, EMsg, WMsg, ErrMsg(..),
 import ContextErrors
 import Flags(Flags, enablePoisonPills, allowIncoherentMatches)
 import CSyntax
+import CType(isCanonType)
 import PoisonUtils
 import Type
 import Subst
@@ -275,6 +276,9 @@ getFreeD vs (CLValueSign (CDefT i vs' qt cs) qs) =
 getFreeD vs _ = internalError "TypeCheck.getFreeD: not CLValueSign"
 
 getFreeT :: [TyVar] -> CType -> [TyVar]
+-- canonical nodes are ground (no TVar anywhere) and may be
+-- exponentially shared: answer without descending
+getFreeT vs t | isCanonType t = []
 getFreeT vs (TVar v) | v `notElem` vs = [v]
 getFreeT vs (TAp t1 t2) = getFreeT vs t1 ++ getFreeT vs t2
 getFreeT vs t = []

--- a/src/comp/Unify.hs
+++ b/src/comp/Unify.hs
@@ -22,6 +22,12 @@ class Unify t where
         -> t -> t -> Maybe (Subst, [(Type, Type)])
 
 instance Unify Type where
+    -- equal canonical ids = the same ground heap object: reflexivity --
+    -- no substitution, no deferred equalities.  (Also prunes the
+    -- per-path descent over exponentially shared ground types; unequal
+    -- ids prove nothing and fall through.)
+    mgu _ t1 t2 | i >= 0, i == typeCanonId t2 = Just (nullSubst, [])
+      where i = typeCanonId t1
     -- an unreducable ATF application: identical types unify cleanly (reflexivity);
     -- different types generate a deferred equality constraint.
     mgu bound_tyvars t1 t2
@@ -127,6 +133,9 @@ isUnSatSyn' (TAp f a) args = isUnSatSyn' f (args + 1)
 isUnSatSyn' _  _ = False
 
 match :: Type -> Type -> Maybe Subst
+-- same canonical object: matches with no bindings (cf. mgu)
+match t1 t2 | i >= 0, i == typeCanonId t2 = Just nullSubst
+  where i = typeCanonId t1
 match (TAp l r) (TAp l' r') = rtrace ("match: TAp: " ++ ppReadable (l,r)) $ do
     sl <- match l l'
     sr <- match r r'


### PR DESCRIPTION
ctype line 4 (9ffd746e): guard sites consult the certificate instead of re-deriving; Unify gets the canonical-id reflexivity fast path (re-expressed on upstream's simple mgu — the matx mguWork context is not part of this line). Builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt