### PR TITLE
Profiling: -fprof-auto exemptions for hot leaf modules

### DIFF
--- a/src/comp/BinData.hs
+++ b/src/comp/BinData.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE ScopedTypeVariables, BangPatterns #-}
 {-# LANGUAGE PatternSynonyms, OverloadedLists, TypeFamilies #-}
 {-# OPTIONS_GHC -Werror -fwarn-incomplete-patterns #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module BinData ( Byte
                , putBs, putB, putI
                , getN, getB, getI -- , getBytesRead

--- a/src/comp/ConTagInfo.hs
+++ b/src/comp/ConTagInfo.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module ConTagInfo(ConTagInfo(..)) where
 
 import Eval

--- a/src/comp/Eval.hs
+++ b/src/comp/Eval.hs
@@ -1,3 +1,7 @@
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Eval(NFData(..), deepseq,
             rnf2, rnf3, rnf4, rnf5, rnf6, rnf7, rnf8, rnf9,
             rnf10, rnf11, rnf12, rnf13, rnf14, rnf15, rnf16,

--- a/src/comp/FStringCompat.hs
+++ b/src/comp/FStringCompat.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module FStringCompat(FString, getFString,
                      tmpFString, cloneFString, concatFString,
                      mkNumFString, mkStrFString, mkFString,

--- a/src/comp/IType.hs
+++ b/src/comp/IType.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 
+-- profiling-only: the Eq/Ord instances funnel through cmpT, a tiny
+-- leaf comparison called at extreme frequency during elaboration; an
+-- SCC here blocks inlining of the instance wrappers (distorting
+-- -fprof-auto profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IType(
   IType(..)
   ,IKind(..)

--- a/src/comp/Id.hs
+++ b/src/comp/Id.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE FlexibleInstances, DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fwarn-name-shadowing -fwarn-missing-signatures #-}
 
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Id(
         Id,
         mkId,

--- a/src/comp/IntLit.hs
+++ b/src/comp/IntLit.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IntLit (IntLit(..),
                ilDec, ilSizedDec, ilHex, ilSizedHex, ilBin, ilSizedBin,
                showVeriIntLit, showSizedVeriIntLit

--- a/src/comp/Libs/IOMutVar.hs
+++ b/src/comp/Libs/IOMutVar.hs
@@ -1,3 +1,7 @@
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module IOMutVar(MutableVar, newVar, readVar, writeVar) where
 
 import Data.IORef

--- a/src/comp/Position.hs
+++ b/src/comp/Position.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Position where
 
 import Data.List(partition)

--- a/src/comp/Prim.hs
+++ b/src/comp/Prim.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Prim(
             PrimOp(..),
             toPrim,

--- a/src/comp/SpeedyString.hs
+++ b/src/comp/SpeedyString.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module SpeedyString(SString, toString, fromString, (++), concat, filter) where
 
 import Prelude hiding((++), concat, filter)

--- a/src/comp/Undefined.hs
+++ b/src/comp/Undefined.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Undefined (
                   UndefKind(..),
 

--- a/src/comp/Wires.hs
+++ b/src/comp/Wires.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+-- profiling-only: tiny leaf functions called at extreme frequency;
+-- an SCC here blocks their inlining (distorting -fprof-auto
+-- profiles) and their time belongs to callers
+{-# OPTIONS_GHC -fno-prof-auto #-}
 module Wires(ClockId, ClockDomain(..), ResetId,
              nextClockId, nextClockDomain, nextResetId,
              initClockId, initClockDomain, initResetId,


### PR DESCRIPTION
**What**: two profiling-attribution improvements (upstream-intent per Ravi: "useful improvements to profiling"):
1. Exempt 12 hot leaf modules (SpeedyString, Id, Position, Eval, Prim, ...) from `-fprof-auto` cost centres — their tiny hot functions otherwise dominate profiles as noise.
2. `-fno-prof-auto` on IType so profiles attribute time to real callers rather than the hand-written hot comparison (`cmpT`) and rnf leaves.

**Why**: `BSC_BUILD=PROF` profiles currently drown the signal in leaf-function cost centres; exempting the leaves makes caller attribution readable. Pragma-only change: 13 files, 53 insertions, zero code changes, no effect on release builds.

**Adaptation note**: on this base IType.hs has plain constructors (no pattern synonyms), so the exemption rationale is the hot `cmpT`/rnf leaves; commit body says so explicitly.

**Verification**: `install-src` exit 0; genuine `BSC_BUILD=PROF` build verified (227 modules with `-prof -fprof-auto`, banner present). No serialization impact; no tags.

**Provenance**: re-cut of MatX #62 (`9f6fd9c3`) + `31a9cfc4` from the iexpr branch; #62 closes in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt