### PR TITLE
IConv: memoize ground-type conversion (convTMemo / convCanonMemo)

### DIFF
--- a/src/comp/IConv.hs
+++ b/src/comp/IConv.hs
@@ -7,6 +7,9 @@ module IConv(
 import Data.List(union, findIndex)
 import Data.Maybe(catMaybes)
 import qualified Data.Map as M
+import qualified Data.IntMap.Strict as IM
+import Data.IORef(IORef, newIORef, readIORef, atomicModifyIORef')
+import System.IO.Unsafe(unsafePerformIO)
 import qualified Data.Set as S
 import qualified Data.List as List
 
@@ -31,10 +34,11 @@ import Assump
 import Pred
 import SymTab
 import Type(tPrimPair, tBit, HasKind(..))
-import CType(cTVarKind, typeclassId, cTVarNum)
+import CType(cTVarKind, typeclassId, cTVarNum, typeCanonId)
 import VModInfo(mkVModInfo, VName(..), VFieldInfo(..))
 import Type(tString, fn, tName, tAttributes)
 import TCMisc(expandSynN)
+import GroundCType(groundCTypeEnabled, internGroundCType)
 import ATFRules(buildATFRules, atfReduceInType)
 import ISyntax
 import ISyntaxSubst
@@ -174,20 +178,78 @@ iConvVS errh flags r env pvs i vs (CQType _ t) cs =
 -- scope-relative reduction may apply; types reaching conversion have
 -- already been normalized by typechecking, so the fallback should be
 -- unreachable, and it is kept only until that is enforced.
+-- Conversions of internable ground types are memoized
+-- process-globally, keyed on their GroundCType node id: a repeated
+-- large type argument -- the dominant content of converted dictionary
+-- constructions and wrapper interface definitions -- costs one IntMap
+-- probe instead of a full normalization plus structural
+-- re-conversion; and a circulating canonical node costs one pointer
+-- probe inside the interner, no walk at all.  The memo is a bridge
+-- between the two intern tables: its keys are interned CType nodes
+-- and its values are interned ITypes.  Soundness: a type the walk
+-- interns is ground, synonym-expandable and type-function-evaluable
+-- purely, and free of associated type functions (the one
+-- symtab-dependent piece of the normalization below, which resolves
+-- them against the current instances) -- for exactly those types the
+-- conversion is independent of the Flags and SymTab arguments, so one
+-- process-wide entry serves every package.
+{-# NOINLINE convTMemo #-}
+convTMemo :: IORef (IM.IntMap IType)
+convTMemo = unsafePerformIO $ newIORef IM.empty
+
 iConvT :: Flags -> SymTab -> Type -> IType
-iConvT flags s t =
+iConvT flags s t
+  | groundCTypeEnabled, Just (nid, tc) <- internGroundCType t =
+      unsafePerformIO $ do
+        m0 <- readIORef convTMemo
+        case IM.lookup nid m0 of
+          Just it -> return it
+          Nothing -> do
+            -- convert the canonical node: it is already in normal
+            -- form (synonym- and ATF-free, so the normalization
+            -- passes below have nothing to do)
+            let it = iConvTUncached flags s tc
+            atomicModifyIORef' convTMemo (\ m -> (IM.insert nid it m, ()))
+            return it
+  | otherwise = iConvTUncached flags s t
+
+iConvTUncached :: Flags -> SymTab -> Type -> IType
+iConvTUncached flags s t =
     let it = iConvT' (expandSyn t)
     in  case atfReduceInType (buildATFRules s) it of
           Just it' -> it'
           Nothing  -> iConvT' (expandSynN flags s t)
 
+-- per-canonical-node conversion memo: iConvT' is a pure function of
+-- structure, and a canonical (cons-interned) CType may be an
+-- exponentially shared DAG -- without this the recursion below
+-- converts it once per PATH, re-probing IType's intern tables each
+-- time.  Keyed by the cons id (a DIFFERENT id space from convTMemo's
+-- GroundCType node ids -- the tables must stay separate).
+{-# NOINLINE convCanonMemo #-}
+convCanonMemo :: IORef (IM.IntMap IType)
+convCanonMemo = unsafePerformIO $ newIORef IM.empty
+
 iConvT' :: Type -> IType
-iConvT' (TVar (TyVar i _ _)) = ITVar i
-iConvT' (TCon (TyCon i (Just k) s)) = ITCon i (iConvK k) s
-iConvT' (TCon (TyNum n _)) = ITNum n
-iConvT' (TCon (TyStr s _)) = ITStr s
-iConvT' (TAp t1 t2) = ITAp (iConvT' t1) (iConvT' t2)
-iConvT' t = internalError("iConvT': " ++ ppReadable t)
+iConvT' t | i >= 0 = unsafePerformIO $ do
+    m0 <- readIORef convCanonMemo
+    case IM.lookup i m0 of
+      Just it -> return it
+      Nothing -> do
+        let it = iConvT'' t
+        _ <- return $! it
+        atomicModifyIORef' convCanonMemo (\ m -> (IM.insert i it m, ()))
+        return it
+  where i = typeCanonId t
+iConvT' t = iConvT'' t
+
+iConvT'' :: Type -> IType
+iConvT'' (TVar (TyVar i _ _)) = ITVar i
+iConvT'' (TCon (TyCon i (Just k) s)) = ITCon i (iConvK k) s
+iConvT'' (TCon (TyNum n _)) = ITNum n
+iConvT'' (TCon (TyStr s _)) = ITStr s
+iConvT'' (TAp t1 t2) = ITAp (iConvT' t1) (iConvT' t2)
+iConvT'' t = internalError("iConvT'': " ++ ppReadable t)
 
 iConvK :: Kind -> IKind
 iConvK KStar = IKStar

--- a/testsuite/bsc.bluetcl/commands/browseinst.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/browseinst.tcl.bluetcl-bh-out.expected
@@ -55,62 +55,66 @@ Command: browseinst list 2
 11 rWorld rule
 ---------
 Command: browseinst detail 2
-X(BSVModule)  = mkM
-X(BSVPath)    = r1
-X(DEBUG)      = BMod r1 Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = mkM
-X(Name)       = r1
-X(Node)       = Synthesized
-X(SynthPath)  = r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 89 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1
+X(DEBUG)       = BMod r1 Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = mkM
+X(Name)        = r1
+X(Node)        = Synthesized
+X(SynthPath)   = r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 89 15
 ---------
 Command: browseinst list 7
 ---------
 Command: browseinst detail 7
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 ptr
-X(DEBUG)      = BLeaf ptr RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = ptr
-X(Node)       = Primitive
-X(SynthPath)  = r1 ptr
-X(UniqueName) = ptr
-X(position)   = Test.bsv 103 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 ptr
+X(DEBUG)       = BLeaf ptr RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = ptr
+X(Node)        = Primitive
+X(SynthPath)   = r1 ptr
+X(UniqueName)  = ptr
+X(position)    = Test.bsv 103 15
 ---------
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 r1
-X(DEBUG)      = BLeaf r1 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r1
-X(Node)       = Primitive
-X(SynthPath)  = r1 r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 104 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 r1
+X(DEBUG)       = BLeaf r1 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r1
+X(Node)        = Primitive
+X(SynthPath)   = r1 r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 104 15
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 r2
-X(DEBUG)      = BLeaf r2 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r2
-X(Node)       = Primitive
-X(SynthPath)  = r1 r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 105 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 r2
+X(DEBUG)       = BLeaf r2 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r2
+X(Node)        = Primitive
+X(SynthPath)   = r1 r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 105 15
 ---------
 Command: browseinst list 10
 ---------
@@ -146,62 +150,66 @@ Command: browseinst list 3
 16 rWorld rule
 ---------
 Command: browseinst detail 3
-X(BSVModule)  = mkM
-X(BSVPath)    = r2
-X(DEBUG)      = BMod r2 Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = mkM
-X(Name)       = r2
-X(Node)       = Synthesized
-X(SynthPath)  = r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 90 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2
+X(DEBUG)       = BMod r2 Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = mkM
+X(Name)        = r2
+X(Node)        = Synthesized
+X(SynthPath)   = r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 90 15
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 ptr
-X(DEBUG)      = BLeaf ptr RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = ptr
-X(Node)       = Primitive
-X(SynthPath)  = r2 ptr
-X(UniqueName) = ptr
-X(position)   = Test.bsv 103 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 ptr
+X(DEBUG)       = BLeaf ptr RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = ptr
+X(Node)        = Primitive
+X(SynthPath)   = r2 ptr
+X(UniqueName)  = ptr
+X(position)    = Test.bsv 103 15
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 r1
-X(DEBUG)      = BLeaf r1 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r1
-X(Node)       = Primitive
-X(SynthPath)  = r2 r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 104 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 r1
+X(DEBUG)       = BLeaf r1 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r1
+X(Node)        = Primitive
+X(SynthPath)   = r2 r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 104 15
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 r2
-X(DEBUG)      = BLeaf r2 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r2
-X(Node)       = Primitive
-X(SynthPath)  = r2 r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 105 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 r2
+X(DEBUG)       = BLeaf r2 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r2
+X(Node)        = Primitive
+X(SynthPath)   = r2 r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 105 15
 ---------
 Command: browseinst list 15
 ---------
@@ -247,17 +255,18 @@ X(position)   = Test.bsv 91 13
 Command: browseinst list 5
 ---------
 Command: browseinst detail 5
-X(BSVModule)  = mkT
-X(BSVPath)    = mb
-X(DEBUG)      = BLeaf mb VFoo Just ((Test.Foo (Prelude.Bit 4)))
-X(Interface)  = Test.Foo (Prelude.Bit 4)
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = mb
-X(Node)       = Primitive
-X(SynthPath)  = mb
-X(UniqueName) = mb
-X(position)   = Test.bsv 92 18
+X(BSVModule)   = mkT
+X(BSVPath)     = mb
+X(DEBUG)       = BLeaf mb VFoo Just ((Test.Foo (Prelude.Bit 4)))
+X(IfcPosition) = Test.bsv 92 4
+X(Interface)   = Test.Foo (Prelude.Bit 4)
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = mb
+X(Node)        = Primitive
+X(SynthPath)   = mb
+X(UniqueName)  = mb
+X(position)    = Test.bsv 92 18
 ---------
 Command: browseinst list 6
 ---------

--- a/testsuite/bsc.bluetcl/commands/browseinst.tcl.bluetcl-out.expected
+++ b/testsuite/bsc.bluetcl/commands/browseinst.tcl.bluetcl-out.expected
@@ -55,62 +55,66 @@ Command: browseinst list 2
 11 rWorld rule
 ---------
 Command: browseinst detail 2
-X(BSVModule)  = mkM
-X(BSVPath)    = r1
-X(DEBUG)      = BMod r1 Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = mkM
-X(Name)       = r1
-X(Node)       = Synthesized
-X(SynthPath)  = r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 89 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1
+X(DEBUG)       = BMod r1 Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = mkM
+X(Name)        = r1
+X(Node)        = Synthesized
+X(SynthPath)   = r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 89 15
 ---------
 Command: browseinst list 7
 ---------
 Command: browseinst detail 7
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 ptr
-X(DEBUG)      = BLeaf ptr RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = ptr
-X(Node)       = Primitive
-X(SynthPath)  = r1 ptr
-X(UniqueName) = ptr
-X(position)   = Test.bsv 103 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 ptr
+X(DEBUG)       = BLeaf ptr RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = ptr
+X(Node)        = Primitive
+X(SynthPath)   = r1 ptr
+X(UniqueName)  = ptr
+X(position)    = Test.bsv 103 15
 ---------
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 r1
-X(DEBUG)      = BLeaf r1 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r1
-X(Node)       = Primitive
-X(SynthPath)  = r1 r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 104 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 r1
+X(DEBUG)       = BLeaf r1 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r1
+X(Node)        = Primitive
+X(SynthPath)   = r1 r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 104 15
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkM
-X(BSVPath)    = r1 r2
-X(DEBUG)      = BLeaf r2 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r2
-X(Node)       = Primitive
-X(SynthPath)  = r1 r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 105 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r1 r2
+X(DEBUG)       = BLeaf r2 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r2
+X(Node)        = Primitive
+X(SynthPath)   = r1 r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 105 15
 ---------
 Command: browseinst list 10
 ---------
@@ -146,62 +150,66 @@ Command: browseinst list 3
 16 rWorld rule
 ---------
 Command: browseinst detail 3
-X(BSVModule)  = mkM
-X(BSVPath)    = r2
-X(DEBUG)      = BMod r2 Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = mkM
-X(Name)       = r2
-X(Node)       = Synthesized
-X(SynthPath)  = r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 90 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2
+X(DEBUG)       = BMod r2 Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = mkM
+X(Name)        = r2
+X(Node)        = Synthesized
+X(SynthPath)   = r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 90 15
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 ptr
-X(DEBUG)      = BLeaf ptr RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = ptr
-X(Node)       = Primitive
-X(SynthPath)  = r2 ptr
-X(UniqueName) = ptr
-X(position)   = Test.bsv 103 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 ptr
+X(DEBUG)       = BLeaf ptr RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = ptr
+X(Node)        = Primitive
+X(SynthPath)   = r2 ptr
+X(UniqueName)  = ptr
+X(position)    = Test.bsv 103 15
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 r1
-X(DEBUG)      = BLeaf r1 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r1
-X(Node)       = Primitive
-X(SynthPath)  = r2 r1
-X(UniqueName) = r1
-X(position)   = Test.bsv 104 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 r1
+X(DEBUG)       = BLeaf r1 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r1
+X(Node)        = Primitive
+X(SynthPath)   = r2 r1
+X(UniqueName)  = r1
+X(position)    = Test.bsv 104 15
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkM
-X(BSVPath)    = r2 r2
-X(DEBUG)      = BLeaf r2 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = r2
-X(Node)       = Primitive
-X(SynthPath)  = r2 r2
-X(UniqueName) = r2
-X(position)   = Test.bsv 105 15
+X(BSVModule)   = mkM
+X(BSVPath)     = r2 r2
+X(DEBUG)       = BLeaf r2 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Test.bsv 102 12
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = r2
+X(Node)        = Primitive
+X(SynthPath)   = r2 r2
+X(UniqueName)  = r2
+X(position)    = Test.bsv 105 15
 ---------
 Command: browseinst list 15
 ---------
@@ -247,17 +255,18 @@ X(position)   = Test.bsv 91 13
 Command: browseinst list 5
 ---------
 Command: browseinst detail 5
-X(BSVModule)  = mkT
-X(BSVPath)    = mb
-X(DEBUG)      = BLeaf mb VFoo Just ((Test::Foo#(Bit#(4))))
-X(Interface)  = Test::Foo#(Bit#(4))
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = mb
-X(Node)       = Primitive
-X(SynthPath)  = mb
-X(UniqueName) = mb
-X(position)   = Test.bsv 92 18
+X(BSVModule)   = mkT
+X(BSVPath)     = mb
+X(DEBUG)       = BLeaf mb VFoo Just ((Test::Foo#(Bit#(4))))
+X(IfcPosition) = Test.bsv 92 4
+X(Interface)   = Test::Foo#(Bit#(4))
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = mb
+X(Node)        = Primitive
+X(SynthPath)   = mb
+X(UniqueName)  = mb
+X(position)    = Test.bsv 92 18
 ---------
 Command: browseinst list 6
 ---------

--- a/testsuite/bsc.bluetcl/commands/browseinst2.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/commands/browseinst2.tcl.bluetcl-bh-out.expected
@@ -77,75 +77,80 @@ Command: browseinst list 2
 11 {_element_3  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 2
-X(BSVModule) = mkTest
-X(BSVPath)   = y
-X(DEBUG)     = BINode y Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))
-X(LocalPath) = y
-X(Name)      = y
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 9 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = y
+X(DEBUG)       = BINode y Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 8 4
+X(Interface)   = Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))
+X(LocalPath)   = y
+X(Name)        = y
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 9 25
 ---------
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_0
-X(DEBUG)      = BLeaf _element_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = y_0
-X(UniqueName) = y_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_0
+X(DEBUG)       = BLeaf _element_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = y_0
+X(UniqueName)  = y_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_1
-X(DEBUG)      = BLeaf _element_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = y_1
-X(UniqueName) = y_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_1
+X(DEBUG)       = BLeaf _element_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = y_1
+X(UniqueName)  = y_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 10
 ---------
 Command: browseinst detail 10
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_2
-X(DEBUG)      = BLeaf _element_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = y_2
-X(UniqueName) = y_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_2
+X(DEBUG)       = BLeaf _element_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = y_2
+X(UniqueName)  = y_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 11
 ---------
 Command: browseinst detail 11
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_3
-X(DEBUG)      = BLeaf _element_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_3
-X(Node)       = Primitive
-X(SynthPath)  = y_3
-X(UniqueName) = y_3
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_3
+X(DEBUG)       = BLeaf _element_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_3
+X(Node)        = Primitive
+X(SynthPath)   = y_3
+X(UniqueName)  = y_3
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 3
 12 {_element_0  Prelude.Reg (Prelude.Int 32)} prim
@@ -155,135 +160,144 @@ Command: browseinst list 3
 16 {_element_4  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 3
-X(BSVModule) = mkTest
-X(BSVPath)   = zw
-X(DEBUG)     = BINode zw Just ((Vector.Vector 5 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = Vector.Vector 5 (Prelude.Reg (Prelude.Int 32))
-X(LocalPath) = zw
-X(Name)      = zw
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 14 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw
+X(DEBUG)       = BINode zw Just ((Vector.Vector 5 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 14 4
+X(Interface)   = Vector.Vector 5 (Prelude.Reg (Prelude.Int 32))
+X(LocalPath)   = zw
+X(Name)        = zw
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 14 25
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_0
-X(DEBUG)      = BLeaf _element_0 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = zw_0
-X(UniqueName) = zw_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_0
+X(DEBUG)       = BLeaf _element_0 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = zw_0
+X(UniqueName)  = zw_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_1
-X(DEBUG)      = BLeaf _element_1 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = zw_1
-X(UniqueName) = zw_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_1
+X(DEBUG)       = BLeaf _element_1 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = zw_1
+X(UniqueName)  = zw_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_2
-X(DEBUG)      = BLeaf _element_2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = zw_2
-X(UniqueName) = zw_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_2
+X(DEBUG)       = BLeaf _element_2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = zw_2
+X(UniqueName)  = zw_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 15
 ---------
 Command: browseinst detail 15
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_3
-X(DEBUG)      = BLeaf _element_3 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_3
-X(Node)       = Primitive
-X(SynthPath)  = zw_3
-X(UniqueName) = zw_3
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_3
+X(DEBUG)       = BLeaf _element_3 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_3
+X(Node)        = Primitive
+X(SynthPath)   = zw_3
+X(UniqueName)  = zw_3
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 16
 ---------
 Command: browseinst detail 16
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_4
-X(DEBUG)      = BLeaf _element_4 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_4
-X(Node)       = Primitive
-X(SynthPath)  = zw_4
-X(UniqueName) = zw_4
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_4
+X(DEBUG)       = BLeaf _element_4 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_4
+X(Node)        = Primitive
+X(SynthPath)   = zw_4
+X(UniqueName)  = zw_4
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 4
 17 {_element_0  Test.Foo Test.Bar} prim
 18 {_element_1  Test.Foo Test.Bar} prim
 ---------
 Command: browseinst detail 4
-X(BSVModule) = mkTest
-X(BSVPath)   = xx
-X(DEBUG)     = BINode xx Just ((Vector.Vector 2 (Test.Foo Test.Bar)))
-X(Interface) = Vector.Vector 2 (Test.Foo Test.Bar)
-X(LocalPath) = xx
-X(Name)      = xx
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 17 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx
+X(DEBUG)       = BINode xx Just ((Vector.Vector 2 (Test.Foo Test.Bar)))
+X(IfcPosition) = Test.bsv 62 9
+X(Interface)   = Vector.Vector 2 (Test.Foo Test.Bar)
+X(LocalPath)   = xx
+X(Name)        = xx
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 17 25
 ---------
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkTest
-X(BSVPath)    = xx _element_0
-X(DEBUG)      = BLeaf _element_0 VFoo Just ((Test.Foo Test.Bar))
-X(Interface)  = Test.Foo Test.Bar
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = xx_0
-X(UniqueName) = xx_0
-X(position)   = %/Libraries/List.bs 784 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx _element_0
+X(DEBUG)       = BLeaf _element_0 VFoo Just ((Test.Foo Test.Bar))
+X(IfcPosition) = Test2.bsv 17 14
+X(Interface)   = Test.Foo Test.Bar
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = xx_0
+X(UniqueName)  = xx_0
+X(position)    = %/Libraries/List.bs 784 4 {Library List}
 ---------
 Command: browseinst list 18
 ---------
 Command: browseinst detail 18
-X(BSVModule)  = mkTest
-X(BSVPath)    = xx _element_1
-X(DEBUG)      = BLeaf _element_1 VFoo Just ((Test.Foo Test.Bar))
-X(Interface)  = Test.Foo Test.Bar
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = xx_1
-X(UniqueName) = xx_1
-X(position)   = %/Libraries/List.bs 784 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx _element_1
+X(DEBUG)       = BLeaf _element_1 VFoo Just ((Test.Foo Test.Bar))
+X(IfcPosition) = Test2.bsv 17 14
+X(Interface)   = Test.Foo Test.Bar
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = xx_1
+X(UniqueName)  = xx_1
+X(position)    = %/Libraries/List.bs 784 4 {Library List}
 ---------
 Command: browseinst list 5
 19 {x_0  Prelude.Reg (Prelude.Int 32)} prim
@@ -292,75 +306,80 @@ Command: browseinst list 5
 22 {x_3  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 5
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop
-X(DEBUG)     = BINode Loop Just ((Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop
-X(Name)      = Loop
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 19 4
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop
+X(DEBUG)       = BINode Loop Just ((Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = %/Libraries/Prelude.bs 3039 10 {Library Prelude}
+X(Interface)   = (Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop
+X(Name)        = Loop
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 19 4
 ---------
 Command: browseinst list 19
 ---------
 Command: browseinst detail 19
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_0
-X(DEBUG)      = BLeaf x_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_0
-X(Node)       = Primitive
-X(SynthPath)  = x_0
-X(UniqueName) = x_0
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_0
+X(DEBUG)       = BLeaf x_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_0
+X(Node)        = Primitive
+X(SynthPath)   = x_0
+X(UniqueName)  = x_0
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 20
 ---------
 Command: browseinst detail 20
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_1
-X(DEBUG)      = BLeaf x_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_1
-X(Node)       = Primitive
-X(SynthPath)  = x_1
-X(UniqueName) = x_1
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_1
+X(DEBUG)       = BLeaf x_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_1
+X(Node)        = Primitive
+X(SynthPath)   = x_1
+X(UniqueName)  = x_1
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_2
-X(DEBUG)      = BLeaf x_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_2
-X(Node)       = Primitive
-X(SynthPath)  = x_2
-X(UniqueName) = x_2
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_2
+X(DEBUG)       = BLeaf x_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_2
+X(Node)        = Primitive
+X(SynthPath)   = x_2
+X(UniqueName)  = x_2
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 22
 ---------
 Command: browseinst detail 22
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_3
-X(DEBUG)      = BLeaf x_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_3
-X(Node)       = Primitive
-X(SynthPath)  = x_3
-X(UniqueName) = x_3
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_3
+X(DEBUG)       = BLeaf x_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_3
+X(Node)        = Primitive
+X(SynthPath)   = x_3
+X(UniqueName)  = x_3
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 6
 23 Body_0 {}
@@ -369,210 +388,224 @@ Command: browseinst list 6
 26 Body_3 {}
 ---------
 Command: browseinst detail 6
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop
-X(DEBUG)     = BINode Loop Just ((Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop
-X(Name)      = Loop
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 4
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop
+X(DEBUG)       = BINode Loop Just ((Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = %/Libraries/Prelude.bs 3039 10 {Library Prelude}
+X(Interface)   = (Prelude.Integer, Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop
+X(Name)        = Loop
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 4
 ---------
 Command: browseinst list 23
 27 {aa_0  Prelude.Reg (Prelude.Int 32)} prim
 28 {bb_0  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 23
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_0
-X(DEBUG)     = BINode Body_0 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop Body_0
-X(Name)      = Body_0
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0
+X(DEBUG)       = BINode Body_0 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop Body_0
+X(Name)        = Body_0
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 27
 ---------
 Command: browseinst detail 27
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_0 aa_0
-X(DEBUG)      = BLeaf aa_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_0
-X(Node)       = Primitive
-X(SynthPath)  = aa_0
-X(UniqueName) = aa_0
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0 aa_0
+X(DEBUG)       = BLeaf aa_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_0
+X(Node)        = Primitive
+X(SynthPath)   = aa_0
+X(UniqueName)  = aa_0
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 28
 ---------
 Command: browseinst detail 28
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_0 bb_0
-X(DEBUG)      = BLeaf bb_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_0
-X(Node)       = Primitive
-X(SynthPath)  = bb_0
-X(UniqueName) = bb_0
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0 bb_0
+X(DEBUG)       = BLeaf bb_0 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_0
+X(Node)        = Primitive
+X(SynthPath)   = bb_0
+X(UniqueName)  = bb_0
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 24
 29 {aa_1  Prelude.Reg (Prelude.Int 32)} prim
 30 {bb_1  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 24
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_1
-X(DEBUG)     = BINode Body_1 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop Body_1
-X(Name)      = Body_1
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1
+X(DEBUG)       = BINode Body_1 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop Body_1
+X(Name)        = Body_1
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 29
 ---------
 Command: browseinst detail 29
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_1 aa_1
-X(DEBUG)      = BLeaf aa_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_1
-X(Node)       = Primitive
-X(SynthPath)  = aa_1
-X(UniqueName) = aa_1
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1 aa_1
+X(DEBUG)       = BLeaf aa_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_1
+X(Node)        = Primitive
+X(SynthPath)   = aa_1
+X(UniqueName)  = aa_1
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 30
 ---------
 Command: browseinst detail 30
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_1 bb_1
-X(DEBUG)      = BLeaf bb_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_1
-X(Node)       = Primitive
-X(SynthPath)  = bb_1
-X(UniqueName) = bb_1
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1 bb_1
+X(DEBUG)       = BLeaf bb_1 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_1
+X(Node)        = Primitive
+X(SynthPath)   = bb_1
+X(UniqueName)  = bb_1
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 25
 31 {aa_2  Prelude.Reg (Prelude.Int 32)} prim
 32 {bb_2  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 25
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_2
-X(DEBUG)     = BINode Body_2 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop Body_2
-X(Name)      = Body_2
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2
+X(DEBUG)       = BINode Body_2 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop Body_2
+X(Name)        = Body_2
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 31
 ---------
 Command: browseinst detail 31
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_2 aa_2
-X(DEBUG)      = BLeaf aa_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_2
-X(Node)       = Primitive
-X(SynthPath)  = aa_2
-X(UniqueName) = aa_2
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2 aa_2
+X(DEBUG)       = BLeaf aa_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_2
+X(Node)        = Primitive
+X(SynthPath)   = aa_2
+X(UniqueName)  = aa_2
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 32
 ---------
 Command: browseinst detail 32
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_2 bb_2
-X(DEBUG)      = BLeaf bb_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_2
-X(Node)       = Primitive
-X(SynthPath)  = bb_2
-X(UniqueName) = bb_2
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2 bb_2
+X(DEBUG)       = BLeaf bb_2 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_2
+X(Node)        = Primitive
+X(SynthPath)   = bb_2
+X(UniqueName)  = bb_2
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 26
 33 {aa_3  Prelude.Reg (Prelude.Int 32)} prim
 34 {bb_3  Prelude.Reg (Prelude.Int 32)} prim
 ---------
 Command: browseinst detail 26
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_3
-X(DEBUG)     = BINode Body_3 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
-X(Interface) = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
-X(LocalPath) = Loop Body_3
-X(Name)      = Body_3
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3
+X(DEBUG)       = BINode Body_3 Just ((Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = (Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)), Vector.Vector 4 (Prelude.Reg (Prelude.Int 32)))
+X(LocalPath)   = Loop Body_3
+X(Name)        = Body_3
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 33
 ---------
 Command: browseinst detail 33
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_3 aa_3
-X(DEBUG)      = BLeaf aa_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_3
-X(Node)       = Primitive
-X(SynthPath)  = aa_3
-X(UniqueName) = aa_3
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3 aa_3
+X(DEBUG)       = BLeaf aa_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_3
+X(Node)        = Primitive
+X(SynthPath)   = aa_3
+X(UniqueName)  = aa_3
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 34
 ---------
 Command: browseinst detail 34
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_3 bb_3
-X(DEBUG)      = BLeaf bb_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_3
-X(Node)       = Primitive
-X(SynthPath)  = bb_3
-X(UniqueName) = bb_3
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3 bb_3
+X(DEBUG)       = BLeaf bb_3 RegUN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_3
+X(Node)        = Primitive
+X(SynthPath)   = bb_3
+X(UniqueName)  = bb_3
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 7
 35 {_element_0  Test2.Sub_Ifc} synth
 36 {_element_1  Test2.Sub_Ifc} synth
 ---------
 Command: browseinst detail 7
-X(BSVModule) = mkTest
-X(BSVPath)   = subis
-X(DEBUG)     = BINode subis Just ((Vector.Vector 2 Test2.Sub_Ifc))
-X(Interface) = Vector.Vector 2 Test2.Sub_Ifc
-X(LocalPath) = subis
-X(Name)      = subis
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 29 23
+X(BSVModule)   = mkTest
+X(BSVPath)     = subis
+X(DEBUG)       = BINode subis Just ((Vector.Vector 2 Test2.Sub_Ifc))
+X(IfcPosition) = Test.bsv 62 9
+X(Interface)   = Vector.Vector 2 Test2.Sub_Ifc
+X(LocalPath)   = subis
+X(Name)        = subis
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 29 23
 ---------
 Command: browseinst list 35
 37 {foo2  Prelude.Reg (Prelude.Int 32)} prim
@@ -594,32 +627,34 @@ X(position)   = %/Libraries/List.bs 748 4 {Library List}
 Command: browseinst list 37
 ---------
 Command: browseinst detail 37
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_0 foo2
-X(DEBUG)      = BLeaf foo2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = foo2
-X(Node)       = Primitive
-X(SynthPath)  = subis_0 foo2
-X(UniqueName) = foo2
-X(position)   = Test2.bsv 41 14
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_0 foo2
+X(DEBUG)       = BLeaf foo2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = foo2
+X(Node)        = Primitive
+X(SynthPath)   = subis_0 foo2
+X(UniqueName)  = foo2
+X(position)    = Test2.bsv 41 14
 ---------
 Command: browseinst list 38
 ---------
 Command: browseinst detail 38
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_0 barx
-X(DEBUG)      = BLeaf barx RegN Just ((Prelude.Reg (Prelude.Bit 3)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 3)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = barx
-X(Node)       = Primitive
-X(SynthPath)  = subis_0 barx
-X(UniqueName) = barx
-X(position)   = Test2.bsv 42 18
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_0 barx
+X(DEBUG)       = BLeaf barx RegN Just ((Prelude.Reg (Prelude.Bit 3)))
+X(IfcPosition) = Test2.bsv 42 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 3)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = barx
+X(Node)        = Primitive
+X(SynthPath)   = subis_0 barx
+X(UniqueName)  = barx
+X(position)    = Test2.bsv 42 18
 ---------
 Command: browseinst list 36
 39 {foo2  Prelude.Reg (Prelude.Int 32)} prim
@@ -641,32 +676,34 @@ X(position)   = %/Libraries/List.bs 748 4 {Library List}
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_1 foo2
-X(DEBUG)      = BLeaf foo2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
-X(Interface)  = Prelude.Reg (Prelude.Int 32)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = foo2
-X(Node)       = Primitive
-X(SynthPath)  = subis_1 foo2
-X(UniqueName) = foo2
-X(position)   = Test2.bsv 41 14
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_1 foo2
+X(DEBUG)       = BLeaf foo2 RegN Just ((Prelude.Reg (Prelude.Int 32)))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Prelude.Reg (Prelude.Int 32)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = foo2
+X(Node)        = Primitive
+X(SynthPath)   = subis_1 foo2
+X(UniqueName)  = foo2
+X(position)    = Test2.bsv 41 14
 ---------
 Command: browseinst list 40
 ---------
 Command: browseinst detail 40
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_1 barx
-X(DEBUG)      = BLeaf barx RegN Just ((Prelude.Reg (Prelude.Bit 3)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 3)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = barx
-X(Node)       = Primitive
-X(SynthPath)  = subis_1 barx
-X(UniqueName) = barx
-X(position)   = Test2.bsv 42 18
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_1 barx
+X(DEBUG)       = BLeaf barx RegN Just ((Prelude.Reg (Prelude.Bit 3)))
+X(IfcPosition) = Test2.bsv 42 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 3)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = barx
+X(Node)        = Primitive
+X(SynthPath)   = subis_1 barx
+X(UniqueName)  = barx
+X(position)    = Test2.bsv 42 18
 ---------
 Command: browseinst debug
 0 ROOT

--- a/testsuite/bsc.bluetcl/commands/browseinst2.tcl.bluetcl-out.expected
+++ b/testsuite/bsc.bluetcl/commands/browseinst2.tcl.bluetcl-out.expected
@@ -77,75 +77,80 @@ Command: browseinst list 2
 11 {_element_3  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 2
-X(BSVModule) = mkTest
-X(BSVPath)   = y
-X(DEBUG)     = BINode y Just ((Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Vector::Vector#(4, Reg#(Int#(32)))
-X(LocalPath) = y
-X(Name)      = y
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 9 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = y
+X(DEBUG)       = BINode y Just ((Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 8 4
+X(Interface)   = Vector::Vector#(4, Reg#(Int#(32)))
+X(LocalPath)   = y
+X(Name)        = y
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 9 25
 ---------
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_0
-X(DEBUG)      = BLeaf _element_0 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = y_0
-X(UniqueName) = y_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_0
+X(DEBUG)       = BLeaf _element_0 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = y_0
+X(UniqueName)  = y_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_1
-X(DEBUG)      = BLeaf _element_1 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = y_1
-X(UniqueName) = y_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_1
+X(DEBUG)       = BLeaf _element_1 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = y_1
+X(UniqueName)  = y_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 10
 ---------
 Command: browseinst detail 10
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_2
-X(DEBUG)      = BLeaf _element_2 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = y_2
-X(UniqueName) = y_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_2
+X(DEBUG)       = BLeaf _element_2 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = y_2
+X(UniqueName)  = y_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 11
 ---------
 Command: browseinst detail 11
-X(BSVModule)  = mkTest
-X(BSVPath)    = y _element_3
-X(DEBUG)      = BLeaf _element_3 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_3
-X(Node)       = Primitive
-X(SynthPath)  = y_3
-X(UniqueName) = y_3
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = y _element_3
+X(DEBUG)       = BLeaf _element_3 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_3
+X(Node)        = Primitive
+X(SynthPath)   = y_3
+X(UniqueName)  = y_3
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 3
 12 {_element_0  Reg#(Int#(32))} prim
@@ -155,135 +160,144 @@ Command: browseinst list 3
 16 {_element_4  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 3
-X(BSVModule) = mkTest
-X(BSVPath)   = zw
-X(DEBUG)     = BINode zw Just ((Vector::Vector#(5, Reg#(Int#(32)))))
-X(Interface) = Vector::Vector#(5, Reg#(Int#(32)))
-X(LocalPath) = zw
-X(Name)      = zw
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 14 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw
+X(DEBUG)       = BINode zw Just ((Vector::Vector#(5, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 14 4
+X(Interface)   = Vector::Vector#(5, Reg#(Int#(32)))
+X(LocalPath)   = zw
+X(Name)        = zw
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 14 25
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_0
-X(DEBUG)      = BLeaf _element_0 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = zw_0
-X(UniqueName) = zw_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_0
+X(DEBUG)       = BLeaf _element_0 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = zw_0
+X(UniqueName)  = zw_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_1
-X(DEBUG)      = BLeaf _element_1 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = zw_1
-X(UniqueName) = zw_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_1
+X(DEBUG)       = BLeaf _element_1 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = zw_1
+X(UniqueName)  = zw_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_2
-X(DEBUG)      = BLeaf _element_2 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = zw_2
-X(UniqueName) = zw_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_2
+X(DEBUG)       = BLeaf _element_2 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = zw_2
+X(UniqueName)  = zw_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 15
 ---------
 Command: browseinst detail 15
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_3
-X(DEBUG)      = BLeaf _element_3 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_3
-X(Node)       = Primitive
-X(SynthPath)  = zw_3
-X(UniqueName) = zw_3
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_3
+X(DEBUG)       = BLeaf _element_3 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_3
+X(Node)        = Primitive
+X(SynthPath)   = zw_3
+X(UniqueName)  = zw_3
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 16
 ---------
 Command: browseinst detail 16
-X(BSVModule)  = mkTest
-X(BSVPath)    = zw _element_4
-X(DEBUG)      = BLeaf _element_4 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = _element_4
-X(Node)       = Primitive
-X(SynthPath)  = zw_4
-X(UniqueName) = zw_4
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = zw _element_4
+X(DEBUG)       = BLeaf _element_4 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = _element_4
+X(Node)        = Primitive
+X(SynthPath)   = zw_4
+X(UniqueName)  = zw_4
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 4
 17 {_element_0  Foo#(Bar)} prim
 18 {_element_1  Foo#(Bar)} prim
 ---------
 Command: browseinst detail 4
-X(BSVModule) = mkTest
-X(BSVPath)   = xx
-X(DEBUG)     = BINode xx Just ((Vector::Vector#(2, Test::Foo#(Test::Bar))))
-X(Interface) = Vector::Vector#(2, Test::Foo#(Test::Bar))
-X(LocalPath) = xx
-X(Name)      = xx
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 17 25
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx
+X(DEBUG)       = BINode xx Just ((Vector::Vector#(2, Test::Foo#(Test::Bar))))
+X(IfcPosition) = Test.bsv 62 9
+X(Interface)   = Vector::Vector#(2, Test::Foo#(Test::Bar))
+X(LocalPath)   = xx
+X(Name)        = xx
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 17 25
 ---------
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkTest
-X(BSVPath)    = xx _element_0
-X(DEBUG)      = BLeaf _element_0 VFoo Just ((Test::Foo#(Test::Bar)))
-X(Interface)  = Test::Foo#(Test::Bar)
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = xx_0
-X(UniqueName) = xx_0
-X(position)   = %/Libraries/List.bs 784 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx _element_0
+X(DEBUG)       = BLeaf _element_0 VFoo Just ((Test::Foo#(Test::Bar)))
+X(IfcPosition) = Test2.bsv 17 14
+X(Interface)   = Test::Foo#(Test::Bar)
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = xx_0
+X(UniqueName)  = xx_0
+X(position)    = %/Libraries/List.bs 784 4 {Library List}
 ---------
 Command: browseinst list 18
 ---------
 Command: browseinst detail 18
-X(BSVModule)  = mkTest
-X(BSVPath)    = xx _element_1
-X(DEBUG)      = BLeaf _element_1 VFoo Just ((Test::Foo#(Test::Bar)))
-X(Interface)  = Test::Foo#(Test::Bar)
-X(LocalPath)  = 
-X(Module)     = VFoo
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = xx_1
-X(UniqueName) = xx_1
-X(position)   = %/Libraries/List.bs 784 4 {Library List}
+X(BSVModule)   = mkTest
+X(BSVPath)     = xx _element_1
+X(DEBUG)       = BLeaf _element_1 VFoo Just ((Test::Foo#(Test::Bar)))
+X(IfcPosition) = Test2.bsv 17 14
+X(Interface)   = Test::Foo#(Test::Bar)
+X(LocalPath)   = 
+X(Module)      = VFoo
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = xx_1
+X(UniqueName)  = xx_1
+X(position)    = %/Libraries/List.bs 784 4 {Library List}
 ---------
 Command: browseinst list 5
 19 {x_0  Reg#(Int#(32))} prim
@@ -292,75 +306,80 @@ Command: browseinst list 5
 22 {x_3  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 5
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop
-X(DEBUG)     = BINode Loop Just (Tuple2#(Integer, Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple2#(Integer, Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop
-X(Name)      = Loop
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 19 4
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop
+X(DEBUG)       = BINode Loop Just (Tuple2#(Integer, Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = %/Libraries/Prelude.bs 3039 10 {Library Prelude}
+X(Interface)   = Tuple2#(Integer, Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop
+X(Name)        = Loop
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 19 4
 ---------
 Command: browseinst list 19
 ---------
 Command: browseinst detail 19
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_0
-X(DEBUG)      = BLeaf x_0 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_0
-X(Node)       = Primitive
-X(SynthPath)  = x_0
-X(UniqueName) = x_0
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_0
+X(DEBUG)       = BLeaf x_0 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_0
+X(Node)        = Primitive
+X(SynthPath)   = x_0
+X(UniqueName)  = x_0
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 20
 ---------
 Command: browseinst detail 20
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_1
-X(DEBUG)      = BLeaf x_1 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_1
-X(Node)       = Primitive
-X(SynthPath)  = x_1
-X(UniqueName) = x_1
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_1
+X(DEBUG)       = BLeaf x_1 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_1
+X(Node)        = Primitive
+X(SynthPath)   = x_1
+X(UniqueName)  = x_1
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_2
-X(DEBUG)      = BLeaf x_2 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_2
-X(Node)       = Primitive
-X(SynthPath)  = x_2
-X(UniqueName) = x_2
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_2
+X(DEBUG)       = BLeaf x_2 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_2
+X(Node)        = Primitive
+X(SynthPath)   = x_2
+X(UniqueName)  = x_2
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 22
 ---------
 Command: browseinst detail 22
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop x_3
-X(DEBUG)      = BLeaf x_3 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = x_3
-X(Node)       = Primitive
-X(SynthPath)  = x_3
-X(UniqueName) = x_3
-X(position)   = Test2.bsv 20 7
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop x_3
+X(DEBUG)       = BLeaf x_3 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = x_3
+X(Node)        = Primitive
+X(SynthPath)   = x_3
+X(UniqueName)  = x_3
+X(position)    = Test2.bsv 20 7
 ---------
 Command: browseinst list 6
 23 Body_0 {}
@@ -369,210 +388,224 @@ Command: browseinst list 6
 26 Body_3 {}
 ---------
 Command: browseinst detail 6
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop
-X(DEBUG)     = BINode Loop Just (Tuple3#(Integer, Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple3#(Integer, Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop
-X(Name)      = Loop
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 4
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop
+X(DEBUG)       = BINode Loop Just (Tuple3#(Integer, Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = %/Libraries/Prelude.bs 3039 10 {Library Prelude}
+X(Interface)   = Tuple3#(Integer, Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop
+X(Name)        = Loop
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 4
 ---------
 Command: browseinst list 23
 27 {aa_0  Reg#(Int#(32))} prim
 28 {bb_0  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 23
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_0
-X(DEBUG)     = BINode Body_0 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop Body_0
-X(Name)      = Body_0
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0
+X(DEBUG)       = BINode Body_0 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop Body_0
+X(Name)        = Body_0
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 27
 ---------
 Command: browseinst detail 27
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_0 aa_0
-X(DEBUG)      = BLeaf aa_0 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_0
-X(Node)       = Primitive
-X(SynthPath)  = aa_0
-X(UniqueName) = aa_0
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0 aa_0
+X(DEBUG)       = BLeaf aa_0 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_0
+X(Node)        = Primitive
+X(SynthPath)   = aa_0
+X(UniqueName)  = aa_0
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 28
 ---------
 Command: browseinst detail 28
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_0 bb_0
-X(DEBUG)      = BLeaf bb_0 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_0
-X(Node)       = Primitive
-X(SynthPath)  = bb_0
-X(UniqueName) = bb_0
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_0 bb_0
+X(DEBUG)       = BLeaf bb_0 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_0
+X(Node)        = Primitive
+X(SynthPath)   = bb_0
+X(UniqueName)  = bb_0
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 24
 29 {aa_1  Reg#(Int#(32))} prim
 30 {bb_1  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 24
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_1
-X(DEBUG)     = BINode Body_1 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop Body_1
-X(Name)      = Body_1
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1
+X(DEBUG)       = BINode Body_1 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop Body_1
+X(Name)        = Body_1
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 29
 ---------
 Command: browseinst detail 29
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_1 aa_1
-X(DEBUG)      = BLeaf aa_1 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_1
-X(Node)       = Primitive
-X(SynthPath)  = aa_1
-X(UniqueName) = aa_1
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1 aa_1
+X(DEBUG)       = BLeaf aa_1 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_1
+X(Node)        = Primitive
+X(SynthPath)   = aa_1
+X(UniqueName)  = aa_1
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 30
 ---------
 Command: browseinst detail 30
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_1 bb_1
-X(DEBUG)      = BLeaf bb_1 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_1
-X(Node)       = Primitive
-X(SynthPath)  = bb_1
-X(UniqueName) = bb_1
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_1 bb_1
+X(DEBUG)       = BLeaf bb_1 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_1
+X(Node)        = Primitive
+X(SynthPath)   = bb_1
+X(UniqueName)  = bb_1
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 25
 31 {aa_2  Reg#(Int#(32))} prim
 32 {bb_2  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 25
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_2
-X(DEBUG)     = BINode Body_2 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop Body_2
-X(Name)      = Body_2
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2
+X(DEBUG)       = BINode Body_2 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop Body_2
+X(Name)        = Body_2
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 31
 ---------
 Command: browseinst detail 31
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_2 aa_2
-X(DEBUG)      = BLeaf aa_2 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_2
-X(Node)       = Primitive
-X(SynthPath)  = aa_2
-X(UniqueName) = aa_2
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2 aa_2
+X(DEBUG)       = BLeaf aa_2 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_2
+X(Node)        = Primitive
+X(SynthPath)   = aa_2
+X(UniqueName)  = aa_2
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 32
 ---------
 Command: browseinst detail 32
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_2 bb_2
-X(DEBUG)      = BLeaf bb_2 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_2
-X(Node)       = Primitive
-X(SynthPath)  = bb_2
-X(UniqueName) = bb_2
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_2 bb_2
+X(DEBUG)       = BLeaf bb_2 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_2
+X(Node)        = Primitive
+X(SynthPath)   = bb_2
+X(UniqueName)  = bb_2
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 26
 33 {aa_3  Reg#(Int#(32))} prim
 34 {bb_3  Reg#(Int#(32))} prim
 ---------
 Command: browseinst detail 26
-X(BSVModule) = mkTest
-X(BSVPath)   = Loop Body_3
-X(DEBUG)     = BINode Body_3 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
-X(Interface) = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
-X(LocalPath) = Loop Body_3
-X(Name)      = Body_3
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 23 44
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3
+X(DEBUG)       = BINode Body_3 Just (Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32)))))
+X(IfcPosition) = Test2.bsv 23 4
+X(Interface)   = Tuple2#(Vector::Vector#(4, Reg#(Int#(32))), Vector::Vector#(4, Reg#(Int#(32))))
+X(LocalPath)   = Loop Body_3
+X(Name)        = Body_3
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 23 44
 ---------
 Command: browseinst list 33
 ---------
 Command: browseinst detail 33
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_3 aa_3
-X(DEBUG)      = BLeaf aa_3 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = aa_3
-X(Node)       = Primitive
-X(SynthPath)  = aa_3
-X(UniqueName) = aa_3
-X(position)   = Test2.bsv 24 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3 aa_3
+X(DEBUG)       = BLeaf aa_3 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = aa_3
+X(Node)        = Primitive
+X(SynthPath)   = aa_3
+X(UniqueName)  = aa_3
+X(position)    = Test2.bsv 24 6
 ---------
 Command: browseinst list 34
 ---------
 Command: browseinst detail 34
-X(BSVModule)  = mkTest
-X(BSVPath)    = Loop Body_3 bb_3
-X(DEBUG)      = BLeaf bb_3 RegUN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = bb_3
-X(Node)       = Primitive
-X(SynthPath)  = bb_3
-X(UniqueName) = bb_3
-X(position)   = Test2.bsv 25 6
+X(BSVModule)   = mkTest
+X(BSVPath)     = Loop Body_3 bb_3
+X(DEBUG)       = BLeaf bb_3 RegUN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = bb_3
+X(Node)        = Primitive
+X(SynthPath)   = bb_3
+X(UniqueName)  = bb_3
+X(position)    = Test2.bsv 25 6
 ---------
 Command: browseinst list 7
 35 {_element_0  Sub_Ifc} synth
 36 {_element_1  Sub_Ifc} synth
 ---------
 Command: browseinst detail 7
-X(BSVModule) = mkTest
-X(BSVPath)   = subis
-X(DEBUG)     = BINode subis Just ((Vector::Vector#(2, Test2::Sub_Ifc)))
-X(Interface) = Vector::Vector#(2, Test2::Sub_Ifc)
-X(LocalPath) = subis
-X(Name)      = subis
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Test2.bsv 29 23
+X(BSVModule)   = mkTest
+X(BSVPath)     = subis
+X(DEBUG)       = BINode subis Just ((Vector::Vector#(2, Test2::Sub_Ifc)))
+X(IfcPosition) = Test.bsv 62 9
+X(Interface)   = Vector::Vector#(2, Test2::Sub_Ifc)
+X(LocalPath)   = subis
+X(Name)        = subis
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Test2.bsv 29 23
 ---------
 Command: browseinst list 35
 37 {foo2  Reg#(Int#(32))} prim
@@ -594,32 +627,34 @@ X(position)   = %/Libraries/List.bs 748 4 {Library List}
 Command: browseinst list 37
 ---------
 Command: browseinst detail 37
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_0 foo2
-X(DEBUG)      = BLeaf foo2 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = foo2
-X(Node)       = Primitive
-X(SynthPath)  = subis_0 foo2
-X(UniqueName) = foo2
-X(position)   = Test2.bsv 41 14
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_0 foo2
+X(DEBUG)       = BLeaf foo2 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = foo2
+X(Node)        = Primitive
+X(SynthPath)   = subis_0 foo2
+X(UniqueName)  = foo2
+X(position)    = Test2.bsv 41 14
 ---------
 Command: browseinst list 38
 ---------
 Command: browseinst detail 38
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_0 barx
-X(DEBUG)      = BLeaf barx RegN Just ((Reg#(Bit#(3))))
-X(Interface)  = Reg#(Bit#(3))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = barx
-X(Node)       = Primitive
-X(SynthPath)  = subis_0 barx
-X(UniqueName) = barx
-X(position)   = Test2.bsv 42 18
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_0 barx
+X(DEBUG)       = BLeaf barx RegN Just ((Reg#(Bit#(3))))
+X(IfcPosition) = Test2.bsv 42 4
+X(Interface)   = Reg#(Bit#(3))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = barx
+X(Node)        = Primitive
+X(SynthPath)   = subis_0 barx
+X(UniqueName)  = barx
+X(position)    = Test2.bsv 42 18
 ---------
 Command: browseinst list 36
 39 {foo2  Reg#(Int#(32))} prim
@@ -641,32 +676,34 @@ X(position)   = %/Libraries/List.bs 748 4 {Library List}
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_1 foo2
-X(DEBUG)      = BLeaf foo2 RegN Just ((Reg#(Int#(32))))
-X(Interface)  = Reg#(Int#(32))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = foo2
-X(Node)       = Primitive
-X(SynthPath)  = subis_1 foo2
-X(UniqueName) = foo2
-X(position)   = Test2.bsv 41 14
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_1 foo2
+X(DEBUG)       = BLeaf foo2 RegN Just ((Reg#(Int#(32))))
+X(IfcPosition) = Test2.bsv 8 14
+X(Interface)   = Reg#(Int#(32))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = foo2
+X(Node)        = Primitive
+X(SynthPath)   = subis_1 foo2
+X(UniqueName)  = foo2
+X(position)    = Test2.bsv 41 14
 ---------
 Command: browseinst list 40
 ---------
 Command: browseinst detail 40
-X(BSVModule)  = mkSub
-X(BSVPath)    = subis _element_1 barx
-X(DEBUG)      = BLeaf barx RegN Just ((Reg#(Bit#(3))))
-X(Interface)  = Reg#(Bit#(3))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = barx
-X(Node)       = Primitive
-X(SynthPath)  = subis_1 barx
-X(UniqueName) = barx
-X(position)   = Test2.bsv 42 18
+X(BSVModule)   = mkSub
+X(BSVPath)     = subis _element_1 barx
+X(DEBUG)       = BLeaf barx RegN Just ((Reg#(Bit#(3))))
+X(IfcPosition) = Test2.bsv 42 4
+X(Interface)   = Reg#(Bit#(3))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = barx
+X(Node)        = Primitive
+X(SynthPath)   = subis_1 barx
+X(UniqueName)  = barx
+X(position)    = Test2.bsv 42 18
 ---------
 Command: browseinst debug
 0 ROOT

--- a/testsuite/bsc.bluetcl/hierarchy/Design.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/hierarchy/Design.tcl.bluetcl-bh-out.expected
@@ -153,17 +153,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 7
 ---------
 Command: browseinst detail 7
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_g
-X(UniqueName) = the_x_0_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_g
+X(UniqueName)  = the_x_0_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 8
 9 Body_0 {}
@@ -201,17 +202,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_0
-X(UniqueName) = the_x_0_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_0
+X(UniqueName)  = the_x_0_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 14
 16 baz rule
@@ -272,17 +274,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_1
-X(UniqueName) = the_x_0_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_1
+X(UniqueName)  = the_x_0_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 18
 20 baz rule
@@ -343,17 +346,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_2
-X(UniqueName) = the_x_0_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_2
+X(UniqueName)  = the_x_0_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 22
 24 baz rule
@@ -414,17 +418,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 25
 ---------
 Command: browseinst detail 25
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_3
-X(UniqueName) = the_x_0_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_3
+X(UniqueName)  = the_x_0_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 26
 28 baz rule
@@ -484,17 +489,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 29
 ---------
 Command: browseinst detail 29
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_g
-X(UniqueName) = the_x_1_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_g
+X(UniqueName)  = the_x_1_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 30
 31 Body_0 {}
@@ -532,17 +538,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 35
 ---------
 Command: browseinst detail 35
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_0
-X(UniqueName) = the_x_1_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_0
+X(UniqueName)  = the_x_1_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 36
 38 baz rule
@@ -603,17 +610,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_1
-X(UniqueName) = the_x_1_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_1
+X(UniqueName)  = the_x_1_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 40
 42 baz rule
@@ -674,17 +682,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 43
 ---------
 Command: browseinst detail 43
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_2
-X(UniqueName) = the_x_1_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_2
+X(UniqueName)  = the_x_1_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 44
 46 baz rule
@@ -745,17 +754,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 47
 ---------
 Command: browseinst detail 47
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_3
-X(UniqueName) = the_x_1_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_3
+X(UniqueName)  = the_x_1_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 48
 50 baz rule
@@ -815,17 +825,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 51
 ---------
 Command: browseinst detail 51
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_g
-X(UniqueName) = the_x_2_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_g
+X(UniqueName)  = the_x_2_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 52
 53 Body_0 {}
@@ -863,17 +874,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 57
 ---------
 Command: browseinst detail 57
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_0
-X(UniqueName) = the_x_2_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_0
+X(UniqueName)  = the_x_2_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 58
 60 baz rule
@@ -934,17 +946,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 61
 ---------
 Command: browseinst detail 61
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_1
-X(UniqueName) = the_x_2_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_1
+X(UniqueName)  = the_x_2_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 62
 64 baz rule
@@ -1005,17 +1018,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 65
 ---------
 Command: browseinst detail 65
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_2
-X(UniqueName) = the_x_2_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_2
+X(UniqueName)  = the_x_2_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 66
 68 baz rule
@@ -1076,17 +1090,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 69
 ---------
 Command: browseinst detail 69
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_3
-X(UniqueName) = the_x_2_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_3
+X(UniqueName)  = the_x_2_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 70
 72 baz rule
@@ -1146,17 +1161,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 73
 ---------
 Command: browseinst detail 73
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_g
-X(UniqueName) = the_x_3_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_g
+X(UniqueName)  = the_x_3_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 74
 75 Body_0 {}
@@ -1194,17 +1210,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 79
 ---------
 Command: browseinst detail 79
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_0
-X(UniqueName) = the_x_3_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_0
+X(UniqueName)  = the_x_3_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 80
 82 baz rule
@@ -1265,17 +1282,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 83
 ---------
 Command: browseinst detail 83
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_1
-X(UniqueName) = the_x_3_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_1
+X(UniqueName)  = the_x_3_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 84
 86 baz rule
@@ -1336,17 +1354,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 87
 ---------
 Command: browseinst detail 87
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_2
-X(UniqueName) = the_x_3_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_2
+X(UniqueName)  = the_x_3_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 88
 90 baz rule
@@ -1407,17 +1426,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 91
 ---------
 Command: browseinst detail 91
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 8)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_3
-X(UniqueName) = the_x_3_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Prelude.Reg (Prelude.Bit 8)))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Prelude.Reg (Prelude.Bit 8)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_3
+X(UniqueName)  = the_x_3_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 92
 94 baz rule

--- a/testsuite/bsc.bluetcl/hierarchy/Design.tcl.bluetcl-out.expected
+++ b/testsuite/bsc.bluetcl/hierarchy/Design.tcl.bluetcl-out.expected
@@ -153,17 +153,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 7
 ---------
 Command: browseinst detail 7
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_g
-X(UniqueName) = the_x_0_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_g
+X(UniqueName)  = the_x_0_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 8
 9 Body_0 {}
@@ -201,17 +202,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_0
-X(UniqueName) = the_x_0_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_0
+X(UniqueName)  = the_x_0_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 14
 16 baz rule
@@ -272,17 +274,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_1
-X(UniqueName) = the_x_0_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_1
+X(UniqueName)  = the_x_0_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 18
 20 baz rule
@@ -343,17 +346,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_2
-X(UniqueName) = the_x_0_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_2
+X(UniqueName)  = the_x_0_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 22
 24 baz rule
@@ -414,17 +418,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 25
 ---------
 Command: browseinst detail 25
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_0 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_0_the_z_3
-X(UniqueName) = the_x_0_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_0 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_0_the_z_3
+X(UniqueName)  = the_x_0_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 26
 28 baz rule
@@ -484,17 +489,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 29
 ---------
 Command: browseinst detail 29
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_g
-X(UniqueName) = the_x_1_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_g
+X(UniqueName)  = the_x_1_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 30
 31 Body_0 {}
@@ -532,17 +538,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 35
 ---------
 Command: browseinst detail 35
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_0
-X(UniqueName) = the_x_1_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_0
+X(UniqueName)  = the_x_1_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 36
 38 baz rule
@@ -603,17 +610,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_1
-X(UniqueName) = the_x_1_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_1
+X(UniqueName)  = the_x_1_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 40
 42 baz rule
@@ -674,17 +682,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 43
 ---------
 Command: browseinst detail 43
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_2
-X(UniqueName) = the_x_1_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_2
+X(UniqueName)  = the_x_1_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 44
 46 baz rule
@@ -745,17 +754,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 47
 ---------
 Command: browseinst detail 47
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_1 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_1_the_z_3
-X(UniqueName) = the_x_1_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_1 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_1_the_z_3
+X(UniqueName)  = the_x_1_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 48
 50 baz rule
@@ -815,17 +825,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 51
 ---------
 Command: browseinst detail 51
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_g
-X(UniqueName) = the_x_2_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_g
+X(UniqueName)  = the_x_2_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 52
 53 Body_0 {}
@@ -863,17 +874,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 57
 ---------
 Command: browseinst detail 57
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_0
-X(UniqueName) = the_x_2_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_0
+X(UniqueName)  = the_x_2_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 58
 60 baz rule
@@ -934,17 +946,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 61
 ---------
 Command: browseinst detail 61
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_1
-X(UniqueName) = the_x_2_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_1
+X(UniqueName)  = the_x_2_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 62
 64 baz rule
@@ -1005,17 +1018,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 65
 ---------
 Command: browseinst detail 65
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_2
-X(UniqueName) = the_x_2_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_2
+X(UniqueName)  = the_x_2_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 66
 68 baz rule
@@ -1076,17 +1090,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 69
 ---------
 Command: browseinst detail 69
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_2 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_2_the_z_3
-X(UniqueName) = the_x_2_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_2 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_2_the_z_3
+X(UniqueName)  = the_x_2_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 70
 72 baz rule
@@ -1146,17 +1161,18 @@ X(position)  = Design.bsv 11 10
 Command: browseinst list 73
 ---------
 Command: browseinst detail 73
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 the_g
-X(DEBUG)      = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_g
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_g
-X(UniqueName) = the_x_3_the_g
-X(position)   = Design.bsv 19 4
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 the_g
+X(DEBUG)       = BLeaf the_g RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_g
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_g
+X(UniqueName)  = the_x_3_the_g
+X(position)    = Design.bsv 19 4
 ---------
 Command: browseinst list 74
 75 Body_0 {}
@@ -1194,17 +1210,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 79
 ---------
 Command: browseinst detail 79
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_0 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_0
-X(UniqueName) = the_x_3_the_z_0
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_0 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_0
+X(UniqueName)  = the_x_3_the_z_0
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 80
 82 baz rule
@@ -1265,17 +1282,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 83
 ---------
 Command: browseinst detail 83
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_1 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_1
-X(UniqueName) = the_x_3_the_z_1
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_1 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_1
+X(UniqueName)  = the_x_3_the_z_1
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 84
 86 baz rule
@@ -1336,17 +1354,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 87
 ---------
 Command: browseinst detail 87
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_2 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_2
-X(UniqueName) = the_x_3_the_z_2
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_2 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_2
+X(UniqueName)  = the_x_3_the_z_2
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 88
 90 baz rule
@@ -1407,17 +1426,18 @@ X(position)  = Design.bsv 23 7
 Command: browseinst list 91
 ---------
 Command: browseinst detail 91
-X(BSVModule)  = mkDesign
-X(BSVPath)    = Loop the_x_3 Loop Body_3 the_z
-X(DEBUG)      = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
-X(Interface)  = Reg#(Bit#(8))
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = the_z
-X(Node)       = Primitive
-X(SynthPath)  = the_x_3_the_z_3
-X(UniqueName) = the_x_3_the_z_3
-X(position)   = Design.bsv 25 10
+X(BSVModule)   = mkDesign
+X(BSVPath)     = Loop the_x_3 Loop Body_3 the_z
+X(DEBUG)       = BLeaf the_z RegN Just ((Reg#(Bit#(8))))
+X(IfcPosition) = Design.bsv 18 4
+X(Interface)   = Reg#(Bit#(8))
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = the_z
+X(Node)        = Primitive
+X(SynthPath)   = the_x_3_the_z_3
+X(UniqueName)  = the_x_3_the_z_3
+X(position)    = Design.bsv 25 10
 ---------
 Command: browseinst list 92
 94 baz rule

--- a/testsuite/bsc.bluetcl/hierarchy/Example.tcl.bluetcl-bh-out.expected
+++ b/testsuite/bsc.bluetcl/hierarchy/Example.tcl.bluetcl-bh-out.expected
@@ -85,17 +85,18 @@ X(UniqueName) =
 Command: browseinst list 2
 ---------
 Command: browseinst detail 2
-X(BSVModule)  = mkExample
-X(BSVPath)    = zow
-X(DEBUG)      = BLeaf zow RWire Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = zow
-X(Node)       = Primitive
-X(SynthPath)  = zow
-X(UniqueName) = zow
-X(position)   = Example.bsv 9 15
+X(BSVModule)   = mkExample
+X(BSVPath)     = zow
+X(DEBUG)       = BLeaf zow RWire Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = zow
+X(Node)        = Primitive
+X(SynthPath)   = zow
+X(UniqueName)  = zow
+X(position)    = Example.bsv 9 15
 ---------
 Command: browseinst list 3
 8 {zow2  Prelude.Reg Prelude.Bool} prim
@@ -114,17 +115,18 @@ X(position)  = Example.bsv 11 4
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkExample
-X(BSVPath)    = mkZow zow2
-X(DEBUG)      = BLeaf zow2 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = zow2
-X(Node)       = Primitive
-X(SynthPath)  = Zow_inst_mkZow_zow2
-X(UniqueName) = Zow_inst_mkZow_zow2
-X(position)   = Zow.bsv 6 15
+X(BSVModule)   = mkExample
+X(BSVPath)     = mkZow zow2
+X(DEBUG)       = BLeaf zow2 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = zow2
+X(Node)        = Primitive
+X(SynthPath)   = Zow_inst_mkZow_zow2
+X(UniqueName)  = Zow_inst_mkZow_zow2
+X(position)    = Zow.bsv 6 15
 ---------
 Command: browseinst list 4
 9 {_element_1  Prelude.Reg (Prelude.Bit 5)} prim
@@ -132,60 +134,64 @@ Command: browseinst list 4
 11 {_element_0  Prelude.Reg (Prelude.Bit 5)} prim
 ---------
 Command: browseinst detail 4
-X(BSVModule) = mkExample
-X(BSVPath)   = xx
-X(DEBUG)     = BINode xx Just ((Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))))
-X(Interface) = Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))
-X(LocalPath) = xx
-X(Name)      = xx
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Example.bsv 13 29
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx
+X(DEBUG)       = BINode xx Just ((Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))))
+X(IfcPosition) = Example.bsv 13 4
+X(Interface)   = Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))
+X(LocalPath)   = xx
+X(Name)        = xx
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Example.bsv 13 29
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_1
-X(DEBUG)      = BLeaf _element_1 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = xx_1
-X(UniqueName) = xx_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_1
+X(DEBUG)       = BLeaf _element_1 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = xx_1
+X(UniqueName)  = xx_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 10
 ---------
 Command: browseinst detail 10
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_2
-X(DEBUG)      = BLeaf _element_2 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = xx_2
-X(UniqueName) = xx_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_2
+X(DEBUG)       = BLeaf _element_2 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = xx_2
+X(UniqueName)  = xx_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 11
 ---------
 Command: browseinst detail 11
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_0
-X(DEBUG)      = BLeaf _element_0 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = xx_0
-X(UniqueName) = xx_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_0
+X(DEBUG)       = BLeaf _element_0 RegUN Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = xx_0
+X(UniqueName)  = xx_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 5
 12 {_element_1  Prelude.Reg (Prelude.Bit 5)} prim
@@ -193,60 +199,64 @@ Command: browseinst list 5
 14 {_element_0  Prelude.Reg (Prelude.Bit 5)} prim
 ---------
 Command: browseinst detail 5
-X(BSVModule) = mkExample
-X(BSVPath)   = ww
-X(DEBUG)     = BINode ww Just ((Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))))
-X(Interface) = Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))
-X(LocalPath) = ww
-X(Name)      = ww
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Example.bsv 15 29
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww
+X(DEBUG)       = BINode ww Just ((Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))))
+X(IfcPosition) = Example.bsv 13 4
+X(Interface)   = Vector.Vector 3 (Prelude.Reg (Prelude.Bit 5))
+X(LocalPath)   = ww
+X(Name)        = ww
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Example.bsv 15 29
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_1
-X(DEBUG)      = BLeaf _element_1 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = ww_1
-X(UniqueName) = ww_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_1
+X(DEBUG)       = BLeaf _element_1 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = ww_1
+X(UniqueName)  = ww_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_2
-X(DEBUG)      = BLeaf _element_2 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = ww_2
-X(UniqueName) = ww_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_2
+X(DEBUG)       = BLeaf _element_2 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = ww_2
+X(UniqueName)  = ww_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_0
-X(DEBUG)      = BLeaf _element_0 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
-X(Interface)  = Prelude.Reg (Prelude.Bit 5)
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = ww_0
-X(UniqueName) = ww_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_0
+X(DEBUG)       = BLeaf _element_0 RWire Just ((Prelude.Reg (Prelude.Bit 5)))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Prelude.Reg (Prelude.Bit 5)
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = ww_0
+X(UniqueName)  = ww_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 6
 15 {z_0  Prelude.Reg Prelude.Bool} prim
@@ -267,47 +277,50 @@ X(position)  = Example.bsv 17 4
 Command: browseinst list 15
 ---------
 Command: browseinst detail 15
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_0
-X(DEBUG)      = BLeaf z_0 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_0
-X(Node)       = Primitive
-X(SynthPath)  = z_0
-X(UniqueName) = z_0
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_0
+X(DEBUG)       = BLeaf z_0 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_0
+X(Node)        = Primitive
+X(SynthPath)   = z_0
+X(UniqueName)  = z_0
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 16
 ---------
 Command: browseinst detail 16
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_1
-X(DEBUG)      = BLeaf z_1 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_1
-X(Node)       = Primitive
-X(SynthPath)  = z_1
-X(UniqueName) = z_1
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_1
+X(DEBUG)       = BLeaf z_1 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_1
+X(Node)        = Primitive
+X(SynthPath)   = z_1
+X(UniqueName)  = z_1
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_2
-X(DEBUG)      = BLeaf z_2 RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_2
-X(Node)       = Primitive
-X(SynthPath)  = z_2
-X(UniqueName) = z_2
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_2
+X(DEBUG)       = BLeaf z_2 RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_2
+X(Node)        = Primitive
+X(SynthPath)   = z_2
+X(UniqueName)  = z_2
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 7
 18 Body_0 {}
@@ -343,17 +356,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 x
-X(DEBUG)      = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_0
-X(UniqueName) = x_0
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 x
+X(DEBUG)       = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_0
+X(UniqueName)  = x_0
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 22
 23 Body_0 {}
@@ -389,17 +403,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 26
 ---------
 Command: browseinst detail 26
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_0
-X(UniqueName) = y_0_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_0
+X(UniqueName)  = y_0_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 27
 ---------
@@ -432,17 +447,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 28
 ---------
 Command: browseinst detail 28
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_1
-X(UniqueName) = y_0_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_1
+X(UniqueName)  = y_0_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 29
 ---------
@@ -475,17 +491,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 30
 ---------
 Command: browseinst detail 30
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_2
-X(UniqueName) = y_0_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_2
+X(UniqueName)  = y_0_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 31
 ---------
@@ -518,17 +535,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 32
 ---------
 Command: browseinst detail 32
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 x
-X(DEBUG)      = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_1
-X(UniqueName) = x_1
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 x
+X(DEBUG)       = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_1
+X(UniqueName)  = x_1
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 33
 34 Body_0 {}
@@ -564,17 +582,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 37
 ---------
 Command: browseinst detail 37
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_0
-X(UniqueName) = y_1_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_0
+X(UniqueName)  = y_1_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 38
 ---------
@@ -607,17 +626,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_1
-X(UniqueName) = y_1_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_1
+X(UniqueName)  = y_1_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 40
 ---------
@@ -650,17 +670,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 41
 ---------
 Command: browseinst detail 41
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_2
-X(UniqueName) = y_1_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_2
+X(UniqueName)  = y_1_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 42
 ---------
@@ -693,17 +714,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 43
 ---------
 Command: browseinst detail 43
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 x
-X(DEBUG)      = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_2
-X(UniqueName) = x_2
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 x
+X(DEBUG)       = BLeaf x RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_2
+X(UniqueName)  = x_2
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 44
 45 Body_0 {}
@@ -739,17 +761,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 48
 ---------
 Command: browseinst detail 48
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_0
-X(UniqueName) = y_2_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_0
+X(UniqueName)  = y_2_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 49
 ---------
@@ -782,17 +805,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 50
 ---------
 Command: browseinst detail 50
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_1
-X(UniqueName) = y_2_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_1
+X(UniqueName)  = y_2_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 51
 ---------
@@ -825,17 +849,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 52
 ---------
 Command: browseinst detail 52
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
-X(Interface)  = Prelude.Reg Prelude.Bool
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_2
-X(UniqueName) = y_2_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Prelude.Reg Prelude.Bool))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Prelude.Reg Prelude.Bool
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_2
+X(UniqueName)  = y_2_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 53
 ---------

--- a/testsuite/bsc.bluetcl/hierarchy/Example.tcl.bluetcl-out.expected
+++ b/testsuite/bsc.bluetcl/hierarchy/Example.tcl.bluetcl-out.expected
@@ -85,17 +85,18 @@ X(UniqueName) =
 Command: browseinst list 2
 ---------
 Command: browseinst detail 2
-X(BSVModule)  = mkExample
-X(BSVPath)    = zow
-X(DEBUG)      = BLeaf zow RWire Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = zow
-X(Node)       = Primitive
-X(SynthPath)  = zow
-X(UniqueName) = zow
-X(position)   = Example.bsv 9 15
+X(BSVModule)   = mkExample
+X(BSVPath)     = zow
+X(DEBUG)       = BLeaf zow RWire Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = zow
+X(Node)        = Primitive
+X(SynthPath)   = zow
+X(UniqueName)  = zow
+X(position)    = Example.bsv 9 15
 ---------
 Command: browseinst list 3
 8 {zow2  Reg#(Bool)} prim
@@ -114,17 +115,18 @@ X(position)  = Example.bsv 11 4
 Command: browseinst list 8
 ---------
 Command: browseinst detail 8
-X(BSVModule)  = mkExample
-X(BSVPath)    = mkZow zow2
-X(DEBUG)      = BLeaf zow2 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = zow2
-X(Node)       = Primitive
-X(SynthPath)  = Zow_inst_mkZow_zow2
-X(UniqueName) = Zow_inst_mkZow_zow2
-X(position)   = Zow.bsv 6 15
+X(BSVModule)   = mkExample
+X(BSVPath)     = mkZow zow2
+X(DEBUG)       = BLeaf zow2 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = zow2
+X(Node)        = Primitive
+X(SynthPath)   = Zow_inst_mkZow_zow2
+X(UniqueName)  = Zow_inst_mkZow_zow2
+X(position)    = Zow.bsv 6 15
 ---------
 Command: browseinst list 4
 9 {_element_1  Reg#(Bit#(5))} prim
@@ -132,60 +134,64 @@ Command: browseinst list 4
 11 {_element_0  Reg#(Bit#(5))} prim
 ---------
 Command: browseinst detail 4
-X(BSVModule) = mkExample
-X(BSVPath)   = xx
-X(DEBUG)     = BINode xx Just ((Vector::Vector#(3, Reg#(Bit#(5)))))
-X(Interface) = Vector::Vector#(3, Reg#(Bit#(5)))
-X(LocalPath) = xx
-X(Name)      = xx
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Example.bsv 13 29
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx
+X(DEBUG)       = BINode xx Just ((Vector::Vector#(3, Reg#(Bit#(5)))))
+X(IfcPosition) = Example.bsv 13 4
+X(Interface)   = Vector::Vector#(3, Reg#(Bit#(5)))
+X(LocalPath)   = xx
+X(Name)        = xx
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Example.bsv 13 29
 ---------
 Command: browseinst list 9
 ---------
 Command: browseinst detail 9
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_1
-X(DEBUG)      = BLeaf _element_1 RegUN Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = xx_1
-X(UniqueName) = xx_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_1
+X(DEBUG)       = BLeaf _element_1 RegUN Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = xx_1
+X(UniqueName)  = xx_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 10
 ---------
 Command: browseinst detail 10
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_2
-X(DEBUG)      = BLeaf _element_2 RegUN Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = xx_2
-X(UniqueName) = xx_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_2
+X(DEBUG)       = BLeaf _element_2 RegUN Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = xx_2
+X(UniqueName)  = xx_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 11
 ---------
 Command: browseinst detail 11
-X(BSVModule)  = mkExample
-X(BSVPath)    = xx _element_0
-X(DEBUG)      = BLeaf _element_0 RegUN Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RegUN
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = xx_0
-X(UniqueName) = xx_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = xx _element_0
+X(DEBUG)       = BLeaf _element_0 RegUN Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RegUN
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = xx_0
+X(UniqueName)  = xx_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 5
 12 {_element_1  Reg#(Bit#(5))} prim
@@ -193,60 +199,64 @@ Command: browseinst list 5
 14 {_element_0  Reg#(Bit#(5))} prim
 ---------
 Command: browseinst detail 5
-X(BSVModule) = mkExample
-X(BSVPath)   = ww
-X(DEBUG)     = BINode ww Just ((Vector::Vector#(3, Reg#(Bit#(5)))))
-X(Interface) = Vector::Vector#(3, Reg#(Bit#(5)))
-X(LocalPath) = ww
-X(Name)      = ww
-X(Node)      = Instance
-X(SynthPath) = 
-X(position)  = Example.bsv 15 29
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww
+X(DEBUG)       = BINode ww Just ((Vector::Vector#(3, Reg#(Bit#(5)))))
+X(IfcPosition) = Example.bsv 13 4
+X(Interface)   = Vector::Vector#(3, Reg#(Bit#(5)))
+X(LocalPath)   = ww
+X(Name)        = ww
+X(Node)        = Instance
+X(SynthPath)   = 
+X(position)    = Example.bsv 15 29
 ---------
 Command: browseinst list 12
 ---------
 Command: browseinst detail 12
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_1
-X(DEBUG)      = BLeaf _element_1 RWire Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_1
-X(Node)       = Primitive
-X(SynthPath)  = ww_1
-X(UniqueName) = ww_1
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_1
+X(DEBUG)       = BLeaf _element_1 RWire Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_1
+X(Node)        = Primitive
+X(SynthPath)   = ww_1
+X(UniqueName)  = ww_1
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 13
 ---------
 Command: browseinst detail 13
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_2
-X(DEBUG)      = BLeaf _element_2 RWire Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_2
-X(Node)       = Primitive
-X(SynthPath)  = ww_2
-X(UniqueName) = ww_2
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_2
+X(DEBUG)       = BLeaf _element_2 RWire Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_2
+X(Node)        = Primitive
+X(SynthPath)   = ww_2
+X(UniqueName)  = ww_2
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 14
 ---------
 Command: browseinst detail 14
-X(BSVModule)  = mkExample
-X(BSVPath)    = ww _element_0
-X(DEBUG)      = BLeaf _element_0 RWire Just ((Reg#(Bit#(5))))
-X(Interface)  = Reg#(Bit#(5))
-X(LocalPath)  = 
-X(Module)     = RWire
-X(Name)       = _element_0
-X(Node)       = Primitive
-X(SynthPath)  = ww_0
-X(UniqueName) = ww_0
-X(position)   = %/Libraries/List.bs 748 4 {Library List}
+X(BSVModule)   = mkExample
+X(BSVPath)     = ww _element_0
+X(DEBUG)       = BLeaf _element_0 RWire Just ((Reg#(Bit#(5))))
+X(IfcPosition) = Example.bsv 13 14
+X(Interface)   = Reg#(Bit#(5))
+X(LocalPath)   = 
+X(Module)      = RWire
+X(Name)        = _element_0
+X(Node)        = Primitive
+X(SynthPath)   = ww_0
+X(UniqueName)  = ww_0
+X(position)    = %/Libraries/List.bs 748 4 {Library List}
 ---------
 Command: browseinst list 6
 15 {z_0  Reg#(Bool)} prim
@@ -267,47 +277,50 @@ X(position)  = Example.bsv 17 4
 Command: browseinst list 15
 ---------
 Command: browseinst detail 15
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_0
-X(DEBUG)      = BLeaf z_0 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_0
-X(Node)       = Primitive
-X(SynthPath)  = z_0
-X(UniqueName) = z_0
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_0
+X(DEBUG)       = BLeaf z_0 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_0
+X(Node)        = Primitive
+X(SynthPath)   = z_0
+X(UniqueName)  = z_0
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 16
 ---------
 Command: browseinst detail 16
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_1
-X(DEBUG)      = BLeaf z_1 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_1
-X(Node)       = Primitive
-X(SynthPath)  = z_1
-X(UniqueName) = z_1
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_1
+X(DEBUG)       = BLeaf z_1 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_1
+X(Node)        = Primitive
+X(SynthPath)   = z_1
+X(UniqueName)  = z_1
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 17
 ---------
 Command: browseinst detail 17
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop z_2
-X(DEBUG)      = BLeaf z_2 RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = z_2
-X(Node)       = Primitive
-X(SynthPath)  = z_2
-X(UniqueName) = z_2
-X(position)   = Example.bsv 18 18
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop z_2
+X(DEBUG)       = BLeaf z_2 RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = z_2
+X(Node)        = Primitive
+X(SynthPath)   = z_2
+X(UniqueName)  = z_2
+X(position)    = Example.bsv 18 18
 ---------
 Command: browseinst list 7
 18 Body_0 {}
@@ -343,17 +356,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 21
 ---------
 Command: browseinst detail 21
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 x
-X(DEBUG)      = BLeaf x RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_0
-X(UniqueName) = x_0
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 x
+X(DEBUG)       = BLeaf x RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_0
+X(UniqueName)  = x_0
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 22
 23 Body_0 {}
@@ -389,17 +403,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 26
 ---------
 Command: browseinst detail 26
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_0
-X(UniqueName) = y_0_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_0
+X(UniqueName)  = y_0_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 27
 ---------
@@ -432,17 +447,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 28
 ---------
 Command: browseinst detail 28
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_1
-X(UniqueName) = y_0_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_1
+X(UniqueName)  = y_0_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 29
 ---------
@@ -475,17 +491,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 30
 ---------
 Command: browseinst detail 30
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_0 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_0_2
-X(UniqueName) = y_0_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_0 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_0_2
+X(UniqueName)  = y_0_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 31
 ---------
@@ -518,17 +535,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 32
 ---------
 Command: browseinst detail 32
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 x
-X(DEBUG)      = BLeaf x RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_1
-X(UniqueName) = x_1
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 x
+X(DEBUG)       = BLeaf x RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_1
+X(UniqueName)  = x_1
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 33
 34 Body_0 {}
@@ -564,17 +582,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 37
 ---------
 Command: browseinst detail 37
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_0
-X(UniqueName) = y_1_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_0
+X(UniqueName)  = y_1_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 38
 ---------
@@ -607,17 +626,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 39
 ---------
 Command: browseinst detail 39
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_1
-X(UniqueName) = y_1_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_1
+X(UniqueName)  = y_1_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 40
 ---------
@@ -650,17 +670,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 41
 ---------
 Command: browseinst detail 41
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_1 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_1_2
-X(UniqueName) = y_1_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_1 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_1_2
+X(UniqueName)  = y_1_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 42
 ---------
@@ -693,17 +714,18 @@ X(position)  = Example.bsv 21 7
 Command: browseinst list 43
 ---------
 Command: browseinst detail 43
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 x
-X(DEBUG)      = BLeaf x RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = x
-X(Node)       = Primitive
-X(SynthPath)  = x_2
-X(UniqueName) = x_2
-X(position)   = Example.bsv 23 21
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 x
+X(DEBUG)       = BLeaf x RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = x
+X(Node)        = Primitive
+X(SynthPath)   = x_2
+X(UniqueName)  = x_2
+X(position)    = Example.bsv 23 21
 ---------
 Command: browseinst list 44
 45 Body_0 {}
@@ -739,17 +761,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 48
 ---------
 Command: browseinst detail 48
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_0 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_0
-X(UniqueName) = y_2_0
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_0 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_0
+X(UniqueName)  = y_2_0
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 49
 ---------
@@ -782,17 +805,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 50
 ---------
 Command: browseinst detail 50
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_1 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_1
-X(UniqueName) = y_2_1
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_1 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_1
+X(UniqueName)  = y_2_1
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 51
 ---------
@@ -825,17 +849,18 @@ X(position)  = Example.bsv 26 13
 Command: browseinst list 52
 ---------
 Command: browseinst detail 52
-X(BSVModule)  = mkExample
-X(BSVPath)    = Loop Body_2 Loop Body_2 y
-X(DEBUG)      = BLeaf y RegN Just ((Reg#(Bool)))
-X(Interface)  = Reg#(Bool)
-X(LocalPath)  = 
-X(Module)     = RegN
-X(Name)       = y
-X(Node)       = Primitive
-X(SynthPath)  = y_2_2
-X(UniqueName) = y_2_2
-X(position)   = Example.bsv 28 27
+X(BSVModule)   = mkExample
+X(BSVPath)     = Loop Body_2 Loop Body_2 y
+X(DEBUG)       = BLeaf y RegN Just ((Reg#(Bool)))
+X(IfcPosition) = Zow.bsv 6 4
+X(Interface)   = Reg#(Bool)
+X(LocalPath)   = 
+X(Module)      = RegN
+X(Name)        = y
+X(Node)        = Primitive
+X(SynthPath)   = y_2_2
+X(UniqueName)  = y_2_2
+X(position)    = Example.bsv 28 27
 ---------
 Command: browseinst list 53
 ---------


### PR DESCRIPTION
ctype line 6: the held-back conversion memos (04a62cdf + the 21d91a4b IConv hunks), de-knobbed and re-expressed around atf/2's iConvT shape (memo entry converts the canonical node — sound because interned types are ATF-free and synonym-free, so conversion is Flags/SymTab-independent). Line note: the flip commit (9eb57ae8) is VACUOUS on this geometry — with the knobs stripped everything is already on; nothing left to flip, so the line ends here. Builds; typeclasses 107/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt