### PR TITLE
cmpE: skip the inlined-positions allocation when neither Id has them

### DIFF
--- a/src/comp/ISyntax.hs
+++ b/src/comp/ISyntax.hs
@@ -504,10 +504,16 @@ cmpE (ICon _ _)      (IVar _)        = GT
 cmpE (ICon i1 ic1) (ICon i2 ic2)     =
         case compare i1 i2 of
         EQ -> case (cmpC ic1 ic2) of
-                -- inlined positions need to be considered in equality tests
-                EQ -> let mposs1 = getIdInlinedPositions i1
-                          mposs2 = getIdInlinedPositions i2
-                      in  compare mposs1 mposs2
+                -- inlined positions need to be considered in equality
+                -- tests; the presence test first keeps the common case
+                -- (neither side has the prop -- e.g. every literal
+                -- constant) free of the Maybe/list allocation
+                EQ -> if not (hasIdInlinedPositions i1) &&
+                         not (hasIdInlinedPositions i2)
+                      then EQ
+                      else let mposs1 = getIdInlinedPositions i1
+                               mposs2 = getIdInlinedPositions i2
+                           in  compare mposs1 mposs2
                 o  -> o
         o  -> o
 cmpE (ICon _ _)      _               = LT

--- a/src/comp/Id.hs
+++ b/src/comp/Id.hs
@@ -103,6 +103,7 @@ module Id(
         getIdDisplayName,
         addIdDisplayName,
         getIdInlinedPositions,
+        hasIdInlinedPositions,
         addIdInlinedPositions,
         removeIdInlinedPositions
          ) where
@@ -657,6 +658,14 @@ dropReadyPrefixId idx
 mkEnableId :: Id -> Id
 mkEnableId idx =
     addIdProp (mkIdPre fsEnable idx)  IdP_enable
+
+-- non-allocating presence test (getIdInlinedPositions builds a Maybe
+-- and a list; comparison fast paths only need to know "neither side
+-- has the prop", which is the overwhelmingly common case)
+hasIdInlinedPositions :: Id -> Bool
+hasIdInlinedPositions i = any isIP (getIdProps i)
+  where isIP (IdPInlinedPositions _) = True
+        isIP _ = False
 
 getIdInlinedPositions :: Id -> Maybe [Position]
 getIdInlinedPositions i =


### PR DESCRIPTION
## What

Adds a non-allocating `hasIdInlinedPositions` presence test (`Id.hs`) and uses it in `cmpE`'s `ICon` equality path before building the two `Maybe [Position]` values (each a list comprehension over the Id props) that in the overwhelmingly common case exist only to compare `Nothing` with `Nothing`.

Semantics are unchanged: absent-on-both-sides compared `EQ` before too, and any Id that does carry the prop takes exactly the old path.

## Measurement (honest version)

Found while profiling the evaluator's predicate-set machinery, where `ICon` comparisons are hot. However, an isolated A/B on the Toooba CI configuration (`RV64ACDFIMSU_Toooba_bluesim`) measures **total allocation within 0.0002% of baseline** — the equality-confirmation path that reaches the positions comparison executes far less often than its call-site frequency suggested. This PR is therefore offered as a small hygiene fix (don't allocate to compare two absent options), not as a performance win: workloads with heavier expression-set equality traffic may benefit, Toooba measurably does not.

## Testing

- Generated Verilog byte-identical to an unpatched build of the same commit for AES, FPMac64 (7 modules), and PureLoop (verified non-empty outputs).
- Toooba compiles with `rc=0`, allocation delta +0.0002%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8zPb2jNE4YVNkAkgZpcuu)_