### PR TITLE
cmpE: compare constructor rank first, fixing a non-transitive Ord (IExpr)

### DIFF
--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -460,15 +460,35 @@ instance Show (IExpr a) where
   show (ICon i ic)    = "(ICon " ++ show i ++ " " ++ show ic ++ ")"
   show (IRefT t p _ _)  = "(IRefT " ++ show t ++ " " ++ "_" ++ show p ++ ")"
 
+-- Rank-first comparison: different constructors are ordered by an
+-- explicit rank (the same structure cmpC already uses via ordC);
+-- same-constructor pairs compare structurally.  The previous pairwise
+-- clause matrix encoded a non-transitive order -- ILAM < ICon,
+-- ICon < IRefT, but IRefT < ILAM (the clauses marked ??? below) --
+-- which was harmless only because ILAM and IRefT never coexist in
+-- live comparisons.  Rank-first reproduces the old order for every
+-- other constructor pair.
 cmpE :: IExpr a -> IExpr a -> Ordering
-cmpE (ILam i1 _ e1)  (ILam i2 _ e2)  =
+cmpE x y =
+    case compare (rankE x) (rankE y) of
+    EQ -> cmpSameRank x y
+    o  -> o
+
+rankE :: IExpr a -> Int
+rankE (ILam _ _ _) = 0
+rankE (IAps _ _ _) = 1
+rankE (IVar _) = 2
+rankE (ILAM _ _ _) = 3
+rankE (ICon _ _) = 4
+rankE (IRefT _ _ _ _) = 5
+
+cmpSameRank :: IExpr a -> IExpr a -> Ordering
+cmpSameRank (ILam i1 _ e1)  (ILam i2 _ e2)  =
         case compare i1 i2 of
         EQ -> cmpE e1 e2
         o  -> o
-cmpE (ILam _ _ _)    _               = LT
 
-cmpE (IAps _  _ _)   (ILam _ _ _)    = GT
-cmpE (IAps e1 ts1 es1) (IAps e2 ts2 es2) =
+cmpSameRank (IAps e1 ts1 es1) (IAps e2 ts2 es2) =
         case compare e1 e2 of
         EQ ->
                 case compare es1 es2 of
@@ -480,28 +500,16 @@ cmpE (IAps e1 ts1 es1) (IAps e2 ts2 es2) =
                 o  -> o
 -}
         o  -> o
-cmpE (IAps _  _ _)   _               = LT
 
-cmpE (IVar _)        (ILam _ _ _)    = GT
-cmpE (IVar _)        (IAps _ _ _)    = GT
-cmpE (IVar i1)       (IVar i2)       = compare i1 i2
-cmpE (IVar _)        _               = LT
+cmpSameRank (IVar i1)       (IVar i2)       = compare i1 i2
 
-cmpE (ILAM _ _ _)    (ILam _ _ _)    = GT
-cmpE (ILAM _ _ _)    (IAps _ _ _)    = GT
-cmpE (ILAM _ _ _)    (IVar _)        = GT
-cmpE (ILAM i1 _ e1)  (ILAM i2 _ e2)  =
+cmpSameRank (ILAM i1 _ e1)  (ILAM i2 _ e2)  =
         case compare i1 i2 of
         EQ -> cmpE e1 e2
         o  -> o
-cmpE (ILAM _ _ _)    (IRefT _ _ _ _)   = GT -- ???????
 
-cmpE (ILAM _  _ _)   _               = LT
 
-cmpE (ICon _ _)      (ILam _ _ _)    = GT
-cmpE (ICon _ _)      (IAps _ _ _)    = GT
-cmpE (ICon _ _)      (IVar _)        = GT
-cmpE (ICon i1 ic1) (ICon i2 ic2)     =
+cmpSameRank (ICon i1 ic1) (ICon i2 ic2)     =
         case compare i1 i2 of
         EQ -> case (cmpC ic1 ic2) of
                 -- inlined positions need to be considered in equality tests
@@ -510,19 +518,11 @@ cmpE (ICon i1 ic1) (ICon i2 ic2)     =
                       in  compare mposs1 mposs2
                 o  -> o
         o  -> o
-cmpE (ICon _ _)      _               = LT
 
-cmpE (IRefT _ _ _ _)   (ILam _ _ _)    = GT
-cmpE (IRefT _ _ _ _)   (IAps _ _ _)    = GT
-cmpE (IRefT _ _ _ _)   (IVar _)        = GT
-cmpE (IRefT _ _ _ _)   (ICon _ _)      = GT
-cmpE (IRefT _ p1 _ _)  (IRefT _ p2 _ _)  = compare p1 p2                -- XXX
+cmpSameRank (IRefT _ p1 _ _)  (IRefT _ p2 _ _)  = compare p1 p2                -- XXX
 
-cmpE (IRefT _ _ _ _)     (ILAM _ _ _)  = LT -- ??????????
 
-{- all cases are covered above, so the compiler complains about this line:
-cmpE e1              e2              = internalError ("not match in cmpE " ++ ppReadable (e1,e2))
--}
+cmpSameRank e1 e2 = internalError ("cmpSameRank: rank mismatch " ++ ppReadable (e1, e2))
 
 instance Eq (IExpr a) where
     x == y  =  cmpE x y == EQ


### PR DESCRIPTION
## What

Rewrites `cmpE`'s cross-constructor ordering as an explicit rank comparison (`rankE`, mirroring the `ordC` structure `cmpC` already uses), with structural comparison within a rank.

## Why: `Ord (IExpr)` is currently not a total order

The pairwise clause matrix encodes:

- `ILAM < ICon` (ILAM catch-all `LT`)
- `ICon < IRefT` (ICon catch-all `LT`)
- `IRefT < ILAM` (the two clauses annotated `???????` / `??????????`)

— a cycle. It is latent only because `ILAM` (pre-elaboration) and `IRefT` (during elaboration) never coexist in live comparisons; any future code putting both in one `Data.Set`/`Data.Map` would get silently corrupted containers. The `???` comments suggest the original author suspected as much.

Rank-first reproduces the previous ordering for every constructor pair **except** the cycle participants, so no output change is expected — and none is observed.

`cmpC` (IConInfo) and `cmpT` (IType) were audited for the same defect: `cmpC` is already rank-first via `ordC` (which is why it never grew this bug), and `cmpT`'s clause matrix is consistent.

## Testing

- Generated Verilog byte-identical to an unpatched build of the same commit for AES, FPMac64 (7 modules), and PureLoop (verified non-empty outputs).
- Toooba (`RV64ACDFIMSU_Toooba_bluesim`) compiles with `rc=0`; total allocation within 0.0002% of the unpatched baseline (perf-neutral, as expected for a bugfix).

Candidate for forwarding upstream to B-Lang-org, where the same latent cycle exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu)_