### PR TITLE
IExpr: cache free-variable sets on nodes; prune eSubst

### DIFF
--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -500,6 +500,7 @@ traceflags = [
           "hack-disable-urgency-warnings",
           "hack-gate-clock-inputs",
           "hack-gate-default-clock",
+          "hack-no-iexpr-fv-cache",
           "hack-no-itype-ftv-cache",
           "hack-strict-inst-tree",
           "outlaw-sv-kws-as-classic-ids",

--- a/src/comp/ISimplify.hs
+++ b/src/comp/ISimplify.hs
@@ -92,6 +92,10 @@ data Occ = None | One | Many
 
 
 countOcc :: Id -> IExpr a -> Int
+-- the cached free-variable set answers the common "no occurrence at
+-- all" case without a walk (sound: every IVar occurrence the walk
+-- below can count is in the cached set)
+countOcc i e | efvCacheEnabled, not (i `vsMember` fVars e) = 0
 countOcc i e = countOcc' i e 0
 
 countOcc' :: Id -> IExpr a -> Int -> Int

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
 module ISyntax(
         IPackage(..),
         IDef(..),
         IKind(..),
         IType(ITVar, ITCon, ITNum, ITStr, ITAp, ITForAll),
-        IExpr(..),
+        IExpr(ILam, IAps, IVar, ILAM, ICon, IRefT),
         ConTagInfo(..),
         IConInfo(..),
         IRules(..),
@@ -49,6 +50,9 @@ module ISyntax(
         fVars,
         ftVars,
         aVars,
+        eFVarSet,
+        eFTVarSet,
+        efvCacheEnabled,
         mkNumConT,
         showTypeless,
         showTypelessRules,
@@ -90,6 +94,7 @@ import qualified Data.Array as Array
 import IntLit
 import Undefined
 import Eval
+import IOUtil(progArgs)
 import Id
 import Wires(ResetId, ClockDomain, ClockId, noClockId, noResetId, noDefaultClockId, noDefaultResetId, WireProps)
 import IdPrint
@@ -432,14 +437,197 @@ splitITAp t0 = go t0 []
 -- a is a placeholder type for the actual data stored in heap cells
 -- so that all things that work on generic IExprs do not touch the heap
 -- and to prevent exposing evaluator implementation details in ISyntax
+--
+-- Interior nodes cache their free value variables and free type
+-- variables (VarSets) in strict fields computed at construction, the
+-- same posture as the interned IType nodes: the real constructors
+-- ILam_/IAps_/ILAM_/ICon_ are private to this module and construction
+-- goes through smart constructors behind the bidirectional pattern
+-- synonyms below, so every other module reads and writes the six
+-- historical constructor names unchanged.  The fields are metadata
+-- only: they never serialize, never print, and never participate in
+-- comparison.
+--
+-- The cached sets are SUPERSETS of everything the substitution
+-- machinery (ISyntaxSubst) can reach below a node -- that is what
+-- makes prune-on-avoid sound at ancestor nodes -- and they are
+-- computed WITHOUT entering the fields substitution never enters
+-- (ICDef's iConDef, ICValue's iValDef, ICStateVar's IStateVar, array
+-- cells, held-coercion payloads).  The latter is a hard requirement,
+-- not a shortcut: those are exactly the fields through which IExpr
+-- structures are knot-tied (FixupDefs/IConv tie top-level defs through
+-- iConDef; clock and reset wires can be recursive through ICStateVar),
+-- so a set that recursed into them would not terminate.
+--
+-- IVar and IRefT stay uncached leaves: a variable answers its
+-- singleton directly, and a heap reference contributes nothing (the
+-- substitution machinery never enters IRefT -- see ISyntaxSubst).
 data IExpr a
-        = ILam Id IType (IExpr a)        -- vanishes after IExpand
-        | IAps (IExpr a) [IType] [IExpr a]
+        = ILam_ !VarSet !VarSet Id IType (IExpr a) -- vanishes after IExpand
+        | IAps_ !VarSet !VarSet (IExpr a) [IType] [IExpr a]
         | IVar Id                        -- vanishes after IExpand
-        | ILAM Id IKind (IExpr a)        -- vanishes after IExpand
-        | ICon Id (IConInfo a)
+        | ILAM_ !VarSet !VarSet Id IKind (IExpr a) -- vanishes after IExpand
+        | ICon_ !VarSet Id (IConInfo a)  -- free type vars only (see eFVarSet)
         -- IRef is only used during reduction, it refers to a "heap" cell
         | IRefT IType !Int (S.Set Position) a -- vanishes after IExpand
+
+pattern ILam :: Id -> IType -> IExpr a -> IExpr a
+pattern ILam i t e <- ILam_ _ _ i t e
+  where ILam i t e = mkILam i t e
+
+pattern IAps :: IExpr a -> [IType] -> [IExpr a] -> IExpr a
+pattern IAps f ts es <- IAps_ _ _ f ts es
+  where IAps f ts es = mkIAps f ts es
+
+pattern ILAM :: Id -> IKind -> IExpr a -> IExpr a
+pattern ILAM i k e <- ILAM_ _ _ i k e
+  where ILAM i k e = mkILAM i k e
+
+pattern ICon :: Id -> IConInfo a -> IExpr a
+pattern ICon i ic <- ICon_ _ i ic
+  where ICon i ic = mkICon i ic
+
+{-# COMPLETE ILam, IAps, IVar, ILAM, ICon, IRefT #-}
+
+-- The hidden flag -hack-no-iexpr-fv-cache (registered in
+-- FlagsDecode.traceflags like -hack-no-itype-ftv-cache) disables the
+-- IExpr free-variable cache and the eSubst pruning that consumes it:
+-- nodes store one shared empty set in the metadata fields and
+-- fVars/ftVars take the exact pre-cache code paths (full walks with
+-- the historical, narrower ICon/ILam semantics).  Absent the flag they
+-- are enabled (the default).  The switch lets the optimization be
+-- measured A/B on any workload with a single binary, and doubles as a
+-- diagnostic chicken switch.
+{-# NOINLINE efvCacheEnabled #-}
+efvCacheEnabled :: Bool
+efvCacheEnabled = not ("-hack-no-iexpr-fv-cache" `elem` progArgs)
+
+mkILam :: Id -> IType -> IExpr a -> IExpr a
+mkILam i t e = ILam_ fvs ftvs i t e
+  where fvs  | efvCacheEnabled = vsDelete i (eFVarSet e)
+             | otherwise       = vsEmpty
+        -- unlike the historical ftVars, the binder's type is included:
+        -- substitution rewrites it (ISyntaxSubst substitutes ILam
+        -- types), so pruning needs its variables counted
+        ftvs | efvCacheEnabled = fTVarSet t `vsUnion` eFTVarSet e
+             | otherwise       = vsEmpty
+
+mkIAps :: IExpr a -> [IType] -> [IExpr a] -> IExpr a
+mkIAps f ts es = IAps_ fvs ftvs f ts es
+  where fvs  | efvCacheEnabled = foldr (vsUnion . eFVarSet) (eFVarSet f) es
+             | otherwise       = vsEmpty
+        ftvs | efvCacheEnabled =
+                 foldr (vsUnion . eFTVarSet)
+                       (foldr (vsUnion . fTVarSet) (eFTVarSet f) ts)
+                       es
+             | otherwise       = vsEmpty
+
+mkILAM :: Id -> IKind -> IExpr a -> IExpr a
+mkILAM i k e = ILAM_ fvs ftvs i k e
+  where fvs  | efvCacheEnabled = eFVarSet e
+             | otherwise       = vsEmpty
+        ftvs | efvCacheEnabled = vsDelete i (eFTVarSet e)
+             | otherwise       = vsEmpty
+
+mkICon :: Id -> IConInfo a -> IExpr a
+mkICon i ic = ICon_ ftvs i ic
+  where ftvs | efvCacheEnabled = conFTVarSet ic
+             | otherwise       = vsEmpty
+
+-- The free type variables reachable by substitution below an ICon:
+-- every type position ISyntaxSubst.etSubstIConInfo rewrites and every
+-- expression it recurses into, nothing else.  In particular the
+-- constructors it leaves Unchanged (ICDef, ICValue) contribute
+-- nothing -- and must not be entered at all, since their payloads can
+-- be cyclic (knot-tied top-level defs, heap references).
+conFTVarSet :: IConInfo a -> VarSet
+conFTVarSet (ICDef {}) = vsEmpty
+conFTVarSet (ICValue {}) = vsEmpty
+-- iConType is always Bit 1 for clocks and resets; substitution
+-- recurses only into the wire expressions
+conFTVarSet (ICClock { iClock = c }) = eFTVarSet (ic_wires c)
+conFTVarSet (ICReset { iReset = r }) =
+    eFTVarSet (ic_wires (ir_clock r)) `vsUnion` eFTVarSet (ir_wire r)
+conFTVarSet ic@(ICInout { iInout = io }) =
+    fTVarSet (iConType ic) `vsUnion`
+    eFTVarSet (ic_wires (io_clock io)) `vsUnion`
+    eFTVarSet (ic_wires (ir_clock (io_reset io))) `vsUnion`
+    eFTVarSet (ir_wire (io_reset io)) `vsUnion`
+    eFTVarSet (io_wire io)
+conFTVarSet ic@(ICVerilog { vMethTs = tss }) =
+    foldr (vsUnion . fTVarSet) (fTVarSet (iConType ic)) (concat tss)
+-- iConType is always itType (no free variables), only iType matters
+conFTVarSet (ICType { iType = t }) = fTVarSet t
+conFTVarSet ic@(ICUndet { imVal = mv }) =
+    fTVarSet (iConType ic) `vsUnion` maybe vsEmpty eFTVarSet mv
+-- the array pointers are left alone by substitution; only the uninit
+-- expressions (and the con type) are rewritten
+conFTVarSet ic@(ICLazyArray { uninit = mu }) =
+    fTVarSet (iConType ic) `vsUnion`
+    maybe vsEmpty (\ (u1, u2) -> eFTVarSet u1 `vsUnion` eFTVarSet u2) mu
+conFTVarSet ic = fTVarSet (iConType ic)
+
+-- The free value variables reachable by substitution below an ICon.
+-- Not cached on the node (unlike the type variables): every arm is a
+-- bounded number of reads of the children's own cached sets, so a
+-- cached copy would buy nothing.
+conFVarSet :: IConInfo a -> VarSet
+conFVarSet (ICUndet { imVal = Just e }) = eFVarSet e
+conFVarSet (ICClock { iClock = c }) = eFVarSet (ic_wires c)
+conFVarSet (ICReset { iReset = r }) =
+    eFVarSet (ic_wires (ir_clock r)) `vsUnion` eFVarSet (ir_wire r)
+conFVarSet (ICInout { iInout = io }) =
+    eFVarSet (ic_wires (io_clock io)) `vsUnion`
+    eFVarSet (ic_wires (ir_clock (io_reset io))) `vsUnion`
+    eFVarSet (ir_wire (io_reset io)) `vsUnion`
+    eFVarSet (io_wire io)
+conFVarSet (ICLazyArray { uninit = Just (u1, u2) }) =
+    eFVarSet u1 `vsUnion` eFVarSet u2
+conFVarSet _ = vsEmpty
+
+-- Free value variables, answered from the cached fields (or from a
+-- one-level read for ICon).  When the cache is disabled the fields
+-- hold a shared dummy empty set, so this walks instead, with the exact
+-- historical semantics (ICon contributes only an ICUndet's imVal).
+eFVarSet :: IExpr a -> VarSet
+eFVarSet e0 | efvCacheEnabled = cached e0
+            | otherwise       = walk e0
+  where cached (ILam_ fvs _ _ _ _) = fvs
+        cached (IAps_ fvs _ _ _ _) = fvs
+        cached (ILAM_ fvs _ _ _ _) = fvs
+        cached (IVar i) = vsSingleton i
+        cached (ICon_ _ _ ic) = conFVarSet ic
+        cached (IRefT _ _ _ _) = vsEmpty
+        walk (ILam_ _ _ i _ e) = vsDelete i (walk e)
+        walk (IAps_ _ _ f _ es) = foldr (vsUnion . walk) (walk f) es
+        walk (ILAM_ _ _ _ _ e) = walk e
+        walk (IVar i) = vsSingleton i
+        walk (ICon_ _ _ (ICUndet {imVal = Just e})) = walk e
+        walk (ICon_ _ _ _) = vsEmpty
+        walk (IRefT _ _ _ _) = vsEmpty
+
+-- Free type variables, answered from the cached fields.  Same
+-- disabled-mode posture as eFVarSet: walk with the exact historical
+-- semantics (ILam types and ICon types not counted).
+eFTVarSet :: IExpr a -> VarSet
+eFTVarSet e0 | efvCacheEnabled = cached e0
+             | otherwise       = walk e0
+  where cached (ILam_ _ ftvs _ _ _) = ftvs
+        cached (IAps_ _ ftvs _ _ _) = ftvs
+        cached (ILAM_ _ ftvs _ _ _) = ftvs
+        cached (IVar _) = vsEmpty
+        cached (ICon_ ftvs _ _) = ftvs
+        cached (IRefT _ _ _ _) = vsEmpty
+        walk (ILam_ _ _ _ _ e) = walk e
+        walk (IAps_ _ _ f ts es) =
+            foldr (vsUnion . walk)
+                  (foldr (vsUnion . fTVarSet) (walk f) ts)
+                  es
+        walk (ILAM_ _ _ i _ e) = vsDelete i (walk e)
+        walk (IVar _) = vsEmpty
+        walk (ICon_ _ _ (ICUndet {imVal = Just e})) = walk e
+        walk (ICon_ _ _ _) = vsEmpty
+        walk (IRefT _ _ _ _) = vsEmpty
 
 instance Show (IExpr a) where
   show (ILam i t e)   = "(ILam " ++ show i ++ " " ++ show t ++ " " ++ show e ++ ")"
@@ -948,15 +1136,13 @@ aVars (IRefT _ _ _ _) = S.empty
 
 -- --------------------
 
--- Free variables
+-- Free variables (answered from the sets cached on the nodes; see the
+-- comment at the IExpr definition).  With the cache enabled this is
+-- slightly wider than the historical walk: clock/reset/inout wires and
+-- lazy-array uninit expressions are counted, matching what expression
+-- substitution can actually reach.
 fVars :: IExpr a -> S.Set Id
-fVars (ILam i _ e) = S.delete i (fVars e)
-fVars (IVar i) = S.singleton i
-fVars (ILAM _ _ e) = fVars e
-fVars (IAps f ts es) = fVars f `S.union` (S.unions (map fVars es))
-fVars (ICon _ (ICUndet {imVal = Just e})) = fVars e
-fVars (ICon _ _) = S.empty
-fVars (IRefT _ _ _ _) = S.empty
+fVars = eFVarSet
 
 -- --------------------
 
@@ -977,16 +1163,13 @@ fdVars' (IRefT _ _ _ _) = S.empty
 
 -- --------------------
 
--- Free type variables
+-- Free type variables (answered from the sets cached on the nodes; see
+-- the comment at the IExpr definition).  With the cache enabled this
+-- is wider than the historical walk, which ignored ILam binder types
+-- and all ICon types: every type position that type substitution can
+-- rewrite is counted.
 ftVars :: IExpr a -> S.Set Id
-ftVars (ILam i _ e) = ftVars e
-ftVars (IVar i) = S.empty
-ftVars (ILAM i _ e) = S.delete i (ftVars e)
-ftVars (IAps f ts es) = (ftVars f) `S.union` (S.unions (map fTVars ts))
-                                     `S.union` (S.unions (map ftVars es))
-ftVars (ICon _ (ICUndet {imVal = Just e})) = ftVars e
-ftVars (ICon _ _) = S.empty                -- XXX
-ftVars (IRefT _ _ _ _) = S.empty
+ftVars = eFTVarSet
 
 -- ============================================================
 -- PPrint (for those instances not defined alongside the type, above)

--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -463,11 +463,11 @@ splitITAp t0 = go t0 []
 -- singleton directly, and a heap reference contributes nothing (the
 -- substitution machinery never enters IRefT -- see ISyntaxSubst).
 data IExpr a
-        = ILam_ !VarSet !VarSet Id IType (IExpr a) -- vanishes after IExpand
-        | IAps_ !VarSet !VarSet (IExpr a) [IType] [IExpr a]
+        = ILam_ VarSet VarSet Id IType (IExpr a) -- vanishes after IExpand
+        | IAps_ VarSet VarSet (IExpr a) [IType] [IExpr a]
         | IVar Id                        -- vanishes after IExpand
-        | ILAM_ !VarSet !VarSet Id IKind (IExpr a) -- vanishes after IExpand
-        | ICon_ !VarSet Id (IConInfo a)  -- free type vars only (see eFVarSet)
+        | ILAM_ VarSet VarSet Id IKind (IExpr a) -- vanishes after IExpand
+        | ICon_ VarSet Id (IConInfo a)   -- free type vars only (see eFVarSet)
         -- IRef is only used during reduction, it refers to a "heap" cell
         | IRefT IType !Int (S.Set Position) a -- vanishes after IExpand
 
@@ -503,36 +503,35 @@ efvCacheEnabled :: Bool
 efvCacheEnabled = not ("-hack-no-iexpr-fv-cache" `elem` progArgs)
 
 mkILam :: Id -> IType -> IExpr a -> IExpr a
-mkILam i t e = ILam_ fvs ftvs i t e
-  where fvs  | efvCacheEnabled = vsDelete i (eFVarSet e)
-             | otherwise       = vsEmpty
+mkILam i t e
+  | efvCacheEnabled = ILam_ fvs ftvs i t e
+  | otherwise       = ILam_ vsEmpty vsEmpty i t e
+  where fvs  = vsDelete i (eFVarSet e)
         -- unlike the historical ftVars, the binder's type is included:
         -- substitution rewrites it (ISyntaxSubst substitutes ILam
         -- types), so pruning needs its variables counted
-        ftvs | efvCacheEnabled = fTVarSet t `vsUnion` eFTVarSet e
-             | otherwise       = vsEmpty
+        ftvs = fTVarSet t `vsUnion` eFTVarSet e
 
 mkIAps :: IExpr a -> [IType] -> [IExpr a] -> IExpr a
-mkIAps f ts es = IAps_ fvs ftvs f ts es
-  where fvs  | efvCacheEnabled = foldr (vsUnion . eFVarSet) (eFVarSet f) es
-             | otherwise       = vsEmpty
-        ftvs | efvCacheEnabled =
-                 foldr (vsUnion . eFTVarSet)
-                       (foldr (vsUnion . fTVarSet) (eFTVarSet f) ts)
-                       es
-             | otherwise       = vsEmpty
+mkIAps f ts es
+  | efvCacheEnabled = IAps_ fvs ftvs f ts es
+  | otherwise       = IAps_ vsEmpty vsEmpty f ts es
+  where fvs  = foldr (vsUnion . eFVarSet) (eFVarSet f) es
+        ftvs = foldr (vsUnion . eFTVarSet)
+                     (foldr (vsUnion . fTVarSet) (eFTVarSet f) ts)
+                     es
 
 mkILAM :: Id -> IKind -> IExpr a -> IExpr a
-mkILAM i k e = ILAM_ fvs ftvs i k e
-  where fvs  | efvCacheEnabled = eFVarSet e
-             | otherwise       = vsEmpty
-        ftvs | efvCacheEnabled = vsDelete i (eFTVarSet e)
-             | otherwise       = vsEmpty
+mkILAM i k e
+  | efvCacheEnabled = ILAM_ fvs ftvs i k e
+  | otherwise       = ILAM_ vsEmpty vsEmpty i k e
+  where fvs  = eFVarSet e
+        ftvs = vsDelete i (eFTVarSet e)
 
 mkICon :: Id -> IConInfo a -> IExpr a
-mkICon i ic = ICon_ ftvs i ic
-  where ftvs | efvCacheEnabled = conFTVarSet ic
-             | otherwise       = vsEmpty
+mkICon i ic
+  | efvCacheEnabled = ICon_ (conFTVarSet ic) i ic
+  | otherwise       = ICon_ vsEmpty i ic
 
 -- The free type variables reachable by substitution below an ICon:
 -- every type position ISyntaxSubst.etSubstIConInfo rewrites and every
@@ -1374,12 +1373,16 @@ instance NFData IAbstractInput where
 instance NFData (IDef a) where
     rnf (IDef i t e p) = rnf4 i t e p
 
+-- Matches the REAL constructors so the cached free-variable sets are
+-- forced too: hyper/rnf must normalize the whole node, and a match
+-- through the pattern synonyms would skip the cache fields (leaving
+-- thunks alive that the hyper discipline exists to kill).
 instance NFData (IExpr a) where
-    rnf (ILam i t e) = rnf3 i t e
-    rnf (IAps e ts es) = rnf3 e ts es
+    rnf (ILam_ fvs ftvs i t e) = rnf2 fvs ftvs `seq` rnf3 i t e
+    rnf (IAps_ fvs ftvs e ts es) = rnf2 fvs ftvs `seq` rnf3 e ts es
     rnf (IVar i) = rnf i
-    rnf (ILAM i k e) = rnf3 i k e
-    rnf (ICon i ic) = rnf2 i ic
+    rnf (ILAM_ fvs ftvs i k e) = rnf2 fvs ftvs `seq` rnf3 i k e
+    rnf (ICon_ ftvs i ic) = rnf ftvs `seq` rnf2 i ic
     rnf (IRefT t p poss _) = rnf2 t poss
 
 instance NFData (IConInfo a) where

--- a/src/comp/ISyntaxSubst.hs
+++ b/src/comp/ISyntaxSubst.hs
@@ -103,27 +103,32 @@ instance SubstContext (SingleExpr a) (IExpr a) where
     if i == i' then SomeCtx (EmptyExpr :: EmptyExpr a) else SomeCtx s
   ctxAdd i' x' (SingleExpr i x fvs) =
     BatchExpr (M.fromList [(i,x), (i',x')]) (fvs `S.union` fVars x')
+              (S.fromList [i, i'])
   ctxNorm _ _ = Unchanged
   ctxAvoids vs (SingleExpr i _ _) = not (i `vsMember` vs)
 
 -- Batch substitution (size >= 2) - uses Map
-data BatchExpr a = BatchExpr !(M.Map Id (IExpr a)) !(S.Set Id)
+-- The third field is the substitution domain (the map's key set),
+-- kept as a Set so that ctxAvoids -- which runs at every node the
+-- substitution visits -- is a single non-allocating disjointness
+-- check instead of a per-key membership loop.
+data BatchExpr a = BatchExpr !(M.Map Id (IExpr a)) !(S.Set Id) !VarSet
 
 instance SubstContext (BatchExpr a) (IExpr a) where
-  lookupVar i (BatchExpr m _) = M.lookup i m
+  lookupVar i (BatchExpr m _ _) = M.lookup i m
   ctxIsEmpty _ = False  -- BatchExpr always has size >= 2
-  ctxContainsVar i (BatchExpr _ fvs) = i `S.member` fvs
-  ctxRemove i (BatchExpr m fvs) =
+  ctxContainsVar i (BatchExpr _ fvs _) = i `S.member` fvs
+  ctxRemove i (BatchExpr m fvs dom) =
     let m' = M.delete i m
     in case M.size m' of
          0 -> SomeCtx (EmptyExpr :: EmptyExpr a)
          1 -> let (j, x) = M.findMin m'
               in SomeCtx $ SingleExpr j x fvs
-         _ -> SomeCtx $ BatchExpr m' fvs
-  ctxAdd i x (BatchExpr m fvs) =
-    BatchExpr (M.insert i x m) (fvs `S.union` fVars x)
+         _ -> SomeCtx $ BatchExpr m' fvs (vsDelete i dom)
+  ctxAdd i x (BatchExpr m fvs dom) =
+    BatchExpr (M.insert i x m) (fvs `S.union` fVars x) (vsInsert i dom)
   ctxNorm _ _ = Unchanged
-  ctxAvoids vs (BatchExpr m _) = not (any (`vsMember` vs) (M.keys m))
+  ctxAvoids vs (BatchExpr _ _ dom) = vs `S.disjoint` dom
 
 -- ============================================================
 -- Type substitution contexts
@@ -150,7 +155,8 @@ instance SubstContext SingleType IType where
   ctxRemove i' s@(SingleType i _ _) =
     if i == i' then SomeCtx EmptyType else SomeCtx s
   ctxAdd i' t' (SingleType i t fvs) =
-    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t') (\ _ -> Unchanged)
+    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t')
+                  (S.fromList [i, i']) (\ _ -> Unchanged)
   ctxNorm _ _ = Unchanged
   ctxAvoids fvs (SingleType i _ _) = not (i `vsMember` fvs)
 
@@ -164,47 +170,52 @@ instance SubstContext SingleTypeNorm IType where
   ctxRemove i' s@(SingleTypeNorm i _ _ _) =
     if i == i' then SomeCtx EmptyType else SomeCtx s
   ctxAdd i' t' (SingleTypeNorm i t fvs norm) =
-    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t') norm
+    BatchTypeNorm (M.fromList [(i,t), (i',t')]) (fvs `vsUnion` fTVarSet t')
+                  (S.fromList [i, i']) norm
   ctxNorm (SingleTypeNorm _ _ _ norm) = norm
   ctxAvoids fvs (SingleTypeNorm i _ _ _) = not (i `vsMember` fvs)
 
 -- Batch type substitution
-data BatchType = BatchType !(M.Map Id IType) !VarSet
+-- (third field: the substitution domain as a Set; see BatchExpr)
+data BatchType = BatchType !(M.Map Id IType) !VarSet !VarSet
 
 instance SubstContext BatchType IType where
-  lookupVar i (BatchType m _) = M.lookup i m
+  lookupVar i (BatchType m _ _) = M.lookup i m
   ctxIsEmpty _ = False
-  ctxContainsVar i (BatchType _ fvs) = i `vsMember` fvs
-  ctxRemove i (BatchType m fvs) =
+  ctxContainsVar i (BatchType _ fvs _) = i `vsMember` fvs
+  ctxRemove i (BatchType m fvs dom) =
     let m' = M.delete i m
     in case M.size m' of
          0 -> SomeCtx EmptyType
          1 -> let (j, t) = M.findMin m'
               in SomeCtx $ SingleType j t fvs
-         _ -> SomeCtx $ BatchType m' fvs
-  ctxAdd i t (BatchType m fvs) =
-    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t) (\ _ -> Unchanged)
+         _ -> SomeCtx $ BatchType m' fvs (vsDelete i dom)
+  ctxAdd i t (BatchType m fvs dom) =
+    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t)
+                  (vsInsert i dom) (\ _ -> Unchanged)
   ctxNorm _ _ = Unchanged
-  ctxAvoids fvs (BatchType m _) = not (any (`vsMember` fvs) (M.keys m))
+  ctxAvoids fvs (BatchType _ _ dom) = fvs `S.disjoint` dom
 
 -- Batch type substitution with normalization
-data BatchTypeNorm = BatchTypeNorm !(M.Map Id IType) !VarSet !(IType -> Changed IType)
+-- (third field: the substitution domain as a Set; see BatchExpr)
+data BatchTypeNorm = BatchTypeNorm !(M.Map Id IType) !VarSet !VarSet !(IType -> Changed IType)
 
 instance SubstContext BatchTypeNorm IType where
-  lookupVar i (BatchTypeNorm m _ _) = M.lookup i m
+  lookupVar i (BatchTypeNorm m _ _ _) = M.lookup i m
   ctxIsEmpty _ = False
-  ctxContainsVar i (BatchTypeNorm _ fvs _) = i `vsMember` fvs
-  ctxRemove i (BatchTypeNorm m fvs norm) =
+  ctxContainsVar i (BatchTypeNorm _ fvs _ _) = i `vsMember` fvs
+  ctxRemove i (BatchTypeNorm m fvs dom norm) =
     let m' = M.delete i m
     in case M.size m' of
          0 -> SomeCtx EmptyType
          1 -> let (j, t) = M.findMin m'
               in SomeCtx $ SingleTypeNorm j t fvs norm
-         _ -> SomeCtx $ BatchTypeNorm m' fvs norm
-  ctxAdd i t (BatchTypeNorm m fvs norm) =
-    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t) norm
-  ctxNorm (BatchTypeNorm _ _ norm) = norm
-  ctxAvoids fvs (BatchTypeNorm m _ _) = not (any (`vsMember` fvs) (M.keys m))
+         _ -> SomeCtx $ BatchTypeNorm m' fvs (vsDelete i dom) norm
+  ctxAdd i t (BatchTypeNorm m fvs dom norm) =
+    BatchTypeNorm (M.insert i t m) (fvs `vsUnion` fTVarSet t)
+                  (vsInsert i dom) norm
+  ctxNorm (BatchTypeNorm _ _ _ norm) = norm
+  ctxAvoids fvs (BatchTypeNorm _ _ dom _) = fvs `S.disjoint` dom
 
 -- ============================================================
 -- Type substitution
@@ -277,7 +288,7 @@ tSubstBatch typeMap t
       in tSubst i ty t
   | otherwise =
       let ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
-          tctx = BatchType typeMap ftxv
+          tctx = BatchType typeMap ftxv (M.keysSet typeMap)
           allIds = S.unions (map fTVars (M.elems typeMap)) `S.union` aTVars t
       in changedOr t (tSubstWith tctx allIds t)
 
@@ -495,7 +506,7 @@ eSubstBatch norm exprMap typeMap e
                     in eSubstWith (EmptyExpr :: EmptyExpr a) (SingleTypeNorm i t (fTVarSet t) norm) (fTVars t `S.union` aVars e) e
           (0, _) -> let ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
                         ftx = S.unions (map fTVars (M.elems typeMap))
-                    in eSubstWith (EmptyExpr :: EmptyExpr a) (BatchTypeNorm typeMap ftxv norm) (ftx `S.union` aVars e) e
+                    in eSubstWith (EmptyExpr :: EmptyExpr a) (BatchTypeNorm typeMap ftxv (M.keysSet typeMap) norm) (ftx `S.union` aVars e) e
           (1, 0) -> let (i, x) = M.findMin exprMap
                         fvx = fVars x
                     in eSubstWith (SingleExpr i x fvx) EmptyType (fvx `S.union` aVars e) e
@@ -507,16 +518,16 @@ eSubstBatch norm exprMap typeMap e
                         fvx = fVars ex
                         ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
                         ftx = S.unions (map fTVars (M.elems typeMap))
-                    in eSubstWith (SingleExpr ei ex fvx) (BatchTypeNorm typeMap ftxv norm) (fvx `S.union` ftx `S.union` aVars e) e
+                    in eSubstWith (SingleExpr ei ex fvx) (BatchTypeNorm typeMap ftxv (M.keysSet typeMap) norm) (fvx `S.union` ftx `S.union` aVars e) e
           (_, 0) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
-                    in eSubstWith (BatchExpr exprMap fvx) EmptyType (fvx `S.union` aVars e) e
+                    in eSubstWith (BatchExpr exprMap fvx (M.keysSet exprMap)) EmptyType (fvx `S.union` aVars e) e
           (_, 1) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
                         (ti, tt) = M.findMin typeMap
-                    in eSubstWith (BatchExpr exprMap fvx) (SingleTypeNorm ti tt (fTVarSet tt) norm) (fvx `S.union` fTVars tt `S.union` aVars e) e
+                    in eSubstWith (BatchExpr exprMap fvx (M.keysSet exprMap)) (SingleTypeNorm ti tt (fTVarSet tt) norm) (fvx `S.union` fTVars tt `S.union` aVars e) e
           (_, _) -> let fvx = S.unions $ M.elems $ M.map fVars exprMap
                         ftxv = foldr (vsUnion . fTVarSet) vsEmpty (M.elems typeMap)
                         ftx = S.unions (map fTVars (M.elems typeMap))
-                    in eSubstWith (BatchExpr exprMap fvx) (BatchTypeNorm typeMap ftxv norm) (fvx `S.union` ftx `S.union` aVars e) e
+                    in eSubstWith (BatchExpr exprMap fvx (M.keysSet exprMap)) (BatchTypeNorm typeMap ftxv (M.keysSet typeMap) norm) (fvx `S.union` ftx `S.union` aVars e) e
 
 {-# INLINE mapChanged #-}
 mapChanged :: (a -> Changed a) -> [a] -> Changed [a]

--- a/src/comp/ISyntaxSubst.hs
+++ b/src/comp/ISyntaxSubst.hs
@@ -67,8 +67,10 @@ class SubstContext ctx v | ctx -> v where
   ctxNorm :: ctx -> v -> Changed v
   -- True if no variable in the given free-variable set is in the
   -- substitution domain, i.e. substituting under a tree with these
-  -- free variables cannot change it.  Only type contexts answer
-  -- precisely; expression contexts conservatively say False.
+  -- free variables cannot change it.  Type contexts check against the
+  -- cached IType free-variable sets; expression contexts against the
+  -- cached IExpr sets (fed the value-variable set for the expression
+  -- domain and, on type contexts, the type-variable set).
   ctxAvoids :: VarSet -> ctx -> Bool
 
 -- Constraint synonyms for clarity
@@ -102,7 +104,7 @@ instance SubstContext (SingleExpr a) (IExpr a) where
   ctxAdd i' x' (SingleExpr i x fvs) =
     BatchExpr (M.fromList [(i,x), (i',x')]) (fvs `S.union` fVars x')
   ctxNorm _ _ = Unchanged
-  ctxAvoids _ _ = False
+  ctxAvoids vs (SingleExpr i _ _) = not (i `vsMember` vs)
 
 -- Batch substitution (size >= 2) - uses Map
 data BatchExpr a = BatchExpr !(M.Map Id (IExpr a)) !(S.Set Id)
@@ -121,7 +123,7 @@ instance SubstContext (BatchExpr a) (IExpr a) where
   ctxAdd i x (BatchExpr m fvs) =
     BatchExpr (M.insert i x m) (fvs `S.union` fVars x)
   ctxNorm _ _ = Unchanged
-  ctxAvoids _ _ = False
+  ctxAvoids vs (BatchExpr m _) = not (any (`vsMember` vs) (M.keys m))
 
 -- ============================================================
 -- Type substitution contexts
@@ -377,7 +379,28 @@ eSubstWith ectx tctx allIds e
       changed1 (changedOrId $ ctxNorm tctx) $ tSubstWith tctx allIds t
     -- sub needs to be polymorphic because the context type can change at
     -- ctxAdd (to batch) or ctxRemove (to single or empty) for both contexts
+    --
+    -- Pruning (mirroring tSubstWith): if a subtree's cached free value
+    -- variables are disjoint from the expression-substitution domain
+    -- AND its cached free type variables are disjoint from the
+    -- type-substitution domain, nothing under it can change; skip it.
+    -- (The cached sets cover everything substitution can reach,
+    -- including the type positions and nested wire/imVal expressions
+    -- inside ICons -- see the smart constructors in ISyntax.)  The
+    -- binder cases must ALSO check ctxContainsVar, exactly as the
+    -- ITForAll case in tSubstWith: when the binder collides with the
+    -- free variables of the substitution payloads, the original code
+    -- alpha-converts (renaming the binder) even when the body contains
+    -- no domain variable, and that rename is observable.  Falling
+    -- through preserves it exactly.  The guards are gated on the flag
+    -- itself, never on the cached sets: with the cache disabled the
+    -- fields hold dummy empty sets, which would otherwise prune
+    -- everything.
     sub :: (ExprSubstCtx ectx' a, TypeSubstCtx tctx') => ectx' -> tctx' -> S.Set Id -> IExpr a -> Changed (IExpr a)
+    sub ectx tctx allIds ee@(ILam i _ _)
+      | efvCacheEnabled, ctxAvoids (eFVarSet ee) ectx,
+        ctxAvoids (eFTVarSet ee) tctx, not (ctxContainsVar i ectx) =
+          Unchanged
     sub ectx tctx allIds ee@(ILam i t e) =
       case lookupVar i ectx of
         Just _ ->
@@ -398,6 +421,10 @@ eSubstWith ectx tctx allIds e
             in Changed $ ILam i' t' e'
           else -- No conflict: continue with same contexts
             changed2 (ILam i) t e (tSubWithNorm tctx allIds t) (sub ectx tctx allIds e)
+    sub ectx tctx allIds ee@(ILAM i _ _)
+      | efvCacheEnabled, ctxAvoids (eFVarSet ee) ectx,
+        ctxAvoids (eFTVarSet ee) tctx, not (ctxContainsVar i tctx) =
+          Unchanged
     sub ectx tctx allIds ee@(ILAM i k e) =
       case lookupVar i tctx of
         Just _ ->
@@ -418,10 +445,18 @@ eSubstWith ectx tctx allIds e
           else -- No conflict: continue with same contexts
             changed1 (ILAM i k) (sub ectx tctx allIds e)
     sub ectx _    _      ee@(IVar i) = maybe Unchanged Changed (lookupVar i ectx)
-    sub ectx tctx allIds ee@(IAps f ts es) =
+    sub ectx tctx allIds ee@(IAps f ts es)
+      | efvCacheEnabled, ctxAvoids (eFVarSet ee) ectx,
+        ctxAvoids (eFTVarSet ee) tctx =
+          Unchanged
+      | otherwise =
         changed3 IAps f ts es (sub ectx tctx allIds f) (mapChanged (tSubWithNorm tctx allIds) ts) (mapChanged (sub ectx tctx allIds) es)
     -- Use helper for IConInfo (handles both type and expression substitution)
-    sub ectx tctx allIds ee@(ICon i ii) =
+    sub ectx tctx allIds ee@(ICon i ii)
+      | efvCacheEnabled, ctxAvoids (eFVarSet ee) ectx,
+        ctxAvoids (eFTVarSet ee) tctx =
+          Unchanged
+      | otherwise =
         changed1 (ICon i) (etSubstIConInfo (tSubWithNorm tctx allIds)
                                            (sub ectx tctx allIds) ii)
     sub _    _    _      ee@(IRefT _ _ _ _) = Unchanged  -- no free tyvar inside IRef


### PR DESCRIPTION
**What**: the expression-side analogue of #70's IType FTV cache — every IExpr node caches its free-variable and free-tyvar sets behind the private constructors; `eSubst` prunes descent using them (substitution skips subtrees that can't mention the domain). Three commits: the cache+pruning core; Set-based batch substitution domains for `ctxAvoids`; lazy cache fields with rnf as the designated force-and-memoize point.

**Why**: elaboration-time substitution re-walked full expression trees regardless of relevance; with cached FV sets the walk stops where the domain can't occur. Fields are lazy — nodes never queried pay nothing; hyper (rnf) forces and memoizes them because unforced set thunks are exactly the leaks hyper exists to kill.

**Base note**: stacks on #70 (atf/3-ftv-cache), not upstream-main — the code hard-depends on that commit's `VarSet`, `ctxAvoids`, and tSubst-pruning machinery, and A/Bs against its `hack-no-itype-ftv-cache` traceflag. Own kill-switch: `hack-no-iexpr-fv-cache` traceflag.

**rnf interaction with #88 (disclosed for review)**: opposite-but-composing postures, each right for its node class — interned immortal IType ⇒ NF-at-construction and O(1) rnf (#88); uninterned transient IExpr ⇒ lazy caches with rnf as on-demand force point (here). No textual overlap on the NFData instances; #88's canary walks IType/Id only. Sibling-stack caveat: this line and atf/4a→5 both fork from atf/3, so whichever lands second rebases through mechanical IType.hs conflicts.

**Verification**: `install-src` exit 0 at head; bsc.typechecker/typeclasses 107/0. Contamination greps clean (weave-only ICLazyPack/ICLazyUnpack arms stripped from the picks). No serialization impact; no tags.

**Provenance**: `28f5c7b9`, `bd58ed4b`, `bdd02420` from `claude/iexpr-free-var-cache-nlmgvj` (its self-reverting experiment pairs, bo2bloogle compat, and design-notes commits excluded; its profiling commits live in #98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt