### PR TITLE
LiftDicts: content-named lifted dictionaries; structural hashType

### DIFF
--- a/src/comp/GenBin.hs
+++ b/src/comp/GenBin.hs
@@ -26,7 +26,7 @@ doTrace = elem "-trace-genbin" progArgs
 -- .bo file tag -- change this whenever the .bo format changes
 -- See also GenABin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260715-5"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-bo-20260804-2"
 
 headerBS :: B.ByteString
 headerBS = B.pack header

--- a/src/comp/LiftDicts.hs
+++ b/src/comp/LiftDicts.hs
@@ -15,7 +15,7 @@ import IOUtil(progArgs)
 import Util(mapSndM, itos)
 
 import CSyntax
-import FStringCompat(FString)
+import FStringCompat(FString, mkFString)
 import CFreeVars(getPV, getFVE, fvSetToFreeVars)
 import CType
 import Assump
@@ -243,17 +243,53 @@ getTopNameInfo i = do
                 tyVars = zipWith tVarKind tmpTyVarIds ks
                 t'     = inst (map TVar tyVars) (qualToType qt)
 
-newDictId :: Position -> L a Id
-newDictId pos = do
-  n <- gets dictNo
+-- Name a lifted dictionary after a hash of its evidence, so that adding an
+-- unrelated definition to a package does not renumber its dictionaries and
+-- move the bytes of every artifact that references them.
+--
+-- A type does not determine a lifted dictionary here (see the "dictPool type
+-- collision (different evidence)" trace), so the evidence is what pins it
+-- down.  Cheap by construction: "renderEvidence" refers to kid dictionaries
+-- by slot and to types by marker, so the only name-dependent input is the kid
+-- list -- and lifting is bottom-up, so kids are already named.  This hashes
+-- one flat record per dictionary rather than walking the evidence DAG;
+-- walking it as a tree is what made an earlier attempt two orders of
+-- magnitude slower (testsuite/bsc.misc/perf-liftdicts-blowup).
+--
+-- A kid without evidence (incoherent) keeps a counter name, so a parent above
+-- one inherits its instability.  That is as stable as such a dictionary can
+-- be: an incoherent resolution is not a function of its evidence alone.
+evidenceBase :: CType -> (String, [Id], [IType]) -> String
+evidenceBase t (str, kids, tys) =
+    dictBaseName t (unlines (str : map getIdBaseString kids ++
+                             map ppString tys))
+
+-- Evidence yields a stable name; without it (an incoherent dictionary) fall
+-- back to the package-local counter.  The counter is also the escape hatch if
+-- a user definition has somehow claimed the hashed name.
+newDictId :: Position -> CType -> Maybe (String, [Id], [IType]) -> L a Id
+newDictId pos t mev = do
   mi <- gets packageName
   taken <- gets topLevelBases
-  -- skip any name a user definition already claims
-  let fresh k | getIdBase (enumId "lifted_dict" pos k) `S.member` taken = fresh (k + 1)
-              | otherwise = k
-      n' = fresh n
-  modify (\s -> s { dictNo = n' + 1 })
-  return $ qualId mi $ addIdProps (enumId "lifted_dict" pos n') [IdPDict, IdPCAF]
+  -- setBadId as enumId does: isBadId marks a name the user did not write, and
+  -- AConv, SimCCBlock and the instance-hierarchy walks all key on it to keep
+  -- these out of Bluesim symbols and bluetcl's hierarchy.
+  let mk base = qualId mi $ addIdProps (setBadId (mkId pos (mkFString base)))
+                                       [IdPDict, IdPCAF]
+  case mev of
+    Just ev | let base = evidenceBase t ev,
+              not (mkFString base `S.member` taken)
+            -> return (mk base)
+    _ -> do
+      n <- gets dictNo
+      -- skip any name a user definition already claims
+      let fresh k | getIdBase (enumId "lifted_dict" pos k) `S.member` taken
+                      = fresh (k + 1)
+                  | otherwise = k
+          n' = fresh n
+      modify (\s -> s { dictNo = n' + 1 })
+      return $ qualId mi $
+          addIdProps (enumId "lifted_dict" pos n') [IdPDict, IdPCAF]
 
 isIncoherentDict :: Id -> Bool
 isIncoherentDict i = isDictId i && hasIdProp i IdPIncoherent
@@ -407,16 +443,13 @@ handleDict incoherent p t e = do
           [] -> do
             when (trace_lift_dicts && not (null cands)) $ traceM $
                 "dictPool type collision (different evidence): " ++ ppReadable t
-            lift_i0 <- newDictId (getPosition e)
-            let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
-                         else lift_i0
-            when trace_lift_dicts $ traceM $
-                "adding lifted dict: " ++ ppReadable (lift_i, e')
             s0 <- get
             -- The evidence identity for cross-package deduplication (see
             -- "renderEvidence"), recorded at mint time.  An incoherent
             -- resolution depends on the instances visible HERE, so it
             -- never gets one.
+            --
+            -- Computed before the name, because the name is derived from it.
             let mev = if incoherent then Nothing
                       else renderEvidence (flags s0) (symt s0) e'
                 props = case mev of
@@ -424,6 +457,11 @@ handleDict incoherent p t e = do
                           Just (str, kids, tys) -> [ DefP_DictRendering str,
                                                      DefP_DictKids kids,
                                                      DefP_DictTypes tys ]
+            lift_i0 <- newDictId (getPosition e) t mev
+            let lift_i = if incoherent then addIdProp lift_i0 IdPIncoherent
+                         else lift_i0
+            when trace_lift_dicts $ traceM $
+                "adding lifted dict: " ++ ppReadable (lift_i, e')
             when (trace_lift_dicts && not incoherent && null props) $ traceM $
                 "no evidence rendering (not cross-package dedupable): "
                 ++ ppReadable (lift_i, e')

--- a/src/comp/LiftDicts.hs
+++ b/src/comp/LiftDicts.hs
@@ -12,7 +12,7 @@ import Error(ErrorHandle)
 import ErrorUtil(internalError)
 import Flags(Flags)
 import IOUtil(progArgs)
-import Util(mapSndM, itos)
+import Util(mapSndM, itos, hashString)
 
 import CSyntax
 import FStringCompat(FString, mkFString)
@@ -261,8 +261,8 @@ getTopNameInfo i = do
 -- be: an incoherent resolution is not a function of its evidence alone.
 evidenceBase :: CType -> (String, [Id], [IType]) -> String
 evidenceBase t (str, kids, tys) =
-    dictBaseName t (unlines (str : map getIdBaseString kids ++
-                             map ppString tys))
+    dictBaseName t (hashString (unlines (str : map getIdBaseString kids ++
+                                         map ppString tys)))
 
 -- Evidence yields a stable name; without it (an incoherent dictionary) fall
 -- back to the package-local counter.  The counter is also the escape hatch if

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -15,10 +15,7 @@ import Prelude hiding ((<>))
 #endif
 
 import Data.List(union, genericSplitAt, genericLength, intersperse)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.ByteString as B
-import Util(hashInit, nextHashByte, showHash)
+import Util(hashString, showHash)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -244,31 +241,45 @@ instance PVPrint Inst where
 
 -----------------------------------------------------------------------------
 
--- The base name for a lifted dictionary: its type, flattened the way mkInstId
--- flattens an instance head, plus a hash of a discriminator.
+-- The base name for a lifted dictionary: its rendered type plus a hash of a
+-- discriminator.
 --
 -- Content-derived rather than counter-derived, so that adding an unrelated
 -- definition to a package does not renumber its dictionaries and move the
 -- bytes of every artifact that references them.  Readable, because these
 -- names reach the user in typechecker output and in dumped IR.
 --
--- The discriminator is hashed in unconditionally rather than only to break
--- ties: a tie-break would depend on what else the package happens to contain,
--- which is the positional instability this exists to remove.  Callers pass
--- whatever pins the dictionary down beyond its type -- its evidence rendering
--- where the type does not determine it, the type itself where it does.
+-- Callers pass whatever pins the dictionary down beyond its type: its evidence
+-- rendering where the type does not determine it (LiftDicts, where two
+-- dictionaries can share a type and differ in evidence); a pool keyed on the
+-- ground type alone would pass the type itself.
+--
+-- The discriminator is hashed in unconditionally, never only to break a tie.
+-- A tie-break would make the name depend on what else the package happens to
+-- contain, which is exactly the positional instability this exists to remove
+-- -- and it would do so intermittently, which is worse to diagnose than the
+-- systematic version.  The rendering below is therefore for readability only;
+-- distinctness rests on the hash, so nobody has to re-prove the rendering
+-- injective when type normalisation changes.
 dictBaseName :: Type -> String -> String
 dictBaseName t disc =
-    "_dict_" ++ typePart ++ "_" ++
-    showHash (B.foldl' nextHashByte hashInit (TE.encodeUtf8 (T.pack disc)))
-  where typePart = concat $ intersperse "~" $ map getIdBaseString $
-                       flat (expandSyn t)
-        flat (TAp t1 t2)          = flat t1 ++ flat t2
-        flat (TVar (TyVar i _ _)) = [i]
-        flat (TCon (TyCon i _ _)) = [i]
-        flat (TCon (TyNum n _))   = [mkNumId n]
-        flat (TCon (TyStr s _))   = [mkStrId s]
-        flat _                    = []
+    "_dict_" ++ render (expandSyn t) ++ "_" ++ showHash (hashString disc)
+  where
+    -- Structure-preserving, unlike mkInstId's flattening: a nested
+    -- application is bracketed, so C (D E) F does not read as C D (E F).
+    render ty = case spine ty [] of
+                  (h, [])   -> leaf h
+                  (h, args) -> concat $ intersperse "~" (leaf h : map arg args)
+    arg a = case spine a [] of
+              (h, []) -> leaf h
+              _       -> "(" ++ render a ++ ")"
+    spine (TAp f x) acc = spine f (x:acc)
+    spine h acc         = (h, acc)
+    leaf (TVar (TyVar i _ _)) = getIdBaseString i
+    leaf (TCon (TyCon i _ _)) = getIdBaseString i
+    leaf (TCon (TyNum n _))   = getIdBaseString (mkNumId n)
+    leaf (TCon (TyStr s _))   = getIdBaseString (mkStrId s)
+    leaf _                    = "_"
 
 expandSyn :: Type -> Type
 expandSyn t0 = exp [] f as

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -4,7 +4,7 @@ module Pred(
             Qual(..), PredWithPositions(..), Pred(..), Class(..), Inst(..),
             removePredPositions, getPredPositions, addPredPositions, mkPredWithPositions,
             expandSyn, predToType, qualToType, mkInst,
-            dictBaseName,
+            dictBaseName, hashType,
             Instantiate(..),
             predToCPred, qualTypeToCQType,
             pureInputPositions,
@@ -15,7 +15,8 @@ import Prelude hiding ((<>))
 #endif
 
 import Data.List(union, genericSplitAt, genericLength, intersperse)
-import Util(hashString, showHash)
+import Util(Hash, hashInit, nextHashByte, nextHashString, showHash)
+import FStringCompat(getFString)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -261,19 +262,51 @@ instance PVPrint Inst where
 -- systematic version.  The rendering below is therefore for readability only;
 -- distinctness rests on the hash, so nobody has to re-prove the rendering
 -- injective when type normalisation changes.
-dictBaseName :: Type -> String -> String
+dictBaseName :: Type -> Hash -> String
 dictBaseName t disc =
-    "_dict_" ++ dictRender (expandSyn t) ("_" ++ showHash (hashString disc))
+    "_dict_" ++ dictRender (expandSyn t) ("_" ++ showHash disc)
+
+-- Hash a type by walking its structure, without rendering it.
+--
+-- The discriminator has only to be a deterministic, collision-resistant
+-- function of the type -- it is never read back.  Producing one by
+-- pretty-printing built a Doc and laid it out, which measured at 64% of
+-- IsaR2Tile's compile once the readable rendering itself was memoized: all
+-- of it to make a string that is hashed and immediately discarded.
+--
+-- A constructor tag per node keeps this at least as discriminating as the
+-- printed form, because the application SHAPE is in the tags: C (D E) and
+-- C D E fold differently even though their leaves agree.  Qualified names,
+-- so two classes of the same base name in different packages cannot
+-- collide -- pPrint showed the base name and relied on the shape around it.
+--
+-- Positions are excluded deliberately: they are not stable across builds
+-- and a dictionary name must be (that is what this whole scheme exists
+-- for).  Kinds and sorts are excluded because the printed form did not
+-- carry them either; adding them could only split a name, never merge two.
+hashType :: Type -> Hash
+hashType = go hashInit
+  where
+    go h (TAp f a)             = go (go (nextHashByte h 1) f) a
+    go h (TCon c)              = tycon (nextHashByte h 2) c
+    go h (TVar (TyVar i _ _))  = nextHashString (nextHashByte h 3) (getIdString i)
+    go h (TGen _ n)            = nextHashString (nextHashByte h 4) (show n)
+    go h (TDefMonad _)         = nextHashByte h 5
+    tycon h (TyCon i _ _)      = nextHashString h (getIdString i)
+    tycon h (TyNum n _)        = nextHashString h (show n)
+    tycon h (TyStr s _)        = nextHashString h (getFString s)
 
 -- Structure-preserving, unlike mkInstId's flattening: a nested application is
 -- bracketed, so C (D E) F does not read as C D (E F).
 --
--- A ShowS rather than a String.  Concatenating at every level of nesting is
--- quadratic in depth, and dictionary types nest deeply enough for that to
--- dominate: on IsaR2Tile the old rendering was 67% of the compile and its
--- longest single render is 53KB.  Difference lists make it linear and let a
--- parent refer to its children instead of copying them; only dictBaseName
--- flattens, once, straight onto the hash suffix.
+-- A ShowS, not a String, and that is the larger half of the fix: concatenating
+-- at every level of nesting is quadratic in depth, and these types nest deeply
+-- enough that the old rendering was 67% of IsaR2Tile's compile.  Difference
+-- lists make it linear, let a parent refer to its children instead of copying
+-- them, and leave only dictBaseName to flatten -- once, straight onto the hash
+-- suffix.  Caching flat strings instead costs 2.1x peak residency for the same
+-- speed, because every nested rendering is then duplicated at every level
+-- above it.
 dictRender :: Type -> ShowS
 dictRender ty = case dictSpine ty [] of
                   (h, [])   -> dictLeaf h
@@ -281,6 +314,10 @@ dictRender ty = case dictSpine ty [] of
                                  intersperse (showChar '~')
                                              (dictLeaf h : map dictArg args)
 
+-- A bare leaf renders straight, bypassing the memo: routing leaves through it
+-- too measures identical (19.49s vs 19.52s over three rounds, 4MB of 55GB,
+-- same residency), the lookup costing about what rebuilding a leaf saves.
+-- Bypassing keeps the table smaller for no loss.
 dictArg :: Type -> ShowS
 dictArg a = case dictSpine a [] of
               (h, []) -> dictLeaf h

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -4,6 +4,7 @@ module Pred(
             Qual(..), PredWithPositions(..), Pred(..), Class(..), Inst(..),
             removePredPositions, getPredPositions, addPredPositions, mkPredWithPositions,
             expandSyn, predToType, qualToType, mkInst,
+            dictBaseName,
             Instantiate(..),
             predToCPred, qualTypeToCQType,
             pureInputPositions,
@@ -13,7 +14,11 @@ module Pred(
 import Prelude hiding ((<>))
 #endif
 
-import Data.List(union, genericSplitAt, genericLength)
+import Data.List(union, genericSplitAt, genericLength, intersperse)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.ByteString as B
+import Util(hashInit, nextHashByte, showHash)
 import Eval
 import Error(ErrMsg(..), internalError, bsErrorReallyUnsafe)
 import Position
@@ -238,6 +243,32 @@ instance PVPrint Inst where
     pvPrint d p (Inst e _ qp pkg) = text "(Inst" <+> pvPrint d 10 e <+> pvPrint d 10 qp <+> pvPrint d 10 pkg <> text ")"
 
 -----------------------------------------------------------------------------
+
+-- The base name for a lifted dictionary: its type, flattened the way mkInstId
+-- flattens an instance head, plus a hash of a discriminator.
+--
+-- Content-derived rather than counter-derived, so that adding an unrelated
+-- definition to a package does not renumber its dictionaries and move the
+-- bytes of every artifact that references them.  Readable, because these
+-- names reach the user in typechecker output and in dumped IR.
+--
+-- The discriminator is hashed in unconditionally rather than only to break
+-- ties: a tie-break would depend on what else the package happens to contain,
+-- which is the positional instability this exists to remove.  Callers pass
+-- whatever pins the dictionary down beyond its type -- its evidence rendering
+-- where the type does not determine it, the type itself where it does.
+dictBaseName :: Type -> String -> String
+dictBaseName t disc =
+    "_dict_" ++ typePart ++ "_" ++
+    showHash (B.foldl' nextHashByte hashInit (TE.encodeUtf8 (T.pack disc)))
+  where typePart = concat $ intersperse "~" $ map getIdBaseString $
+                       flat (expandSyn t)
+        flat (TAp t1 t2)          = flat t1 ++ flat t2
+        flat (TVar (TyVar i _ _)) = [i]
+        flat (TCon (TyCon i _ _)) = [i]
+        flat (TCon (TyNum n _))   = [mkNumId n]
+        flat (TCon (TyStr s _))   = [mkStrId s]
+        flat _                    = []
 
 expandSyn :: Type -> Type
 expandSyn t0 = exp [] f as

--- a/src/comp/Pred.hs
+++ b/src/comp/Pred.hs
@@ -263,23 +263,39 @@ instance PVPrint Inst where
 -- injective when type normalisation changes.
 dictBaseName :: Type -> String -> String
 dictBaseName t disc =
-    "_dict_" ++ render (expandSyn t) ++ "_" ++ showHash (hashString disc)
-  where
-    -- Structure-preserving, unlike mkInstId's flattening: a nested
-    -- application is bracketed, so C (D E) F does not read as C D (E F).
-    render ty = case spine ty [] of
-                  (h, [])   -> leaf h
-                  (h, args) -> concat $ intersperse "~" (leaf h : map arg args)
-    arg a = case spine a [] of
-              (h, []) -> leaf h
-              _       -> "(" ++ render a ++ ")"
-    spine (TAp f x) acc = spine f (x:acc)
-    spine h acc         = (h, acc)
-    leaf (TVar (TyVar i _ _)) = getIdBaseString i
-    leaf (TCon (TyCon i _ _)) = getIdBaseString i
-    leaf (TCon (TyNum n _))   = getIdBaseString (mkNumId n)
-    leaf (TCon (TyStr s _))   = getIdBaseString (mkStrId s)
-    leaf _                    = "_"
+    "_dict_" ++ dictRender (expandSyn t) ("_" ++ showHash (hashString disc))
+
+-- Structure-preserving, unlike mkInstId's flattening: a nested application is
+-- bracketed, so C (D E) F does not read as C D (E F).
+--
+-- A ShowS rather than a String.  Concatenating at every level of nesting is
+-- quadratic in depth, and dictionary types nest deeply enough for that to
+-- dominate: on IsaR2Tile the old rendering was 67% of the compile and its
+-- longest single render is 53KB.  Difference lists make it linear and let a
+-- parent refer to its children instead of copying them; only dictBaseName
+-- flattens, once, straight onto the hash suffix.
+dictRender :: Type -> ShowS
+dictRender ty = case dictSpine ty [] of
+                  (h, [])   -> dictLeaf h
+                  (h, args) -> foldr (.) id $
+                                 intersperse (showChar '~')
+                                             (dictLeaf h : map dictArg args)
+
+dictArg :: Type -> ShowS
+dictArg a = case dictSpine a [] of
+              (h, []) -> dictLeaf h
+              _       -> showChar '(' . dictRender a . showChar ')'
+
+dictSpine :: Type -> [Type] -> (Type, [Type])
+dictSpine (TAp f x) acc = dictSpine f (x:acc)
+dictSpine h acc         = (h, acc)
+
+dictLeaf :: Type -> ShowS
+dictLeaf (TVar (TyVar i _ _)) = showString (getIdBaseString i)
+dictLeaf (TCon (TyCon i _ _)) = showString (getIdBaseString i)
+dictLeaf (TCon (TyNum n _))   = showString (getIdBaseString (mkNumId n))
+dictLeaf (TCon (TyStr s _))   = showString (getIdBaseString (mkStrId s))
+dictLeaf _                    = showString "_"
 
 expandSyn :: Type -> Type
 expandSyn t0 = exp [] f as

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -641,7 +641,14 @@ hashBytesL :: BL.ByteString -> Hash
 hashBytesL = BL.foldl' nextHashByte hashInit
 
 hashString :: String -> Hash
-hashString = hashBytes . TE.encodeUtf8 . T.pack
+hashString = nextHashString hashInit
+
+-- Continue a fold with a string's bytes.  A caller hashing a STRUCTURE
+-- interleaves literal text with its own tags, and must not have to
+-- concatenate the text first -- that is the cost such a caller exists to
+-- avoid (see Pred.hashType).
+nextHashString :: Hash -> String -> Hash
+nextHashString h s = B.foldl' nextHashByte h (TE.encodeUtf8 (T.pack s))
 
 -- For diagnostics and user-visible output.  Not the storage form: prefer the
 -- Hash itself, which is 8 bytes and cannot be malformed.

--- a/src/comp/Util.hs
+++ b/src/comp/Util.hs
@@ -10,6 +10,10 @@ import Control.Monad(foldM)
 import Debug.Trace(trace)
 import qualified Data.Set as S
 import qualified Data.Map as M
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 -- import Numeric(showHex)
 
 import ErrorUtil(internalError)
@@ -604,7 +608,12 @@ isWhitespace _ = False
 -- A computational simple hash
 -- 4000000063 and 1442968193 are large primes that fit in 32 bits
 
+-- Eq/Ord so a hash can be stored and compared as itself.  Without them the
+-- only comparable form was showHash's decimal rendering, which is why every
+-- caller escaped to String immediately and why hashes are stored as ~21 bytes
+-- of text where 8 would do.
 data Hash = Hash !Word32 !Word32
+  deriving (Eq, Ord)
 
 hashInit :: Hash
 hashInit = Hash 0 4000000063
@@ -620,5 +629,21 @@ nextHashByte (Hash x y) c =
 hashValue :: Hash -> Word64
 hashValue (Hash x y) = ((fromIntegral x) `shiftL` 32) .|. (fromIntegral y)
 
+-- Every caller wants exactly one of these folds; hand-rolling them per call
+-- site is how the codebase ended up with the same expression in five places.
+-- One home also means one place to change if 64 bits proves too narrow --
+-- these now name lifted dictionaries, where a collision is two different
+-- dictionaries sharing an identity.
+hashBytes :: B.ByteString -> Hash
+hashBytes = B.foldl' nextHashByte hashInit
+
+hashBytesL :: BL.ByteString -> Hash
+hashBytesL = BL.foldl' nextHashByte hashInit
+
+hashString :: String -> Hash
+hashString = hashBytes . TE.encodeUtf8 . T.pack
+
+-- For diagnostics and user-visible output.  Not the storage form: prefer the
+-- Hash itself, which is 8 bytes and cannot be malformed.
 showHash :: Hash -> String
 showHash h = show (hashValue h)

--- a/testsuite/bsc.bluesim/interactive/mkTop_glob.out.expected
+++ b/testsuite/bsc.bluesim/interactive/mkTop_glob.out.expected
@@ -1,5 +1,5 @@
 *
-{CAN_FIRE_RL_done signal} {CAN_FIRE_RL_incr signal} {count {module with value}} {count__h141 signal} {level1 module} {mid1 module} {mid2 module} {RL_done rule} {RL_incr rule} {WILL_FIRE_RL_done signal} {WILL_FIRE_RL_incr signal}
+{CAN_FIRE_RL_done signal} {CAN_FIRE_RL_incr signal} {count {module with value}} {count__h133 signal} {level1 module} {mid1 module} {mid2 module} {RL_done rule} {RL_incr rule} {WILL_FIRE_RL_done signal} {WILL_FIRE_RL_incr signal}
 -------
 mid?.CAN_FIRE_*
 {mid1.CAN_FIRE_RL_incr signal} {mid1.CAN_FIRE_RL_sub1_flip signal} {mid1.CAN_FIRE_RL_wrap signal} {mid2.CAN_FIRE_RL_incr signal} {mid2.CAN_FIRE_RL_sub1_flip signal} {mid2.CAN_FIRE_RL_wrap signal}
@@ -17,13 +17,13 @@ mid[0-9].*
 {mid1.CAN_FIRE_RL_incr signal} {mid1.CAN_FIRE_RL_sub1_flip signal} {mid1.CAN_FIRE_RL_wrap signal} {mid1.count {module with value}} {mid1.count__h163 signal} {mid1.limit signal} {mid1.RL_incr rule} {mid1.RL_sub1_flip rule} {mid1.RL_wrap rule} {mid1.sub1_x {module with value}} {mid1.WILL_FIRE_RL_incr signal} {mid1.WILL_FIRE_RL_sub1_flip signal} {mid1.WILL_FIRE_RL_wrap signal} {mid2.CAN_FIRE_RL_incr signal} {mid2.CAN_FIRE_RL_sub1_flip signal} {mid2.CAN_FIRE_RL_wrap signal} {mid2.count {module with value}} {mid2.count__h163 signal} {mid2.limit signal} {mid2.RL_incr rule} {mid2.RL_sub1_flip rule} {mid2.RL_wrap rule} {mid2.sub1_x {module with value}} {mid2.WILL_FIRE_RL_incr signal} {mid2.WILL_FIRE_RL_sub1_flip signal} {mid2.WILL_FIRE_RL_wrap signal}
 -------
 *1
-{count__h141 signal} {level1 module} {mid1 module}
+{level1 module} {mid1 module}
 -------
 m*[12].RL_*
 {mid1.RL_incr rule} {mid1.RL_sub1_flip rule} {mid1.RL_wrap rule} {mid2.RL_incr rule} {mid2.RL_sub1_flip rule} {mid2.RL_wrap rule}
 -------
 ?[!ie]*
-{CAN_FIRE_RL_done signal} {CAN_FIRE_RL_incr signal} {count {module with value}} {count__h141 signal} {RL_done rule} {RL_incr rule} {WILL_FIRE_RL_done signal} {WILL_FIRE_RL_incr signal}
+{CAN_FIRE_RL_done signal} {CAN_FIRE_RL_incr signal} {count {module with value}} {count__h133 signal} {RL_done rule} {RL_incr rule} {WILL_FIRE_RL_done signal} {WILL_FIRE_RL_incr signal}
 -------
 *FIRE_RL_?[]a-zA-Z]*[-npw-z]*
 {CAN_FIRE_RL_done signal} {WILL_FIRE_RL_done signal}

--- a/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
@@ -36,14 +36,17 @@ next def..........................................................
 DummyInDeflQual._lifted_dict0 :: Prelude.Literal (Prelude.Bit 12)
 DummyInDeflQual._lifted_dict0 = Prelude.Prelude.Literal~Prelude.Bit~n= ·12
 -- IdProp: DummyInDeflQual::_lifted_dict0[IdP_bad_name,IdPDict,IdPCAF]
+-- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 12]]
 next def..........................................................
 DummyInDeflQual._lifted_dict1 :: Prelude.Literal (Prelude.Bit 2)
 DummyInDeflQual._lifted_dict1 = Prelude.Prelude.Literal~Prelude.Bit~n= ·2
 -- IdProp: DummyInDeflQual::_lifted_dict1[IdP_bad_name,IdPDict,IdPCAF]
+-- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
 DummyInDeflQual._lifted_dict2 :: Prelude.Eq (Prelude.Bit 2)
 DummyInDeflQual._lifted_dict2 = Prelude.Prelude.Eq~Prelude.Bit~n= ·2
 -- IdProp: DummyInDeflQual::_lifted_dict2[IdP_bad_name,IdPDict,IdPCAF]
+-- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B24:Prelude.Eq~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
 
 

--- a/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
@@ -26,33 +26,34 @@ DummyInDeflQual.dummyInDeflQual =
 	     ·1
 	     (.(Prelude.==)
 		·(Prelude.Bit 2)
-		DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559=
+		DummyInDeflQual._dict_Eq~(Bit~2)_15799318761694300559=
 		(PrimBuildUndefined ·(Prelude.Bit 2) _ 1)
 		(.Prelude.fromInteger
 		   ·(Prelude.Bit 2)
-		   DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491=
+		   DummyInDeflQual._dict_Literal~(Bit~2)_17327480572033035491=
 		   0b11)))
 	  (.Prelude.fromInteger ·_tctyvar1063 _tcdict1050 0)
 	  (PrimBuildUndefined ·_tctyvar1063 (PrimGetEvalPosition ·_tctyvar1064 x) 2)
   in  f ·(Prelude.Bit 12)
 	·Prelude.Bool
-	DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032=
+	DummyInDeflQual._dict_Literal~(Bit~12)_16246552260886297032=
 	(Prelude.True Prelude.PrimUnit)
 next def..........................................................
-DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032 :: Prelude.Literal (Prelude.Bit 12)
-DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032 =
+DummyInDeflQual._dict_Literal~(Bit~12)_16246552260886297032 :: Prelude.Literal (Prelude.Bit 12)
+DummyInDeflQual._dict_Literal~(Bit~12)_16246552260886297032 =
   Prelude.Prelude.Literal~Prelude.Bit~n= ·12
--- IdProp: DummyInDeflQual::_dict_Literal~Bit~12_16246552260886297032[IdP_bad_name,IdPDict,IdPCAF]
+-- IdProp: DummyInDeflQual::_dict_Literal~(Bit~12)_16246552260886297032[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 12]]
 next def..........................................................
-DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491 :: Prelude.Literal (Prelude.Bit 2)
-DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491 = Prelude.Prelude.Literal~Prelude.Bit~n= ·2
--- IdProp: DummyInDeflQual::_dict_Literal~Bit~2_17327480572033035491[IdP_bad_name,IdPDict,IdPCAF]
+DummyInDeflQual._dict_Literal~(Bit~2)_17327480572033035491 :: Prelude.Literal (Prelude.Bit 2)
+DummyInDeflQual._dict_Literal~(Bit~2)_17327480572033035491 =
+  Prelude.Prelude.Literal~Prelude.Bit~n= ·2
+-- IdProp: DummyInDeflQual::_dict_Literal~(Bit~2)_17327480572033035491[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
-DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559 :: Prelude.Eq (Prelude.Bit 2)
-DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559 = Prelude.Prelude.Eq~Prelude.Bit~n= ·2
--- IdProp: DummyInDeflQual::_dict_Eq~Bit~2_15799318761694300559[IdP_bad_name,IdPDict,IdPCAF]
+DummyInDeflQual._dict_Eq~(Bit~2)_15799318761694300559 :: Prelude.Eq (Prelude.Bit 2)
+DummyInDeflQual._dict_Eq~(Bit~2)_15799318761694300559 = Prelude.Prelude.Eq~Prelude.Bit~n= ·2
+-- IdProp: DummyInDeflQual::_dict_Eq~(Bit~2)_15799318761694300559[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B24:Prelude.Eq~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
 

--- a/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/dontcare/DummyInDeflQual.bs.bsc-out.expected
@@ -26,26 +26,33 @@ DummyInDeflQual.dummyInDeflQual =
 	     ·1
 	     (.(Prelude.==)
 		·(Prelude.Bit 2)
-		DummyInDeflQual._lifted_dict2=
+		DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559=
 		(PrimBuildUndefined ·(Prelude.Bit 2) _ 1)
-		(.Prelude.fromInteger ·(Prelude.Bit 2) DummyInDeflQual._lifted_dict1= 0b11)))
+		(.Prelude.fromInteger
+		   ·(Prelude.Bit 2)
+		   DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491=
+		   0b11)))
 	  (.Prelude.fromInteger ·_tctyvar1063 _tcdict1050 0)
 	  (PrimBuildUndefined ·_tctyvar1063 (PrimGetEvalPosition ·_tctyvar1064 x) 2)
-  in  f ·(Prelude.Bit 12) ·Prelude.Bool DummyInDeflQual._lifted_dict0= (Prelude.True Prelude.PrimUnit)
+  in  f ·(Prelude.Bit 12)
+	·Prelude.Bool
+	DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032=
+	(Prelude.True Prelude.PrimUnit)
 next def..........................................................
-DummyInDeflQual._lifted_dict0 :: Prelude.Literal (Prelude.Bit 12)
-DummyInDeflQual._lifted_dict0 = Prelude.Prelude.Literal~Prelude.Bit~n= ·12
--- IdProp: DummyInDeflQual::_lifted_dict0[IdP_bad_name,IdPDict,IdPCAF]
+DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032 :: Prelude.Literal (Prelude.Bit 12)
+DummyInDeflQual._dict_Literal~Bit~12_16246552260886297032 =
+  Prelude.Prelude.Literal~Prelude.Bit~n= ·12
+-- IdProp: DummyInDeflQual::_dict_Literal~Bit~12_16246552260886297032[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 12]]
 next def..........................................................
-DummyInDeflQual._lifted_dict1 :: Prelude.Literal (Prelude.Bit 2)
-DummyInDeflQual._lifted_dict1 = Prelude.Prelude.Literal~Prelude.Bit~n= ·2
--- IdProp: DummyInDeflQual::_lifted_dict1[IdP_bad_name,IdPDict,IdPCAF]
+DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491 :: Prelude.Literal (Prelude.Bit 2)
+DummyInDeflQual._dict_Literal~Bit~2_17327480572033035491 = Prelude.Prelude.Literal~Prelude.Bit~n= ·2
+-- IdProp: DummyInDeflQual::_dict_Literal~Bit~2_17327480572033035491[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
-DummyInDeflQual._lifted_dict2 :: Prelude.Eq (Prelude.Bit 2)
-DummyInDeflQual._lifted_dict2 = Prelude.Prelude.Eq~Prelude.Bit~n= ·2
--- IdProp: DummyInDeflQual::_lifted_dict2[IdP_bad_name,IdPDict,IdPCAF]
+DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559 :: Prelude.Eq (Prelude.Bit 2)
+DummyInDeflQual._dict_Eq~Bit~2_15799318761694300559 = Prelude.Prelude.Eq~Prelude.Bit~n= ·2
+-- IdProp: DummyInDeflQual::_dict_Eq~Bit~2_15799318761694300559[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B24:Prelude.Eq~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 2]]
 next def..........................................................
 

--- a/testsuite/bsc.typechecker/typeclasses/ContextOnClassSubset.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ContextOnClassSubset.bs.bsc-out.expected
@@ -17,13 +17,13 @@ ContextOnClassSubset.ContextOnClassSubset.Foo~Prelude.Bit~32~Prelude.Bit~16~Prel
 	·(Prelude.Bit 16)
 	·(Prelude.Bit 8)
 	_bar
-	ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232=
+	ContextOnClassSubset._dict_Literal~(Bit~16)_16246552827821980232=
 -- IdProp: ContextOnClassSubset::ContextOnClassSubset.Foo~Prelude.Bit~32~Prelude.Bit~16~Prelude.Bit~8[IdPDict]
 next def..........................................................
-ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232 :: Prelude.Literal (Prelude.Bit 16)
-ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232 =
+ContextOnClassSubset._dict_Literal~(Bit~16)_16246552827821980232 :: Prelude.Literal (Prelude.Bit 16)
+ContextOnClassSubset._dict_Literal~(Bit~16)_16246552827821980232 =
   Prelude.Prelude.Literal~Prelude.Bit~n= ·16
--- IdProp: ContextOnClassSubset::_dict_Literal~Bit~16_16246552827821980232[IdP_bad_name,IdPDict,IdPCAF]
+-- IdProp: ContextOnClassSubset::_dict_Literal~(Bit~16)_16246552827821980232[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 16]]
 next def..........................................................
 

--- a/testsuite/bsc.typechecker/typeclasses/ContextOnClassSubset.bs.bsc-out.expected
+++ b/testsuite/bsc.typechecker/typeclasses/ContextOnClassSubset.bs.bsc-out.expected
@@ -17,12 +17,13 @@ ContextOnClassSubset.ContextOnClassSubset.Foo~Prelude.Bit~32~Prelude.Bit~16~Prel
 	·(Prelude.Bit 16)
 	·(Prelude.Bit 8)
 	_bar
-	ContextOnClassSubset._lifted_dict0=
+	ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232=
 -- IdProp: ContextOnClassSubset::ContextOnClassSubset.Foo~Prelude.Bit~32~Prelude.Bit~16~Prelude.Bit~8[IdPDict]
 next def..........................................................
-ContextOnClassSubset._lifted_dict0 :: Prelude.Literal (Prelude.Bit 16)
-ContextOnClassSubset._lifted_dict0 = Prelude.Prelude.Literal~Prelude.Bit~n= ·16
--- IdProp: ContextOnClassSubset::_lifted_dict0[IdP_bad_name,IdPDict,IdPCAF]
+ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232 :: Prelude.Literal (Prelude.Bit 16)
+ContextOnClassSubset._dict_Literal~Bit~16_16246552827821980232 =
+  Prelude.Prelude.Literal~Prelude.Bit~n= ·16
+-- IdProp: ContextOnClassSubset::_dict_Literal~Bit~16_16246552827821980232[IdP_bad_name,IdPDict,IdPCAF]
 -- Properties: [DefP_DictRendering "P1(V(Q7:Prelude;B29:Prelude.Literal~Prelude.Bit~n;)T0;)",DefP_DictKids [],DefP_DictTypes [ITNum 16]]
 next def..........................................................
 


### PR DESCRIPTION
II-23 (af6b5353 minus pool hunks → 25cab56d Hash value type [this line is the second lander and carries it — verified absent from ser/1] → d837258e → 1a90c874 with its .bo tag, bsc-bo-20260804-2 — same cross-line tag note as above). GOLDEN HONESTY: the campaign's regolds for this material were never executed on this geometry and two classes were wrong (campaign tctyvar renumbering; hash digits that came from the EXCLUDED f2708cc0) — all goldens here were rebuilt from actual runs, and the tag-bump commit provably touches no goldens on this stack. Also fixes the inherited DummyInDeflQual staleness at the bottom. Builds; typeclasses 110/0, dontcare 25/0, liftdicts-wrapper 16/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt