### PR TITLE
trs/1: the BIR exporter (-bir)

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         run: |
           cabal update
-          cabal v1-install old-time regex-compat split strict-concurrency syb
+          cabal v1-install cborg old-time regex-compat split strict-concurrency syb
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.

--- a/.github/workflows/build-and-test-ubuntu.yml
+++ b/.github/workflows/build-and-test-ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         run: |
           cabal update
-          cabal v1-install old-time regex-compat split strict-concurrency syb
+          cabal v1-install cborg old-time regex-compat split strict-concurrency syb
       # Restore previous ccache cache of compiled object files. Use a SHA
       # in the key so that a new cache file is generated after every build,
       # and have the restore-key use the most recent.

--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -52,6 +52,7 @@ data Flags = Flags {
         finalcleanup :: Int,
         genABin :: Bool,
         genABinVerilog :: Bool,
+        genBir :: Bool,
         genName :: [String],
         genSysC :: Bool,
         ifcPathRaw :: [String],

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -544,6 +544,7 @@ defaultFlags bluespecdir = Flags {
         finalcleanup = 1,
         genABin = False,
         genABinVerilog = False,
+        genBir = False,
         genName = [],
         genSysC = False,
         -- The ifcPath value will be produced from the raw value,
@@ -1158,6 +1159,10 @@ externalFlags = [
         ("elab-verilog",
          (Toggle (\f x -> f {genABinVerilog=x}) (showIfTrue genABinVerilog),
           "include generated Verilog in .ba files", Hidden)),
+
+        ("bir",
+         (Toggle (\f x -> f {genBir=x}) (showIfTrue genBir),
+          "generate a .bir (TRS IR) file when linking with -sim", Hidden)),
 
         ("expand-ATS-limit",
          (Arg "n"
@@ -1851,6 +1856,7 @@ showFlagsRaw flags =
           ("finalcleanup", show (finalcleanup flags)),
           ("genABin", show (genABin flags)),
           ("genABinVerilog", show (genABinVerilog flags)),
+          ("genBir", show (genBir flags)),
           ("genName", show (genName flags)),
           ("genSysC", show (genSysC flags)),
           ("ifLift", show (ifLift flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260712-1"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260805-4"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,7 +561,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133) =
+                a_130 a_131 a_132 a_133 a_134) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
       where
@@ -612,7 +612,7 @@ instance Bin Flags where
         wr_chunk8 =
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-             toBin a_130; toBin a_131; toBin a_132; toBin a_133
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -631,7 +631,7 @@ instance Bin Flags where
           (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-           a_128, a_129, a_130, a_131, a_132, a_133) <- rd_chunk8
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +646,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133)
+                a_130 a_131 a_132 a_133 a_134)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -708,9 +708,10 @@ instance Bin Flags where
         rd_chunk8 =
           do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
-             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin
+             a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin;
+             a_134 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-                     a_128, a_129, a_130, a_131, a_132, a_133)
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
 
 -- ----------
 

--- a/src/comp/Makefile
+++ b/src/comp/Makefile
@@ -147,6 +147,7 @@ PACKAGES = \
 	text \
 	deepseq \
 	strict-concurrency \
+	cborg \
 
 # GHC can compile either a single file (use GHCCOMPILEFLAGS) or
 # in make mode where it follows dependencies (use GHCMAKEFLAGS).

--- a/src/comp/SimCCBlock.hs
+++ b/src/comp/SimCCBlock.hs
@@ -19,6 +19,7 @@ module SimCCBlock( SBId
                  , mkGateConst
                  , mkLiteralName
                  , mkStringLiteralName
+                 , isOkId
                  , simCCBlockToClassDeclaration
                  , simCCBlockToClassDefinition
                  , simCCScheduleToFunctionDefinition

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -585,6 +585,12 @@ encStmt (SFSAssignAction _ i act _) = do
     dE <- idE i
     aE <- encAction act
     return $ encVariant "AvAction" (encStruct [("def", dE), ("action", aE)])
+encStmt (SFSCond c ts es) = do
+    cE <- encExpr c
+    tE <- encStmts ts
+    eE <- encStmts es
+    return $ encVariant "Cond"
+               (encStruct [("cond", cE), ("then_", tE), ("else_", eE)])
 encStmt s = internalError ("SimExportIR.encStmt: " ++ ppReadable s)
 
 -- mempty markers from declaration-only stmts must not appear in the list

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -1,0 +1,540 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | BIR export: serialize the post-scheduling simulation system for the
+-- TRS backend (src/trs).
+--
+-- The format is specified in src/trs/BIR.md and defined operationally
+-- by the Rust types in src/trs/crates/trs-ir; @trs ir dump@
+-- round-trips the output.  The input is the same 'SimSystem' that
+-- 'simMakeCBlocks' consumes today (post 'simExpand' / 'simPackageOpt'),
+-- so schedule merging and package optimization stay in this compiler.
+--
+-- Wire conventions match ciborium's serde defaults on the Rust side:
+-- structs are CBOR maps keyed by field name, tuples and Vecs are arrays,
+-- @Option@ is null-or-value, unit enum variants are strings, and payload
+-- variants are single-entry maps ({variant: payload}).
+--
+-- STATUS (P0, in progress): exports the design skeleton plus module
+-- bodies — clock domains, resets, inputs, instances (with method-order
+-- pairs), defs, rules, and interface methods, with full expression and
+-- action trees.  Not yet exported: segmented schedules, compositions,
+-- ME inhibitors, foreign-function signatures, content hashes.  Unhandled
+-- IR constructs fail loudly ('internalError') rather than exporting
+-- wrong data.
+module SimExportIR
+    ( birVersion
+    , simSystemToBir
+    , writeBirFile
+    ) where
+
+import qualified Data.ByteString.Lazy as L
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import Control.Monad.State.Strict (State, runState, gets, modify)
+import Data.Bits (shiftR, (.&.))
+import Data.Word (Word32)
+
+import qualified Codec.CBOR.Encoding as C
+import qualified Codec.CBOR.Write as CW
+
+import ErrorUtil (internalError)
+import Id (Id, getIdBaseString, mkIdCanFire, mkIdWillFire)
+import IntLit (IntLit(..))
+import PPrint (ppReadable)
+import Prim (PrimOp(..))
+import Pragma (RulePragma(..))
+import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..))
+import VModInfo (vName, getVNameString)
+import ASyntax
+import SimPackage
+
+-- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
+-- trs-ir/src/lib.rs.
+birVersion :: Word32
+birVersion = 1
+
+-- ===============
+-- String interning
+--
+-- All identifiers in BIR are indices into one design-wide string table.
+-- Encoders run in a state monad accumulating the table; the table is
+-- emitted after all bodies are encoded (CBOR encodings are values, so
+-- assembly order is independent of write order).
+
+data StrTable = StrTable !(M.Map String Word32) ![String] !Word32
+
+type EncM = State StrTable
+
+emptyStrTable :: StrTable
+emptyStrTable = StrTable M.empty [] 0
+
+str :: String -> EncM Word32
+str s = do
+    StrTable m rev n <- gets id
+    case M.lookup s m of
+      Just i  -> return i
+      Nothing -> do
+        modify (\_ -> StrTable (M.insert s n m) (s : rev) (n + 1))
+        return n
+
+strE :: String -> EncM C.Encoding
+strE s = encW32 <$> str s
+
+idE :: Id -> EncM C.Encoding
+idE = strE . getIdBaseString
+
+tableStrings :: StrTable -> [String]
+tableStrings (StrTable _ rev _) = reverse rev
+
+-- ===============
+-- Encoding helpers (ciborium/serde conventions)
+
+-- A struct is a map keyed by field name.
+encStruct :: [(String, C.Encoding)] -> C.Encoding
+encStruct fields =
+    C.encodeMapLen (fromIntegral (length fields))
+    <> mconcat [ encStr k <> v | (k, v) <- fields ]
+
+-- A unit enum variant is its name.
+encUnitVariant :: String -> C.Encoding
+encUnitVariant = encStr
+
+-- A payload-carrying enum variant is {name: payload}.
+encVariant :: String -> C.Encoding -> C.Encoding
+encVariant name payload = C.encodeMapLen 1 <> encStr name <> payload
+
+-- Vec<T> and tuples are arrays.
+encList :: [C.Encoding] -> C.Encoding
+encList xs = C.encodeListLen (fromIntegral (length xs)) <> mconcat xs
+
+encPair :: C.Encoding -> C.Encoding -> C.Encoding
+encPair a b = C.encodeListLen 2 <> a <> b
+
+-- Option<T> is null or the value.
+encMaybe :: (a -> C.Encoding) -> Maybe a -> C.Encoding
+encMaybe _ Nothing  = C.encodeNull
+encMaybe f (Just x) = f x
+
+encW32 :: Word32 -> C.Encoding
+encW32 = C.encodeWord32
+
+encBool :: Bool -> C.Encoding
+encBool = C.encodeBool
+
+encStr :: String -> C.Encoding
+encStr = C.encodeString . T.pack
+
+-- ===============
+-- SimSystem -> BIR
+
+-- | Encode a 'SimSystem' as a BIR design document.
+simSystemToBir :: SimSystem -> L.ByteString
+simSystemToBir ssys = CW.toLazyByteString (encDesign ssys)
+
+-- | Write the design's .bir file.
+writeBirFile :: FilePath -> SimSystem -> IO ()
+writeBirFile path ssys = L.writeFile path (simSystemToBir ssys)
+
+encDesign :: SimSystem -> C.Encoding
+encDesign ssys =
+    let pkgs = M.elems (ssys_packages ssys)
+        pkgNames = S.fromList (map (getIdBaseString . sp_name) pkgs)
+        instmap = M.toList (ssys_instmap ssys)
+
+        action :: EncM [(String, C.Encoding)]
+        action = do
+          topId <- str (getIdBaseString (ssys_top ssys))
+          modsEnc <- mapM (encModule pkgNames) pkgs
+          instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
+          clkId <- traverse str (ssys_default_clk ssys)
+          rstId <- traverse str (ssys_default_rst ssys)
+          return
+            [ ("version", encW32 birVersion)
+            , ("strings", mempty)   -- placeholder, replaced below
+            , ("top", encW32 topId)
+            , ("modules", encList modsEnc)
+            , ("instance_map", encList instEnc)
+            , ("compositions", encList [])   -- P0 TODO: schedule composition
+            , ("foreign_funcs", encList [])  -- P0 TODO: from ssys_ffuncmap
+            , ("default_clock", encMaybe encW32 clkId)
+            , ("default_reset", encMaybe encW32 rstId)
+            ]
+
+        (fields, finalTbl) = runState action emptyStrTable
+        strsEnc = encList (map encStr (tableStrings finalTbl))
+        fields' = [ (k, if k == "strings" then strsEnc else v)
+                  | (k, v) <- fields ]
+    in  encStruct fields'
+
+-- ===============
+-- Modules
+
+encModule :: S.Set String -> SimPackage -> EncM C.Encoding
+encModule pkgNames pkg = do
+    nameId <- idE (sp_name pkg)
+    domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
+    rstsEnc <- mapM encReset (sp_reset_list pkg)
+    insEnc <- mapM encInput (sp_inputs pkg)
+    instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
+                     (M.elems (sp_state_instances pkg))
+    defsEnc <- mapM encDef (M.elems (sp_local_defs pkg))
+    rulesEnc <- mapM encRule (sp_rules pkg)
+    methodsEnc <- concat <$> mapM encMethod (sp_interface pkg)
+    return $ encStruct
+      [ ("name", nameId)
+      , ("content_hash", encList (replicate 32 (C.encodeWord8 0))) -- P0 TODO
+      , ("clock_domains", encList domsEnc)
+      , ("resets", encList rstsEnc)
+      , ("inputs", encList insEnc)
+      , ("instances", encList instsEnc)
+      , ("defs", encList defsEnc)
+      , ("rules", encList rulesEnc)
+      , ("methods", encList methodsEnc)
+      , ("schedule", encSchedule)
+      ]
+
+-- P0 TODO: segmented per-(domain,edge) schedules (BIR.md section 4).
+encSchedule :: C.Encoding
+encSchedule =
+    encStruct
+      [ ("domains", encList [])
+      , ("conflicts", encList [])
+      , ("disjoint", encList [])
+      ]
+
+encClockDomain :: AClockDomain -> EncM C.Encoding
+encClockDomain (ClockDomain n, clocks) = do
+    clksEnc <- mapM (\c -> encPair <$> encExpr (aclock_osc c)
+                                   <*> encExpr (aclock_gate c))
+                    clocks
+    return $ encStruct
+      [ ("id", encW32 (fromIntegral n))
+      , ("clocks", encList clksEnc)
+      ]
+
+encReset :: (ResetId, AReset) -> EncM C.Encoding
+encReset (rid, rst) = do
+    wireEnc <- encExpr (areset_wire rst)
+    return $ encStruct
+      [ ("id", encW32 (fromIntegral (writeResetId rid)))
+      , ("wire", wireEnc)
+      ]
+
+encInput :: AAbstractInput -> EncM C.Encoding
+encInput (AAI_Port (i, t)) = encPort (i, t) "MethodArg"
+encInput (AAI_Clock osc _mgate) = do
+    n <- idE osc
+    return $ encPortRaw n 1 "Clock"
+encInput (AAI_Reset r) = do
+    n <- idE r
+    return $ encPortRaw n 1 "Reset"
+encInput (AAI_Inout {}) =
+    internalError "SimExportIR.encInput: Inout not supported by Bluesim"
+
+encPort :: (Id, AType) -> String -> EncM C.Encoding
+encPort (i, t) kind = do
+    n <- idE i
+    return $ encPortRaw n (aTypeWidth t) kind
+
+encPortRaw :: C.Encoding -> Word32 -> String -> C.Encoding
+encPortRaw nameEnc w kind =
+    encStruct
+      [ ("name", nameEnc)
+      , ("width", encW32 w)
+      , ("kind", encUnitVariant kind)
+      ]
+
+encInstance :: S.Set String -> MethodOrderMap -> AVInst -> EncM C.Encoding
+encInstance pkgNames mom avi = do
+    nameId <- idE (avi_vname avi)
+    let modName = getVNameString (vName (avi_vmi avi))
+    kindEnc <-
+      if modName `S.member` pkgNames
+        then encVariant "Module" <$> strE modName
+        -- P0 TODO: map primitives to their structured kinds (Reg, Fifo,
+        -- ...) instead of Other; the structured mapping lands with codegen.
+        else do mEnc <- strE modName
+                return $ encVariant "Prim"
+                           (encVariant "Other" (encStruct [("name", mEnc)]))
+    argsEnc <- mapM encExpr (avi_iargs avi)
+    let morder = S.toList (M.findWithDefault S.empty (avi_vname avi) mom)
+    morderEnc <- mapM (\(a, b) -> encPair <$> idE a <*> idE b) morder
+    portsEnc <- mapM (\(m, n) -> encPair <$> idE m
+                                         <*> pure (encW32 (fromIntegral n)))
+                     (avi_iarray avi)
+    return $ encStruct
+      [ ("name", nameId)
+      , ("kind", kindEnc)
+      , ("args", encList argsEnc)
+      , ("method_order", encList morderEnc)
+      , ("port_counts", encList portsEnc)
+      ]
+
+encDef :: ADef -> EncM C.Encoding
+encDef (ADef i t e _props) = do
+    nameId <- idE i
+    exprEnc <- encExpr e
+    let base = getIdBaseString i
+        isCF = take 9 base == "CAN_FIRE_"
+        isWF = take 10 base == "WILL_FIRE_"
+    return $ encStruct
+      [ ("name", nameId)
+      , ("width", encW32 (aTypeWidth t))
+      , ("expr", exprEnc)
+      , ("props", encStruct
+          [ ("can_fire", encBool isCF)
+          , ("will_fire", encBool isWF)
+          , ("signed", encBool False)   -- P0 TODO: from id props
+          ])
+      ]
+
+encRule :: ARule -> EncM C.Encoding
+encRule r = do
+    nameId <- idE (arule_id r)
+    -- The predicate is a reference to the CAN_FIRE def after
+    -- aAddScheduleDefs; recover the def names.
+    let cfId = case arule_pred r of
+                 ASDef _ i -> i
+                 _         -> mkIdCanFire (arule_id r)
+    cf <- idE cfId
+    wf <- idE (mkIdWillFire (arule_id r))
+    bodyEnc <- mapM encAction (arule_actions r)
+    let dom = case wpClockDomain (arule_wprops r) of
+                Just (ClockDomain n) -> fromIntegral n
+                Nothing -> 0
+        crossing = RPclockCrossingRule `elem` arule_pragmas r
+    return $ encStruct
+      [ ("name", nameId)
+      , ("can_fire", cf)
+      , ("will_fire", wf)
+      , ("body", encList bodyEnc)
+      , ("clock_domain", encW32 dom)
+      , ("crossing", encBool crossing)
+      , ("me_inhibits", encList [])   -- P0 TODO: with segmented schedules
+      ]
+
+-- Interface methods.  Clock/reset/inout interface entries carry no
+-- executable content (they are in the clock/reset lists); skip them.
+encMethod :: AIFace -> EncM [C.Encoding]
+encMethod (AIDef name inputs props pred_ (ADef _ t e _) _ _) = do
+    m <- encMethodStruct name "Value" (concat inputs) (Just pred_) [] (Just (t, e)) props
+    return [m]
+encMethod (AIAction inputs props pred_ name body _) = do
+    m <- encMethodStruct name "Action" (concat inputs) (Just pred_)
+                         (concatMap arule_actions body) Nothing props
+    return [m]
+encMethod (AIActionValue inputs props pred_ name body (ADef _ t e _) _) = do
+    m <- encMethodStruct name "ActionValue" (concat inputs) (Just pred_)
+                         (concatMap arule_actions body) (Just (t, e)) props
+    return [m]
+encMethod (AIClock {}) = return []
+encMethod (AIReset {}) = return []
+encMethod (AIInout {}) = return []
+
+encMethodStruct :: Id -> String -> [AInput] -> Maybe APred -> [AAction]
+                -> Maybe (AType, AExpr) -> WireProps -> EncM C.Encoding
+encMethodStruct name kind inputs mpred body mresult props = do
+    nameId <- idE name
+    argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
+    readyEnc <- traverse encExpr mpred
+    bodyEnc <- mapM encAction body
+    resultEnc <- traverse (encExpr . snd) mresult
+    let dom = case wpClockDomain props of
+                Just (ClockDomain n) -> fromIntegral n
+                Nothing -> 0
+    return $ encStruct
+      [ ("name", nameId)
+      , ("kind", encUnitVariant kind)
+      , ("args", encList argsEnc)
+      , ("ready", encMaybe id readyEnc)
+      , ("body", encList bodyEnc)
+      , ("result", encMaybe id resultEnc)
+      , ("clock_domain", encW32 dom)
+      ]
+
+-- ===============
+-- Expressions
+
+aTypeWidth :: AType -> Word32
+aTypeWidth (ATBit n) = fromIntegral n
+aTypeWidth (ATString _) = 0
+aTypeWidth t = internalError ("SimExportIR.aTypeWidth: " ++ ppReadable t)
+
+-- An Integer as little-endian 32-bit limbs (matching WideData layout).
+toLimbs :: Word32 -> Integer -> [Word32]
+toLimbs w v =
+    let nlimbs = max 1 ((fromIntegral w + 31) `div` 32)
+        limb k = fromIntegral ((v `shiftR` (32 * k)) .&. 0xFFFFFFFF)
+    in  map limb [0 .. nlimbs - 1]
+
+encExpr :: AExpr -> EncM C.Encoding
+encExpr (ASInt _ t lit) =
+    let w = aTypeWidth t
+    in  return $ encVariant "Const" $ encStruct
+          [ ("width", encW32 w)
+          , ("limbs", encList (map encW32 (toLimbs w (ilValue lit))))
+          ]
+encExpr (ASDef _ i) = encVariant "Def" <$> idE i
+encExpr (ASPort _ i) = encVariant "Port" <$> idE i
+encExpr (ASParam _ i) = encVariant "Param" <$> idE i
+encExpr (ASStr _ _ s) = encVariant "Str" <$> strE s
+encExpr (AMethCall t obj meth args) = do
+    o <- idE obj
+    m <- idE meth
+    argsEnc <- mapM encExpr args
+    return $ encVariant "MethCall" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("instance", o)
+      , ("method", m)
+      , ("port", encW32 0)   -- P0 TODO: multi-port assignment
+      , ("args", encList argsEnc)
+      ]
+encExpr (AMethValue t obj meth) = do
+    o <- idE obj
+    m <- idE meth
+    return $ encVariant "MethValue" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("instance", o)
+      , ("method", m)
+      ]
+encExpr (ATaskValue t _ _ _ cookie) =
+    return $ encVariant "TaskValue" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("cookie", encW32 (fromIntegral cookie))
+      ]
+encExpr (AFunCall t _ fun _ args) = do
+    f <- strE fun
+    argsEnc <- mapM encExpr args
+    return $ encVariant "ForeignCall" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("func", f)
+      , ("args", encList argsEnc)
+      ]
+encExpr (AMGate _ obj clk) = do
+    o <- idE obj
+    c <- idE clk
+    return $ encVariant "Gate" $ encStruct
+      [ ("instance", o)
+      , ("clock", c)
+      ]
+encExpr (ASClock _ clk) = do
+    oscEnc <- encExpr (aclock_osc clk)
+    gateEnc <- encExpr (aclock_gate clk)
+    return $ encVariant "Clock" $ encStruct
+      [ ("osc", oscEnc)
+      , ("gate", gateEnc)
+      ]
+encExpr (ASReset _ rst) = do
+    wireEnc <- encExpr (areset_wire rst)
+    return $ encVariant "Reset" $ encStruct
+      [ ("wire", wireEnc)
+      ]
+encExpr (APrim _ t PrimIf [c, x, y]) = do
+    cEnc <- encExpr c
+    xEnc <- encExpr x
+    yEnc <- encExpr y
+    return $ encVariant "If" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("cond", cEnc)
+      , ("then_", xEnc)
+      , ("else_", yEnc)
+      ]
+encExpr (APrim _ t PrimCase (scrut : dflt : arms)) = do
+    sEnc <- encExpr scrut
+    dEnc <- encExpr dflt
+    armsEnc <- encCaseArms arms
+    return $ encVariant "Case" $ encStruct
+      [ ("width", encW32 (aTypeWidth t))
+      , ("scrutinee", sEnc)
+      , ("arms", encList armsEnc)
+      , ("default", dEnc)
+      ]
+encExpr (APrim _ t op args) = do
+    argsEnc <- mapM encExpr args
+    return $ encVariant "Prim" $ encStruct
+      [ ("op", encUnitVariant (primOpName op))
+      , ("width", encW32 (aTypeWidth t))
+      , ("args", encList argsEnc)
+      ]
+encExpr e = internalError ("SimExportIR.encExpr: " ++ ppReadable e)
+
+encCaseArms :: [AExpr] -> EncM [C.Encoding]
+encCaseArms [] = return []
+encCaseArms (ASInt _ _ lit : v : rest) = do
+    vEnc <- encExpr v
+    restEnc <- encCaseArms rest
+    return (encPair (C.encodeWord64 (fromIntegral (ilValue lit))) vEnc
+            : restEnc)
+encCaseArms es =
+    internalError ("SimExportIR.encCaseArms: " ++ ppReadable es)
+
+primOpName :: PrimOp -> String
+primOpName PrimAdd = "Add"
+primOpName PrimSub = "Sub"
+primOpName PrimAnd = "And"
+primOpName PrimOr = "Or"
+primOpName PrimXor = "Xor"
+primOpName PrimMul = "Mul"
+primOpName PrimQuot = "Quot"
+primOpName PrimRem = "Rem"
+primOpName PrimSL = "Shl"
+primOpName PrimSRL = "Lshr"
+primOpName PrimSRA = "Ashr"
+primOpName PrimInv = "Not"
+primOpName PrimNeg = "Neg"
+primOpName PrimEQ = "Eq"
+primOpName PrimEQ3 = "Eq"   -- Bluesim is 2-state; === is ==
+primOpName PrimULE = "Ule"
+primOpName PrimULT = "Ult"
+primOpName PrimSLE = "Sle"
+primOpName PrimSLT = "Slt"
+primOpName PrimSignExt = "SignExt"
+primOpName PrimZeroExt = "ZeroExt"
+primOpName PrimExtract = "Extract"
+primOpName PrimConcat = "Concat"
+primOpName PrimBNot = "Not"
+primOpName PrimBAnd = "And"
+primOpName PrimBOr = "Or"
+primOpName PrimArrayDynSelect = "Select"
+primOpName op = internalError ("SimExportIR.primOpName: " ++ show op)
+
+-- ===============
+-- Actions
+
+encAction :: AAction -> EncM C.Encoding
+encAction (ACall obj meth (cond : args)) = do
+    o <- idE obj
+    m <- idE meth
+    condEnc <- encExpr cond
+    argsEnc <- mapM encExpr args
+    return $ encVariant "MethCall" $ encStruct
+      [ ("instance", o)
+      , ("method", m)
+      , ("port", encW32 0)   -- P0 TODO: multi-port assignment
+      , ("cond", condEnc)
+      , ("args", encList argsEnc)
+      ]
+encAction (AFCall _ fun _ (cond : args) _) = do
+    f <- strE fun
+    condEnc <- encExpr cond
+    argsEnc <- mapM encExpr args
+    return $ encVariant "Foreign" $ encStruct
+      [ ("func", f)
+      , ("cond", condEnc)
+      , ("args", encList argsEnc)
+      ]
+encAction (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
+    f <- strE fun
+    tempEnc <- traverse idE mtemp
+    condEnc <- encExpr cond
+    argsEnc <- mapM encExpr args
+    return $ encVariant "Task" $ encStruct
+      [ ("func", f)
+      , ("cookie", encW32 (fromIntegral cookie))
+      , ("temp", encMaybe id tempEnc)
+      , ("width", encW32 (aTypeWidth mty))
+      , ("cond", condEnc)
+      , ("args", encList argsEnc)
+      ]
+encAction a = internalError ("SimExportIR.encAction: " ++ ppReadable a)

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -52,7 +52,7 @@ import Pragma (RulePragma(..), isAlwaysEn)
 import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..), wpResets)
 import VModInfo (vName, getVNameString, VWireInfo(..), VClockInfo(..), VResetInfo(..))
 import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
-import ASyntaxUtil (aVars)
+import ASyntaxUtil (aVars, tupleElemRange, argInputPorts)
 import SimCCBlock (SimCCFnStmt(..))
 import SimMakeCBlocks (cvtActions, mkAVMethTmpId)
 import SimPrimitiveModules (primMap, tickElem, tickIsPos, tickIsNeg)
@@ -1115,6 +1115,8 @@ aTypeWidth :: AType -> Word32
 aTypeWidth (ATBit n) = fromIntegral n
 aTypeWidth (ATString _) = 0
 aTypeWidth ATReal = 64
+-- a tuple is a wide bit vector, first element in the MSBs
+aTypeWidth (ATTuple ts) = sum (map aTypeWidth ts)
 aTypeWidth t = internalError ("SimExportIR.aTypeWidth: " ++ ppReadable t)
 
 -- An Integer as little-endian 32-bit limbs (matching WideData layout).
@@ -1139,7 +1141,10 @@ encExpr (ASStr _ _ s) = encVariant "Str" <$> strE s
 encExpr (AMethCall t obj meth args) = do
     o <- idE obj
     m <- idE meth
-    argsEnc <- mapM encExpr args
+    -- one value PER PORT, matching the callee's flattened (concat
+    -- inputs) method-input defs: split-port args (ATuple / tuple-typed
+    -- exprs) expand exactly as the C++ backend's call sites do
+    argsEnc <- mapM encExpr (concatMap argInputPorts args)
     return $ encVariant "MethCall" $ encStruct
       [ ("width", encW32 (aTypeWidth t))
       , ("instance", o)
@@ -1220,6 +1225,33 @@ encExpr (APrim _ t op args) = do
       , ("width", encW32 (aTypeWidth t))
       , ("args", encList argsEnc)
       ]
+-- SplitPorts tuples (multi-output methods) are laid out as wide bit
+-- vectors with the first element in the most-significant bits
+-- (Verilog {e1,...,en}) — the identical lowering the C++ backend
+-- performs (SimCCBlock aExprToCExpr ATuple/ATupleSel), so exporting
+-- the lowered form is byte-parity-correct by construction.  Encoded
+-- as the existing Concat/Extract prims: no BIR change.
+encExpr (ATuple t es) = do
+    argsEnc <- mapM encExpr es
+    return $ encVariant "Prim" $ encStruct
+      [ ("op", encUnitVariant "Concat")
+      , ("width", encW32 (aTypeWidth t))
+      , ("args", encList argsEnc)
+      ]
+encExpr (ATupleSel t e idx) = do
+    -- idx is 1-based (see AConv/AState); tupleElemRange gives the
+    -- element's [hi:lo] over the concatenated layout
+    eEnc <- encExpr e
+    let (hi, lo) = tupleElemRange (ae_type e) idx
+        ixEnc v = encVariant "Const" $ encStruct
+          [ ("width", encW32 32)
+          , ("limbs", encList [encW32 (fromIntegral v)])
+          ]
+    return $ encVariant "Prim" $ encStruct
+      [ ("op", encUnitVariant "Extract")
+      , ("width", encW32 (aTypeWidth t))
+      , ("args", encList [eEnc, ixEnc hi, ixEnc lo])
+      ]
 encExpr e = internalError ("SimExportIR.encExpr: " ++ ppReadable e)
 
 encCaseArms :: [AExpr] -> EncM [C.Encoding]
@@ -1271,7 +1303,8 @@ encAction _ (ACall obj meth (cond : args)) = do
     o <- idE obj
     m <- idE meth
     condEnc <- encExpr cond
-    argsEnc <- mapM encExpr args
+    -- per-port arg expansion: see encExpr (AMethCall ...)
+    argsEnc <- mapM encExpr (concatMap argInputPorts args)
     return $ encVariant "MethCall" $ encStruct
       [ ("instance", o)
       , ("method", m)

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -141,15 +141,19 @@ encStr = C.encodeString . T.pack
 -- SimSystem -> BIR
 
 -- | Encode a 'SimSystem' as a BIR design document.
-simSystemToBir :: Bool -> SimSystem -> L.ByteString
-simSystemToBir keepF ssys = CW.toLazyByteString (encDesign keepF ssys)
+simSystemToBir :: Bool -> M.Map String (S.Set AId) -> SimSystem
+               -> L.ByteString
+simSystemToBir keepF symMap ssys =
+    CW.toLazyByteString (encDesign keepF symMap ssys)
 
 -- | Write the design's .bir file.
-writeBirFile :: FilePath -> Bool -> SimSystem -> IO ()
-writeBirFile path keepF ssys = L.writeFile path (simSystemToBir keepF ssys)
+writeBirFile :: FilePath -> Bool -> M.Map String (S.Set AId) -> SimSystem
+             -> IO ()
+writeBirFile path keepF symMap ssys =
+    L.writeFile path (simSystemToBir keepF symMap ssys)
 
-encDesign :: Bool -> SimSystem -> C.Encoding
-encDesign keepF ssys =
+encDesign :: Bool -> M.Map String (S.Set AId) -> SimSystem -> C.Encoding
+encDesign keepF symMap ssys =
     let pkgs = M.elems (ssys_packages ssys)
         pkgNames = S.fromList (map (getIdBaseString . sp_name) pkgs)
         instmap = M.toList (ssys_instmap ssys)
@@ -169,7 +173,10 @@ encDesign keepF ssys =
         action = do
           topId <- str (getIdBaseString (ssys_top ssys))
           modsEnc <- mapM (\p -> encModule pkgNames
-                                   (msis M.! getIdBaseString (sp_name p)) p)
+                                   (msis M.! getIdBaseString (sp_name p))
+                                   (M.findWithDefault S.empty
+                                      (getIdBaseString (sp_name p)) symMap)
+                                   p)
                           pkgs
           instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
           compsEnc <- concat <$> mapM (encComposition instToMod msis topGates)
@@ -637,8 +644,9 @@ oscName clk = case aclock_osc clk of
 -- ===============
 -- Modules
 
-encModule :: S.Set String -> ModSchedInfo -> SimPackage -> EncM C.Encoding
-encModule pkgNames msi pkg = do
+encModule :: S.Set String -> ModSchedInfo -> S.Set AId -> SimPackage
+          -> EncM C.Encoding
+encModule pkgNames msi symSet pkg = do
     nameId <- idE (sp_name pkg)
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
@@ -666,7 +674,7 @@ encModule pkgNames msi pkg = do
     -- Def-reference results resolve on the backend side
     let av_defs = [ d | AIActionValue { aif_value = d } <- sp_interface pkg
                   , not (M.member (adef_objid d) (sp_local_defs pkg)) ]
-    defsEnc <- mapM encDef (M.elems (sp_local_defs pkg) ++ av_defs)
+    defsEnc <- mapM (encDef symSet) (M.elems (sp_local_defs pkg) ++ av_defs)
     rulesEnc <- mapM (encRule msi pkg) (sp_rules pkg)
     methodsEnc <- concat <$> mapM (encMethod pkg) (sp_interface pkg)
     schedEnc <- encSchedule msi pkg
@@ -889,8 +897,8 @@ substAV (AMethCall ty obj meth es) = AMethCall ty obj meth (map substAV es)
 substAV (AFunCall ty i f isC es) = AFunCall ty i f isC (map substAV es)
 substAV e = e
 
-encDef :: ADef -> EncM C.Encoding
-encDef (ADef i t e0 _props) = do
+encDef :: S.Set AId -> ADef -> EncM C.Encoding
+encDef symSet (ADef i t e0 _props) = do
     let e = substAV e0
     nameId <- idE i
     exprEnc <- encExpr e
@@ -905,6 +913,10 @@ encDef (ADef i t e0 _props) = do
           [ ("can_fire", encBool isCF)
           , ("will_fire", encBool isWF)
           , ("signed", encBool False)   -- P0 TODO: from id props
+          -- the def survives as a C++ MEMBER in the reference
+          -- (post-SimCOpt sb_publicDefs, isOkId-filtered): the
+          -- debug-tier symbol set (bk symbol tree, sim ls)
+          , ("sym", encBool (i `S.member` symSet))
           ])
       ]
 

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -47,9 +47,10 @@ import Id (Id, getIdBaseString, getIdQualString, isSignedId,
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
-import Pragma (RulePragma(..))
+import SCC (tsort)
+import Pragma (RulePragma(..), isAlwaysEn)
 import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..), wpResets)
-import VModInfo (vName, getVNameString, VWireInfo(..), VClockInfo(..))
+import VModInfo (vName, getVNameString, VWireInfo(..), VClockInfo(..), VResetInfo(..))
 import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
 import ASyntaxUtil (aVars)
 import SimCCBlock (SimCCFnStmt(..))
@@ -140,15 +141,15 @@ encStr = C.encodeString . T.pack
 -- SimSystem -> BIR
 
 -- | Encode a 'SimSystem' as a BIR design document.
-simSystemToBir :: SimSystem -> L.ByteString
-simSystemToBir ssys = CW.toLazyByteString (encDesign ssys)
+simSystemToBir :: Bool -> SimSystem -> L.ByteString
+simSystemToBir keepF ssys = CW.toLazyByteString (encDesign keepF ssys)
 
 -- | Write the design's .bir file.
-writeBirFile :: FilePath -> SimSystem -> IO ()
-writeBirFile path ssys = L.writeFile path (simSystemToBir ssys)
+writeBirFile :: FilePath -> Bool -> SimSystem -> IO ()
+writeBirFile path keepF ssys = L.writeFile path (simSystemToBir keepF ssys)
 
-encDesign :: SimSystem -> C.Encoding
-encDesign ssys =
+encDesign :: Bool -> SimSystem -> C.Encoding
+encDesign keepF ssys =
     let pkgs = M.elems (ssys_packages ssys)
         pkgNames = S.fromList (map (getIdBaseString . sp_name) pkgs)
         instmap = M.toList (ssys_instmap ssys)
@@ -186,6 +187,7 @@ encDesign ssys =
             , ("foreign_funcs", encList ffEnc)
             , ("default_clock", encMaybe encW32 clkId)
             , ("default_reset", encMaybe encW32 rstId)
+            , ("keep_fires", encBool keepF)
             ]
 
         (fields, finalTbl) = runState action emptyStrTable
@@ -230,59 +232,6 @@ analyzeModule pkgNames pkg =
         methodNames = S.fromList
             [ getIdBaseString (aif_name f) | f <- sp_interface pkg ]
 
-        -- Rules that call into user-submodule instances are fusion points:
-        -- the merge attaches cross-boundary constraints to them, so each
-        -- gets a singleton segment (a child's segments may have to run
-        -- between two such rules).  Primitive calls don't cut: primitives
-        -- are not scheduled modules.
-        userInsts = S.fromList
-            [ getIdBaseString (avi_vname avi)
-            | avi <- M.elems (sp_state_instances pkg)
-            , getVNameString (vName (avi_vmi avi)) `S.member` pkgNames ]
-
-        defmap = sp_local_defs pkg
-
-        -- transitive def closure from a seed set of ids
-        defClosure :: S.Set AId -> S.Set AId
-        defClosure = go S.empty
-          where go seen pending = case S.minView pending of
-                  Nothing -> seen
-                  Just (i, rest)
-                    | i `S.member` seen -> go seen rest
-                    | otherwise ->
-                        case M.lookup i defmap of
-                          Nothing -> go (S.insert i seen) rest
-                          Just (ADef _ _ e _) ->
-                              go (S.insert i seen)
-                                 (rest `S.union` S.fromList (aVars e))
-
-        exprTouches :: AExpr -> Bool
-        exprTouches (AMethCall _ o _ es) =
-            getIdBaseString o `S.member` userInsts || any exprTouches es
-        exprTouches (AMethValue _ o _) = getIdBaseString o `S.member` userInsts
-        exprTouches (APrim _ _ _ es) = any exprTouches es
-        exprTouches (AFunCall _ _ _ _ es) = any exprTouches es
-        exprTouches _ = False
-
-        defsTouch :: S.Set AId -> Bool
-        defsTouch ids = or [ exprTouches e
-                           | i <- S.toList ids
-                           , Just (ADef _ _ e _) <- [M.lookup i defmap] ]
-
-        actTouches :: AAction -> Bool
-        actTouches (ACall o _ es) =
-            getIdBaseString o `S.member` userInsts || any exprTouches es
-        actTouches a = any exprTouches (aact_args a)
-
-        touchingRules = S.fromList
-            [ getIdBaseString (arule_id r)
-            | r <- sp_rules pkg
-            , let seed = S.fromList
-                    (aVars (arule_pred r)
-                     ++ concatMap aVars (concatMap aact_args (arule_actions r)))
-            , any actTouches (arule_actions r)
-              || defsTouch (defClosure seed) ]
-
         ruleDom :: M.Map String Int
         ruleDom = M.fromList
             [ (getIdBaseString (arule_id r), domOf (arule_wprops r))
@@ -324,41 +273,36 @@ analyzeModule pkgNames pkg =
                                                Just "$stop"])
                   (arule_actions r) ]
 
-        -- Rules in any ME (disjoint) relation also get per-node singleton
-        -- segments: bsc's merged graph carries no ordering edge between ME
-        -- rules, yet its flat order keeps every Sched ahead of the ME
-        -- partner's Exec — reproducing that needs the Sched and Exec
-        -- independently placeable (encComposition adds the unit edges).
-        meRules = S.unions (M.elems disj)
-                  `S.union` S.fromList [ r | (r, ds) <- M.toList disj
-                                           , not (S.null ds) ]
-                  `S.union` finishRules
-
         -- Split this domain's rule nodes into segments: cut at interface
-        -- method positions AND isolate child-calling / ME rules as
-        -- singletons.
+        -- method positions, ONE SEGMENT PER RULE NODE.  Per-node segments
+        -- make the composed order reproduce bsc's flat merged order
+        -- exactly (encComposition's Kahn sort breaks ties by first
+        -- appearance in that order): CF rules carry no ordering edge, yet
+        -- their Exec order is observable through unguarded primitives
+        -- (mkUGFIFOF warn/drop, bsc.lib/getput) and task output, and a
+        -- multi-node segment cannot interleave another instance's Exec
+        -- between its own nodes.  This also keeps every ME/finish
+        -- endpoint independently placeable — including design-level ME
+        -- pairs derived through child methods (combineSchedDRDB), which
+        -- interlocked multi-node segments into a cycle
+        -- (bsc.interra/libraries/SRAMFile) — so the projected unit graph
+        -- is trivially acyclic.
         segsFor :: Int -> [Seg]
         segsFor d =
-            let step (segs, nodes, cut) node =
+            let step (segs, cut) node =
                     let base = getIdBaseString (getSchedNodeId node)
                     in  if base `S.member` methodNames
-                        then (segs, nodes, nub (cut ++ [base]))
+                        then (segs, nub (cut ++ [base]))
                         else if M.lookup base ruleDom /= Just d
-                        then (segs, nodes, cut)
-                        else if base `S.member` touchingRules
-                             || base `S.member` meRules
-                        then -- close any open segment, emit a singleton
-                             let closed = if null nodes && null cut
+                        then (segs, cut)
+                        else let closed = if null cut
                                           then segs
-                                          else segs ++ [Seg nodes cut]
-                             in  (closed ++ [Seg [node] []], [], [])
-                        else if null cut
-                        then (segs, nodes ++ [node], [])
-                        else (segs ++ [Seg nodes cut], [node], [])
-                (segs, nodes, cut) = foldl' step ([], [], []) order
-            in  if null nodes && null cut && not (null segs)
+                                          else segs ++ [Seg [] cut]
+                             in  (closed ++ [Seg [node] []], [])
+                (segs, cut) = foldl' step ([], []) order
+            in  if null cut && not (null segs)
                 then segs
-                else segs ++ [Seg nodes cut]
+                else segs ++ [Seg [] cut]
 
         domSegs = [ (d, segsFor d) | d <- doms ]
 
@@ -574,8 +518,35 @@ encComposition instToMod msis topGates ss = do
                 then Just (getIdQualString prim, getIdBaseString prim,
                            getIdBaseString port, aclock_gate clk)
                 else Nothing
-        all_prims = [ p | di <- M.elems (ss_domain_info_map ss)
-                        , p <- di_prims di ]
+        -- gate-dependency tick order (SimMakeCBlocks.sortTickCalls): a
+        -- group whose ticked prim drives another group's clock GATE runs
+        -- first, so tick gate arguments read post-update values
+        -- (GatedClock chains: bsc.mcd/Gating)
+        all_prims0 = [ p | di <- M.elems (ss_domain_info_map ss)
+                         , p <- di_prims di ]
+        primPathOf i = qp (getIdQualString i) (getIdBaseString i)
+        gateSrcPath (AMGate _ o _) = Just (primPathOf o)
+        gateSrcPath (ASPort _ i)
+            | not (null (getIdQualString i)) = Just (getIdQualString i)
+        gateSrcPath _ = Nothing
+        tickGroups = M.fromListWith (++)
+                       [ (clk, [pr]) | pr@(_, (_, clk)) <- all_prims0 ]
+        -- gate-producing instance path -> the clocks its gate feeds
+        gateClockMap = M.fromListWith (++)
+                         [ (src, [clk])
+                         | clk <- M.keys tickGroups
+                         , Just src <- [gateSrcPath (aclock_gate clk)] ]
+        tickOrderEdges =
+            [ (clk, concat [ M.findWithDefault [] (primPathOf p) gateClockMap
+                           | (p, _) <- prs ])
+            | (clk, prs) <- M.toList tickGroups ]
+        all_prims =
+            case tsort tickOrderEdges of
+              Left is -> internalError
+                ("SimExportIR: cyclic tick gate dependencies: "
+                 ++ ppReadable is)
+              Right cs -> concat [ reverse (M.findWithDefault [] c tickGroups)
+                                 | c <- reverse cs ]
         -- conditional reset ticks (mkResetTickStmt; posedge only), after
         -- the regular ticks; each carries the prim's clock gate
         -- (addGateInfo), with top-level input gates as constant true
@@ -718,6 +689,37 @@ encModule pkgNames msi pkg = do
                        _ -> return constZero
            return (encPair (encW32 pn) oscEnc)
       | f@(AIClock {}) <- sp_interface pkg ]
+    -- interface output clock GATES, keyed by the clock's interface
+    -- method name (what AMGate references): a parent rule that calls a
+    -- method clocked by a child's gated clock reads this through
+    -- Expr::Gate (Bug 1677 lifts the gate into the rule condition)
+    ifcClkGatesEnc <- sequence
+      [ do gn <- str (getIdBaseString (aif_name f))
+           gateEnc <- case aclock_gate (aif_clock f) of
+                        ASPort _ i | not (null (getIdQualString i)) ->
+                            encVariant "Port" <$>
+                              (encW32 <$> str (getIdQualString i ++ "$"
+                                               ++ getIdBaseString i))
+                        g -> encExpr g
+           return (encPair (encW32 gn) gateEnc)
+      | f@(AIClock {}) <- sp_interface pkg ]
+    -- interface output resets: external port name -> the internal reset
+    -- wire being re-exported (parents refer to it as "<inst>$<port>")
+    let orsts = output_resets (wRst (sp_external_wires pkg))
+        orstPortName n = case lookup n orsts of
+                           Just (Just vn, _) -> getVNameString vn
+                           _ -> getIdBaseString n
+        rstWireName i = if null (getIdQualString i)
+                        then getIdBaseString i
+                        else getIdQualString i ++ "$" ++ getIdBaseString i
+    ifcRstsEnc <- sequence
+      [ do pn <- str (orstPortName (aif_name f))
+           wn <- case areset_wire (aif_reset f) of
+                   ASPort _ i -> str (rstWireName i)
+                   ASDef _ i  -> str (rstWireName i)
+                   _          -> str ""
+           return (encPair (encW32 pn) (encW32 wn))
+      | f@(AIReset {}) <- sp_interface pkg ]
     return $ encStruct
       [ ("name", nameId)
       , ("content_hash", encList (replicate 32 (C.encodeWord8 0))) -- P0 TODO
@@ -725,6 +727,8 @@ encModule pkgNames msi pkg = do
       , ("resets", encList rstsEnc)
       , ("inputs", encList insEnc)
       , ("ifc_clocks", encList ifcClksEnc)
+      , ("ifc_clock_gates", encList ifcClkGatesEnc)
+      , ("ifc_resets", encList ifcRstsEnc)
       , ("instances", encList instsEnc)
       , ("defs", encList defsEnc)
       , ("rules", encList rulesEnc)
@@ -924,7 +928,9 @@ bodyStmts pkg rid wprops mretdef acts =
         closure seen (i : rest)
           | i `S.member` seen = closure seen rest
           | otherwise = case M.lookup i defmap of
-              Nothing -> closure (S.insert i seen) rest
+              -- method-argument ports and state ids are not defs; they
+              -- must not reach cvtActions' findDef
+              Nothing -> closure seen rest
               Just (ADef _ _ e _) ->
                   closure (S.insert i seen) (aVars e ++ rest)
         other_defs = case mretdef of
@@ -1054,6 +1060,7 @@ encMethodStructAV pkg name inputs mpred body retdef props = do
       , ("body", bodyEnc)
       , ("result", resultEnc)
       , ("clock_domain", encW32 dom)
+      , ("always_enabled", encBool (isAlwaysEn (sp_pps pkg) name))
       ]
 
 encMethodStruct :: SimPackage -> Id -> String -> [AInput] -> Maybe APred
@@ -1069,6 +1076,8 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
     let dom = case wpClockDomain props of
                 Just (ClockDomain n) -> fromIntegral n
                 Nothing -> 0
+        -- the runtime RDY check only matters for methods with actions
+        ae = kind /= "Value" && isAlwaysEn (sp_pps pkg) name
     return $ encStruct
       [ ("name", nameId)
       , ("kind", encUnitVariant kind)
@@ -1077,6 +1086,7 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
       , ("body", bodyEnc)
       , ("result", encMaybe id resultEnc)
       , ("clock_domain", encW32 dom)
+      , ("always_enabled", encBool ae)
       ]
 
 -- ===============

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -38,12 +38,12 @@ import Data.Word (Word32)
 import qualified Codec.CBOR.Encoding as C
 import qualified Codec.CBOR.Write as CW
 
-import Data.List (foldl', nub)
-import Data.Maybe (mapMaybe)
+import Data.List (foldl', nub, sortBy)
+import Data.Maybe (mapMaybe, isJust)
 
 import ErrorUtil (internalError)
 import Id (Id, getIdBaseString, getIdQualString, isSignedId,
-           mkIdCanFire, mkIdWillFire)
+           mkIdCanFire, mkIdWillFire, cmpIdByName)
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
@@ -156,7 +156,6 @@ encDesign ssys =
         msis = M.fromList [ (getIdBaseString (sp_name p),
                              analyzeModule pkgNames p)
                           | p <- pkgs ]
-        segmaps = M.map msi_segIdx msis
         instToMod = ssys_instmap ssys
 
         -- gates of top-level input clocks are always on in simulation
@@ -171,7 +170,7 @@ encDesign ssys =
                                    (msis M.! getIdBaseString (sp_name p)) p)
                           pkgs
           instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
-          compsEnc <- concat <$> mapM (encComposition instToMod segmaps topGates)
+          compsEnc <- concat <$> mapM (encComposition instToMod msis topGates)
                                        (ssys_schedules ssys)
           clkId <- traverse str (ssys_default_clk ssys)
           rstId <- traverse str (ssys_default_rst ssys)
@@ -211,6 +210,8 @@ data ModSchedInfo = ModSchedInfo
     , msi_segIdx  :: M.Map String ((Int, Int), Int)
     , msi_execPos :: M.Map String Int         -- rule name -> local exec pos
     , msi_disj    :: M.Map String (S.Set String) -- rule -> disjoint rules
+    , msi_taskRules   :: S.Set String  -- rules with system/foreign tasks
+    , msi_finishRules :: S.Set String  -- rules calling $finish/$fatal/$stop
     }
 
 -- Segment lookup key for a schedule node ("S:rule" / "E:rule"), local
@@ -302,6 +303,25 @@ analyzeModule pkgNames pkg =
 
         doms = nub (M.elems ruleDom)
 
+        -- Rules with observable task effects: a $finish/$fatal in one rule
+        -- makes the relative Exec order with any other task-bearing rule
+        -- observable (bk_finished suppresses later output in the same
+        -- instant), so encComposition pins those orders to bsc's flat
+        -- order; finish rules also get singleton segments below
+        actTaskName (AFCall { afcall_fun = f }) = Just f
+        actTaskName (ATaskAction { ataskact_fun = f }) = Just f
+        actTaskName _ = Nothing
+        taskRules = S.fromList
+            [ getIdBaseString (arule_id r)
+            | r <- sp_rules pkg
+            , any (isJust . actTaskName) (arule_actions r) ]
+        finishRules = S.fromList
+            [ getIdBaseString (arule_id r)
+            | r <- sp_rules pkg
+            , any (\a -> actTaskName a `elem` [Just "$finish", Just "$fatal",
+                                               Just "$stop"])
+                  (arule_actions r) ]
+
         -- Rules in any ME (disjoint) relation also get per-node singleton
         -- segments: bsc's merged graph carries no ordering edge between ME
         -- rules, yet its flat order keeps every Sched ahead of the ME
@@ -310,6 +330,7 @@ analyzeModule pkgNames pkg =
         meRules = S.unions (M.elems disj)
                   `S.union` S.fromList [ r | (r, ds) <- M.toList disj
                                            , not (S.null ds) ]
+                  `S.union` finishRules
 
         -- Split this domain's rule nodes into segments: cut at interface
         -- method positions AND isolate child-calling / ME rules as
@@ -350,7 +371,9 @@ analyzeModule pkgNames pkg =
         ModSchedInfo { msi_domains = domSegs
                      , msi_segIdx = segIdx
                      , msi_execPos = execPos
-                     , msi_disj = disj }
+                     , msi_disj = disj
+                     , msi_taskRules = taskRules
+                     , msi_finishRules = finishRules }
 
 -- ===============
 -- Compositions
@@ -363,10 +386,11 @@ qualPath i = case getIdQualString i of
                q   -> q ++ "." ++ getIdBaseString i
 
 encComposition :: M.Map String String
-               -> M.Map String (M.Map String ((Int, Int), Int))
+               -> M.Map String ModSchedInfo
                -> [AId] -> SimSchedule -> EncM [C.Encoding]
-encComposition instToMod segmaps topGates ss = do
-    let order = ss_sched_order ss
+encComposition instToMod msis topGates ss = do
+    let segmaps = M.map msi_segIdx msis
+        order = ss_sched_order ss
 
         -- resolve a merged node to (instance path, segment index) plus
         -- the node's position inside the segment; top-module method nodes
@@ -436,7 +460,35 @@ encComposition instToMod segmaps topGates ss = do
                       ++ qualPath d)
               else True ]
 
-        unitEdges = graphEdges `S.union` meEdges
+        -- $finish/$fatal end output for the rest of the instant, so the
+        -- Exec order between a finish-calling rule and ANY task-bearing
+        -- rule is observable even with no graph edge; pin those pairs to
+        -- bsc's flat order (finish rules have singleton segments)
+        execUnit = M.fromList [ (qualPath n, u)
+                              | e@(Exec n) <- order
+                              , Just u <- [resolve e] ]
+        instMsi i = M.lookup (M.findWithDefault "" i instToMod) msis
+        qualsOf sel = [ q
+                      | i <- nub [ i' | (i', _) <- units ]
+                      , Just msi <- [instMsi i]
+                      , b <- S.toList (sel msi)
+                      , let q = qp i b
+                      , M.member q execPos ]
+        finishQs = qualsOf msi_finishRules
+        taskQs = qualsOf msi_taskRules
+        finishEdges = S.fromList
+            [ (ue, ul)
+            | f <- finishQs
+            , t <- taskQs
+            , f /= t
+            , let (e_, l_) = if execPos M.! f < execPos M.! t
+                             then (f, t)
+                             else (t, f)
+            , Just ue <- [M.lookup e_ execUnit]
+            , Just ul <- [M.lookup l_ execUnit]
+            , ue /= ul ]
+
+        unitEdges = graphEdges `S.union` meEdges `S.union` finishEdges
 
         -- Kahn's algorithm; ties broken by first appearance in the flat
         -- order so the output tracks bsc's own choice.
@@ -469,14 +521,37 @@ encComposition instToMod segmaps topGates ss = do
         execPos = M.fromList [ (qualPath i, p)
                              | (Exec i, p) <- zip order [(0 :: Int) ..] ]
 
-        crossPairs =
-            [ (qualPath r, qualPath d)
-            | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
-            , d <- S.toList ds
-            , getIdQualString r /= getIdQualString d
-            , let pr = M.lookup (qualPath r) execPos
-            , let pd = M.lookup (qualPath d) execPos
-            , maybe False id ((<) <$> pr <*> pd) ]
+        -- ME inhibitors, mkMERuleInhibits semantics against the node
+        -- order the backend actually executes (the composed entries
+        -- expanded to their segment nodes): rule r is inhibited by
+        -- disjoint rule d iff Exec(d) runs before Sched(r).  All pairs
+        -- (same- or cross-instance) export at composition level; the
+        -- per-rule me_inhibits list is empty now that the composed order
+        -- is instance-specific.
+        segNodes inst (dom, seg) =
+            let modName = M.findWithDefault "" inst instToMod
+                segs = case M.lookup modName msis of
+                         Just msi -> case lookup dom (msi_domains msi) of
+                                       Just s -> s
+                                       Nothing -> []
+                         Nothing -> []
+            in  if seg < length segs then seg_nodes (segs !! seg) else []
+        qp i b = if null i then b else i ++ "." ++ b
+        composedNodes =
+            [ (i, node) | (i, ds) <- entries, node <- segNodes i ds ]
+        disjQ = M.fromListWith S.union
+                  ([ (qualPath r, S.map qualPath ds)
+                   | (r, ds) <- M.toList (ss_disjoint_rules_db ss) ]
+                   ++ [ (qualPath d, S.singleton (qualPath r))
+                      | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
+                      , d <- S.toList ds ])
+        stepME (seen, acc) (i, Exec n) =
+            (S.insert (qp i (getIdBaseString n)) seen, acc)
+        stepME (seen, acc) (i, Sched n) =
+            let q = qp i (getIdBaseString n)
+                inh = S.intersection (M.findWithDefault S.empty q disjQ) seen
+            in  (seen, acc ++ [ (d, q) | d <- S.toList inh ])
+        crossPairs = snd (foldl' stepME (S.empty, []) composedNodes)
 
         -- direction-filter the primitive ticks against the primMap tick
         -- specs (doTickCall): a posedge schedule also produces a
@@ -595,8 +670,25 @@ encModule pkgNames msi pkg = do
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
     insEnc <- concat <$> mapM encInput (sp_inputs pkg)
-    instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
-                     (M.elems (sp_state_instances pkg))
+    -- construction order matters for load-time output (RegFileLoad gap
+    -- warnings): match the C++ backend's alphabetization (raw_avis)
+    let avis = sortBy (\a b -> avi_vname a `cmpIdByName` avi_vname b)
+                      (M.elems (sp_state_instances pkg))
+    instsEnc0 <- mapM (encInstance pkgNames (sp_method_order_map pkg)) avis
+    -- noinline functions instantiate as argument-less modules whose one
+    -- value method computes the function
+    niEnc <- mapM (\(iname, mname) -> do
+                     nmEnc <- strE iname
+                     kEnc <- encVariant "Module" <$> strE mname
+                     return $ encStruct
+                       [ ("name", nmEnc)
+                       , ("kind", kEnc)
+                       , ("args", encList [])
+                       , ("method_order", encList [])
+                       , ("port_counts", encList [])
+                       ])
+                  (sp_noinline_instances pkg)
+    let instsEnc = instsEnc0 ++ niEnc
     -- interface ActionValue return defs join the def table so the
     -- Def-reference results resolve on the backend side
     let av_defs = [ d | AIActionValue { aif_value = d } <- sp_interface pkg
@@ -880,15 +972,11 @@ encRule msi pkg r = do
                 Just (ClockDomain n) -> fromIntegral n
                 Nothing -> 0
         crossing = RPclockCrossingRule `elem` arule_pragmas r
-        -- disjoint rules of this module executing earlier in the module's
-        -- own order inhibit this rule (destructive-execution patch;
-        -- cross-module pairs live in the composition)
-        base = getIdBaseString (arule_id r)
-        myPos = M.findWithDefault maxBound base (msi_execPos msi)
-        earlier r' = M.findWithDefault maxBound r' (msi_execPos msi) < myPos
-        inhibits = filter earlier
-                     (S.toList (M.findWithDefault S.empty base (msi_disj msi)))
-    inhibitsEnc <- mapM strE inhibits
+    -- ME inhibitors are all composition-level (cross_inhibits): the
+    -- executed order is instance-specific, so a module-shared list
+    -- cannot express them (and the pragma-asserted pairs must not
+    -- inhibit at all when every Sched runs before its partners' Execs)
+    let inhibitsEnc = [] :: [C.Encoding]
     return $ encStruct
       [ ("name", nameId)
       , ("can_fire", cf)
@@ -972,6 +1060,7 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
 aTypeWidth :: AType -> Word32
 aTypeWidth (ATBit n) = fromIntegral n
 aTypeWidth (ATString _) = 0
+aTypeWidth ATReal = 64
 aTypeWidth t = internalError ("SimExportIR.aTypeWidth: " ++ ppReadable t)
 
 -- An Integer as little-endian 32-bit limbs (matching WideData layout).
@@ -988,6 +1077,7 @@ encExpr (ASInt _ t lit) =
           [ ("width", encW32 w)
           , ("limbs", encList (map encW32 (toLimbs w (ilValue lit))))
           ]
+encExpr (ASReal _ _ d) = return $ encVariant "Real" (C.encodeDouble d)
 encExpr (ASDef _ i) = encVariant "Def" <$> idE i
 encExpr (ASPort _ i) = encVariant "Port" <$> idE i
 encExpr (ASParam _ i) = encVariant "Param" <$> idE i
@@ -1089,6 +1179,7 @@ encCaseArms es =
     internalError ("SimExportIR.encCaseArms: " ++ ppReadable es)
 
 primOpName :: PrimOp -> String
+primOpName PrimStringConcat = "StringConcat"
 primOpName PrimAdd = "Add"
 primOpName PrimSub = "Sub"
 primOpName PrimAnd = "And"

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -56,6 +56,7 @@ import SimCCBlock (SimCCFnStmt(..))
 import SimMakeCBlocks (cvtActions, mkAVMethTmpId)
 import SimPrimitiveModules (primMap, tickElem, tickIsPos, tickIsNeg)
 import SimDomainInfo (DomainInfo(..))
+import ForeignFunctions (ForeignFunction(..), ForeignType(..))
 import ASyntax
 import SimPackage
 
@@ -172,6 +173,7 @@ encDesign ssys =
           instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
           compsEnc <- concat <$> mapM (encComposition instToMod msis topGates)
                                        (ssys_schedules ssys)
+          ffEnc <- mapM encForeignFunc (M.toList (ssys_ffuncmap ssys))
           clkId <- traverse str (ssys_default_clk ssys)
           rstId <- traverse str (ssys_default_rst ssys)
           return
@@ -181,7 +183,7 @@ encDesign ssys =
             , ("modules", encList modsEnc)
             , ("instance_map", encList instEnc)
             , ("compositions", encList compsEnc)
-            , ("foreign_funcs", encList [])  -- P0 TODO: from ssys_ffuncmap
+            , ("foreign_funcs", encList ffEnc)
             , ("default_clock", encMaybe encW32 clkId)
             , ("default_reset", encMaybe encW32 rstId)
             ]
@@ -793,6 +795,29 @@ encReset (rid, rst) = do
       [ ("id", encW32 (fromIntegral (writeResetId rid)))
       , ("wire", wireEnc)
       ]
+
+-- BDPI import signatures; the C ABI is fixed by toCtype/mkFFDecl:
+-- narrow by value, wide/poly as unsigned int* limb pointers, strings as
+-- char*, wide/poly returns via a first-argument out-pointer.
+encForeignFunc :: (String, ForeignFunction) -> EncM C.Encoding
+encForeignFunc (linkname, FF fname rt ats) = do
+    nm <- strE linkname
+    cn <- idE fname
+    argsEnc <- mapM encForeignType ats
+    retEnc <- encForeignType rt
+    return $ encStruct
+      [ ("name", nm)
+      , ("c_name", cn)
+      , ("ret", retEnc)
+      , ("args", encList argsEnc)
+      ]
+
+encForeignType :: ForeignType -> EncM C.Encoding
+encForeignType Void = return $ encUnitVariant "Void"
+encForeignType (Narrow n) = return $ encVariant "Bits" (encW32 (fromIntegral n))
+encForeignType (Wide n) = return $ encVariant "Wide" (encW32 (fromIntegral n))
+encForeignType Polymorphic = return $ encUnitVariant "Poly"
+encForeignType StringPtr = return $ encUnitVariant "CString"
 
 encInput :: AAbstractInput -> EncM [C.Encoding]
 encInput (AAI_Port (i, t)) = (: []) <$> encPort (i, t) "MethodArg"

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -874,7 +874,14 @@ encInstance pkgNames mom avi = do
                 return $ encVariant "Prim"
                            (encVariant "Other" (encStruct [("name", mEnc)]))
     argsEnc <- mapM encExpr (avi_iargs avi)
-    let morder = S.toList (M.findWithDefault S.empty (avi_vname avi) mom)
+    -- name-sorted: the set is (AId, AId) pairs and AId's Ord follows
+    -- run/context-dependent interned-FString order — the encoded list
+    -- is a constraint RELATION, so canonical order is free (and .bir
+    -- bytes must not shift when batch vs -c/-e compilation changes
+    -- interning order)
+    let morder = sortBy (\(a, b) (c, d) ->
+                           (a `cmpIdByName` c) <> (b `cmpIdByName` d))
+                        (S.toList (M.findWithDefault S.empty (avi_vname avi) mom))
     morderEnc <- mapM (\(a, b) -> encPair <$> idE a <*> idE b) morder
     portsEnc <- mapM (\(m, n) -> encPair <$> idE m
                                          <*> pure (encW32 (fromIntegral n)))

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -53,7 +53,7 @@ import VModInfo (vName, getVNameString)
 import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
 import ASyntaxUtil (aVars)
 import SimCCBlock (SimCCFnStmt(..))
-import SimMakeCBlocks (cvtActions)
+import SimMakeCBlocks (cvtActions, mkAVMethTmpId)
 import SimDomainInfo (DomainInfo(..))
 import ASyntax
 import SimPackage
@@ -474,7 +474,11 @@ encModule pkgNames msi pkg = do
     insEnc <- mapM encInput (sp_inputs pkg)
     instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
                      (M.elems (sp_state_instances pkg))
-    defsEnc <- mapM encDef (M.elems (sp_local_defs pkg))
+    -- interface ActionValue return defs join the def table so the
+    -- Def-reference results resolve on the backend side
+    let av_defs = [ d | AIActionValue { aif_value = d } <- sp_interface pkg
+                  , not (M.member (adef_objid d) (sp_local_defs pkg)) ]
+    defsEnc <- mapM encDef (M.elems (sp_local_defs pkg) ++ av_defs)
     rulesEnc <- mapM (encRule msi pkg) (sp_rules pkg)
     methodsEnc <- concat <$> mapM (encMethod pkg) (sp_interface pkg)
     schedEnc <- encSchedule msi pkg
@@ -605,8 +609,19 @@ encInstance pkgNames mom avi = do
       , ("port_counts", encList portsEnc)
       ]
 
+-- ActionValue results are read through the synthetic temp def that the
+-- corresponding AvAction statement latches -- never by re-invoking the
+-- method (mirrors substAV, SimMakeCBlocks.hs:1481-1482).
+substAV :: AExpr -> AExpr
+substAV (AMethValue ty obj meth) = ASDef ty (mkAVMethTmpId obj meth)
+substAV (APrim i ty op es) = APrim i ty op (map substAV es)
+substAV (AMethCall ty obj meth es) = AMethCall ty obj meth (map substAV es)
+substAV (AFunCall ty i f isC es) = AFunCall ty i f isC (map substAV es)
+substAV e = e
+
 encDef :: ADef -> EncM C.Encoding
-encDef (ADef i t e _props) = do
+encDef (ADef i t e0 _props) = do
+    let e = substAV e0
     nameId <- idE i
     exprEnc <- encExpr e
     let base = getIdBaseString i
@@ -626,23 +641,40 @@ encDef (ADef i t e _props) = do
 -- The exact def/action interleaving that Bluesim executes: reuse the
 -- backend's own linearization (tsortActionsAndDefs via cvtActions) and
 -- encode its statement list.
-bodyStmts :: SimPackage -> Id -> WireProps -> S.Set AId -> [AAction]
+bodyStmts :: SimPackage -> Id -> WireProps -> Maybe ADef -> [AAction]
           -> [SimCCFnStmt]
-bodyStmts pkg rid wprops other_defs acts =
+bodyStmts pkg rid wprops mretdef acts =
     let reset_ids = [ ae_objid (areset_wire rst)
                     | n <- wpResets wprops
                     , Just rst <- [lookup n (sp_reset_list pkg)] ]
-    in  cvtActions (sp_name pkg) rid (sp_local_defs pkg)
+        -- an ActionValue return def joins the linearization so its reads
+        -- are positioned by the method-order edges (a deq-then-return-
+        -- first method must read first before the deq; cvtIFace does the
+        -- same, SimMakeCBlocks.hs:560-575)
+        defmap = case mretdef of
+                   Just d -> M.insert (adef_objid d) d (sp_local_defs pkg)
+                   Nothing -> sp_local_defs pkg
+        closure seen [] = seen
+        closure seen (i : rest)
+          | i `S.member` seen = closure seen rest
+          | otherwise = case M.lookup i defmap of
+              Nothing -> closure (S.insert i seen) rest
+              Just (ADef _ _ e _) ->
+                  closure (S.insert i seen) (aVars e ++ rest)
+        other_defs = case mretdef of
+                       Just d -> closure S.empty [adef_objid d]
+                       Nothing -> S.empty
+    in  cvtActions (sp_name pkg) rid defmap
                    (sp_method_order_map pkg) other_defs acts reset_ids
 
 type SignedOracle = AId -> Bool
 
 encStmt :: SignedOracle -> SimCCFnStmt -> EncM C.Encoding
-encStmt _ (SFSDef _ (_, i) (Just _)) = encVariant "Def" <$> idE i
+encStmt _ (SFSDef _ (_, i) (Just e)) = encDefStmt i e
 encStmt _ (SFSDef _ _ Nothing) =
     -- declaration only (e.g. a task temp); the Task action fills it
     return mempty
-encStmt _ (SFSAssign _ i _) = encVariant "Def" <$> idE i
+encStmt _ (SFSAssign _ i e) = encDefStmt i e
 encStmt sgn (SFSAction act) = encVariant "Action" <$> encAction sgn act
 encStmt sgn (SFSAssignAction _ i act _) = do
     dE <- idE i
@@ -656,6 +688,17 @@ encStmt sgn (SFSCond c ts es) = do
                (encStruct [("cond", cE), ("then_", tE), ("else_", eE)])
 encStmt _ s = internalError ("SimExportIR.encStmt: " ++ ppReadable s)
 
+-- The statement's own expression is authoritative (it carries the
+-- tsort's ActionValue substitutions, which the def table may not after
+-- inlining re-embedded calls); substAV catches AMethValue forms the
+-- tsort leaves for the reader.
+encDefStmt :: AId -> AExpr -> EncM C.Encoding
+encDefStmt i e = do
+    nameE <- idE i
+    exprE <- encExpr (substAV e)
+    return $ encVariant "Def"
+               (encStruct [("name", nameE), ("expr", exprE)])
+
 -- mempty markers from declaration-only stmts must not appear in the list
 encStmts :: SignedOracle -> [SimCCFnStmt] -> EncM C.Encoding
 encStmts sgn stmts = do
@@ -664,14 +707,12 @@ encStmts sgn stmts = do
     encList <$> mapM (encStmt sgn) (filter keep stmts)
 
 -- Signed display for a system-task argument: encodeArgs's "-" prefix
--- checks the referenced Id's sign property; the property may live on the
--- reference or on the def's own id (removeSignCasts rewrites both ways).
+-- checks exactly the referenced Id's sign property
+-- (ForeignFunctions.hs:258).  Checking the def's own id as well
+-- over-flags and widens columns Bluesim prints unsigned (found by the
+-- sweep regressing when it was tried).
 mkSignedOracle :: SimPackage -> SignedOracle
-mkSignedOracle pkg i =
-    isSignedId i
-    || case M.lookup i (sp_local_defs pkg) of
-         Just (ADef di _ _ _) -> isSignedId di
-         Nothing -> False
+mkSignedOracle _ = isSignedId
 
 encRule :: ModSchedInfo -> SimPackage -> ARule -> EncM C.Encoding
 encRule msi pkg r = do
@@ -685,7 +726,7 @@ encRule msi pkg r = do
     wf <- idE (mkIdWillFire (arule_id r))
     bodyEnc <- encStmts (mkSignedOracle pkg)
                         (bodyStmts pkg (arule_id r) (arule_wprops r)
-                                   S.empty (arule_actions r))
+                                   Nothing (arule_actions r))
     let dom = case wpClockDomain (arule_wprops r) of
                 Just (ClockDomain n) -> fromIntegral n
                 Nothing -> 0
@@ -720,13 +761,38 @@ encMethod pkg (AIAction inputs props pred_ name body _) = do
     m <- encMethodStruct pkg name "Action" (concat inputs) (Just pred_)
                          (concatMap arule_actions body) Nothing props
     return [m]
-encMethod pkg (AIActionValue inputs props pred_ name body (ADef _ t e _) _) = do
-    m <- encMethodStruct pkg name "ActionValue" (concat inputs) (Just pred_)
-                         (concatMap arule_actions body) (Just (t, e)) props
+encMethod pkg (AIActionValue inputs props pred_ name body retdef _) = do
+    m <- encMethodStructAV pkg name (concat inputs) (Just pred_)
+                           (concatMap arule_actions body) retdef props
     return [m]
 encMethod _ (AIClock {}) = return []
 encMethod _ (AIReset {}) = return []
 encMethod _ (AIInout {}) = return []
+
+-- ActionValue methods: the return def is linearized with the body and
+-- the result is a reference to it.
+encMethodStructAV :: SimPackage -> Id -> [AInput] -> Maybe APred
+                  -> [AAction] -> ADef -> WireProps -> EncM C.Encoding
+encMethodStructAV pkg name inputs mpred body retdef props = do
+    nameId <- idE name
+    argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
+    readyEnc <- traverse encExpr mpred
+    bodyEnc <- encStmts (mkSignedOracle pkg)
+                        (bodyStmts pkg name props (Just retdef) body)
+    let ADef ret_id rt _ _ = retdef
+    resultEnc <- encExpr (ASDef rt ret_id)
+    let dom = case wpClockDomain props of
+                Just (ClockDomain n) -> fromIntegral n
+                Nothing -> 0
+    return $ encStruct
+      [ ("name", nameId)
+      , ("kind", encUnitVariant "ActionValue")
+      , ("args", encList argsEnc)
+      , ("ready", encMaybe id readyEnc)
+      , ("body", bodyEnc)
+      , ("result", resultEnc)
+      , ("clock_domain", encW32 dom)
+      ]
 
 encMethodStruct :: SimPackage -> Id -> String -> [AInput] -> Maybe APred
                 -> [AAction] -> Maybe (AType, AExpr) -> WireProps
@@ -735,14 +801,8 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
     readyEnc <- traverse encExpr mpred
-    -- defs the result expression needs must be computed with the body
-    -- (an ActionValue's return can depend on the body's effects order)
-    let result_defs = case mresult of
-          Just (_, e) -> S.fromList
-              [ i | i <- aVars e, i `M.member` sp_local_defs pkg ]
-          Nothing -> S.empty
     bodyEnc <- encStmts (mkSignedOracle pkg)
-                        (bodyStmts pkg name props result_defs body)
+                        (bodyStmts pkg name props Nothing body)
     resultEnc <- traverse (encExpr . snd) mresult
     let dom = case wpClockDomain props of
                 Just (ClockDomain n) -> fromIntegral n

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -635,31 +635,43 @@ bodyStmts pkg rid wprops other_defs acts =
     in  cvtActions (sp_name pkg) rid (sp_local_defs pkg)
                    (sp_method_order_map pkg) other_defs acts reset_ids
 
-encStmt :: SimCCFnStmt -> EncM C.Encoding
-encStmt (SFSDef _ (_, i) (Just _)) = encVariant "Def" <$> idE i
-encStmt (SFSDef _ _ Nothing) =
+type SignedOracle = AId -> Bool
+
+encStmt :: SignedOracle -> SimCCFnStmt -> EncM C.Encoding
+encStmt _ (SFSDef _ (_, i) (Just _)) = encVariant "Def" <$> idE i
+encStmt _ (SFSDef _ _ Nothing) =
     -- declaration only (e.g. a task temp); the Task action fills it
     return mempty
-encStmt (SFSAssign _ i _) = encVariant "Def" <$> idE i
-encStmt (SFSAction act) = encVariant "Action" <$> encAction act
-encStmt (SFSAssignAction _ i act _) = do
+encStmt _ (SFSAssign _ i _) = encVariant "Def" <$> idE i
+encStmt sgn (SFSAction act) = encVariant "Action" <$> encAction sgn act
+encStmt sgn (SFSAssignAction _ i act _) = do
     dE <- idE i
-    aE <- encAction act
+    aE <- encAction sgn act
     return $ encVariant "AvAction" (encStruct [("def", dE), ("action", aE)])
-encStmt (SFSCond c ts es) = do
+encStmt sgn (SFSCond c ts es) = do
     cE <- encExpr c
-    tE <- encStmts ts
-    eE <- encStmts es
+    tE <- encStmts sgn ts
+    eE <- encStmts sgn es
     return $ encVariant "Cond"
                (encStruct [("cond", cE), ("then_", tE), ("else_", eE)])
-encStmt s = internalError ("SimExportIR.encStmt: " ++ ppReadable s)
+encStmt _ s = internalError ("SimExportIR.encStmt: " ++ ppReadable s)
 
 -- mempty markers from declaration-only stmts must not appear in the list
-encStmts :: [SimCCFnStmt] -> EncM C.Encoding
-encStmts stmts = do
+encStmts :: SignedOracle -> [SimCCFnStmt] -> EncM C.Encoding
+encStmts sgn stmts = do
     let keep (SFSDef _ _ Nothing) = False
         keep _ = True
-    encList <$> mapM encStmt (filter keep stmts)
+    encList <$> mapM (encStmt sgn) (filter keep stmts)
+
+-- Signed display for a system-task argument: encodeArgs's "-" prefix
+-- checks the referenced Id's sign property; the property may live on the
+-- reference or on the def's own id (removeSignCasts rewrites both ways).
+mkSignedOracle :: SimPackage -> SignedOracle
+mkSignedOracle pkg i =
+    isSignedId i
+    || case M.lookup i (sp_local_defs pkg) of
+         Just (ADef di _ _ _) -> isSignedId di
+         Nothing -> False
 
 encRule :: ModSchedInfo -> SimPackage -> ARule -> EncM C.Encoding
 encRule msi pkg r = do
@@ -671,7 +683,8 @@ encRule msi pkg r = do
                  _         -> mkIdCanFire (arule_id r)
     cf <- idE cfId
     wf <- idE (mkIdWillFire (arule_id r))
-    bodyEnc <- encStmts (bodyStmts pkg (arule_id r) (arule_wprops r)
+    bodyEnc <- encStmts (mkSignedOracle pkg)
+                        (bodyStmts pkg (arule_id r) (arule_wprops r)
                                    S.empty (arule_actions r))
     let dom = case wpClockDomain (arule_wprops r) of
                 Just (ClockDomain n) -> fromIntegral n
@@ -728,7 +741,8 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
           Just (_, e) -> S.fromList
               [ i | i <- aVars e, i `M.member` sp_local_defs pkg ]
           Nothing -> S.empty
-    bodyEnc <- encStmts (bodyStmts pkg name props result_defs body)
+    bodyEnc <- encStmts (mkSignedOracle pkg)
+                        (bodyStmts pkg name props result_defs body)
     resultEnc <- traverse (encExpr . snd) mresult
     let dom = case wpClockDomain props of
                 Just (ClockDomain n) -> fromIntegral n
@@ -820,6 +834,12 @@ encExpr (ASReset _ rst) = do
     return $ encVariant "Reset" $ encStruct
       [ ("wire", wireEnc)
       ]
+encExpr (APrim _ _ PrimResetUnassertedVal []) =
+    -- the value of an unasserted reset wire (active-low convention: 1)
+    return $ encVariant "Const" $ encStruct
+      [ ("width", encW32 1)
+      , ("limbs", encList [encW32 1])
+      ]
 encExpr (APrim _ t PrimIf [c, x, y]) = do
     cEnc <- encExpr c
     xEnc <- encExpr x
@@ -892,8 +912,8 @@ primOpName op = internalError ("SimExportIR.primOpName: " ++ show op)
 -- ===============
 -- Actions
 
-encAction :: AAction -> EncM C.Encoding
-encAction (ACall obj meth (cond : args)) = do
+encAction :: SignedOracle -> AAction -> EncM C.Encoding
+encAction _ (ACall obj meth (cond : args)) = do
     o <- idE obj
     m <- idE meth
     condEnc <- encExpr cond
@@ -905,7 +925,7 @@ encAction (ACall obj meth (cond : args)) = do
       , ("cond", condEnc)
       , ("args", encList argsEnc)
       ]
-encAction (AFCall _ fun _ (cond : args) _) = do
+encAction sgn (AFCall _ fun _ (cond : args) _) = do
     f <- strE fun
     condEnc <- encExpr cond
     argsEnc <- mapM encExpr args
@@ -913,9 +933,9 @@ encAction (AFCall _ fun _ (cond : args) _) = do
       [ ("func", f)
       , ("cond", condEnc)
       , ("args", encList argsEnc)
-      , ("signed", encList (map (encBool . argSigned) args))
+      , ("signed", encList (map (encBool . argSigned sgn) args))
       ]
-encAction (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
+encAction sgn (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
     f <- strE fun
     tempEnc <- traverse idE mtemp
     condEnc <- encExpr cond
@@ -927,12 +947,13 @@ encAction (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
       , ("width", encW32 (aTypeWidth mty))
       , ("cond", condEnc)
       , ("args", encList argsEnc)
-      , ("signed", encList (map (encBool . argSigned) args))
+      , ("signed", encList (map (encBool . argSigned sgn) args))
       ]
-encAction a = internalError ("SimExportIR.encAction: " ++ ppReadable a)
+encAction _ a = internalError ("SimExportIR.encAction: " ++ ppReadable a)
 
 -- Signed-display flag for a system-task argument: matches encodeArgs's
--- "-" prefix rule (ForeignFunctions.hs:256-262).
-argSigned :: AExpr -> Bool
-argSigned (ASDef _ aid) = isSignedId aid
-argSigned _ = False
+-- "-" prefix rule (ForeignFunctions.hs:256-262), extended with the def
+-- table (the sign property may be on the def rather than the reference).
+argSigned :: SignedOracle -> AExpr -> Bool
+argSigned sgn (ASDef _ aid) = sgn aid
+argSigned _ _ = False

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -38,14 +38,19 @@ import Data.Word (Word32)
 import qualified Codec.CBOR.Encoding as C
 import qualified Codec.CBOR.Write as CW
 
+import Data.List (foldl', nub)
+import Data.Maybe (mapMaybe)
+
 import ErrorUtil (internalError)
-import Id (Id, getIdBaseString, mkIdCanFire, mkIdWillFire)
+import Id (Id, getIdBaseString, getIdQualString, mkIdCanFire, mkIdWillFire)
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
 import Pragma (RulePragma(..))
 import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..))
 import VModInfo (vName, getVNameString)
+import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
+import SimDomainInfo (DomainInfo(..))
 import ASyntax
 import SimPackage
 
@@ -142,11 +147,21 @@ encDesign ssys =
         pkgNames = S.fromList (map (getIdBaseString . sp_name) pkgs)
         instmap = M.toList (ssys_instmap ssys)
 
+        -- per-module schedule analysis (segments, exec order, disjointness)
+        msis = M.fromList [ (getIdBaseString (sp_name p), analyzeModule p)
+                          | p <- pkgs ]
+        segmaps = M.map msi_segIdx msis
+        instToMod = ssys_instmap ssys
+
         action :: EncM [(String, C.Encoding)]
         action = do
           topId <- str (getIdBaseString (ssys_top ssys))
-          modsEnc <- mapM (encModule pkgNames) pkgs
+          modsEnc <- mapM (\p -> encModule pkgNames
+                                   (msis M.! getIdBaseString (sp_name p)) p)
+                          pkgs
           instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
+          compsEnc <- mapM (encComposition instToMod segmaps)
+                           (ssys_schedules ssys)
           clkId <- traverse str (ssys_default_clk ssys)
           rstId <- traverse str (ssys_default_rst ssys)
           return
@@ -155,7 +170,7 @@ encDesign ssys =
             , ("top", encW32 topId)
             , ("modules", encList modsEnc)
             , ("instance_map", encList instEnc)
-            , ("compositions", encList [])   -- P0 TODO: schedule composition
+            , ("compositions", encList compsEnc)
             , ("foreign_funcs", encList [])  -- P0 TODO: from ssys_ffuncmap
             , ("default_clock", encMaybe encW32 clkId)
             , ("default_reset", encMaybe encW32 rstId)
@@ -168,10 +183,226 @@ encDesign ssys =
     in  encStruct fields'
 
 -- ===============
+-- Module-local schedule analysis (BIR.md section 4)
+--
+-- A module's own schedule order (asi_sched_order) contains its rule nodes
+-- AND its interface-method nodes; the method positions are the only points
+-- where the outside world can interleave (the merge fuses method nodes
+-- into calling parent rules).  Cutting at method positions yields the
+-- per-module-type segments; the design-level composition then references
+-- (instance, segment).
+
+data Seg = Seg { seg_nodes :: [SchedNode], seg_cut :: [String] }
+
+data ModSchedInfo = ModSchedInfo
+    { msi_domains :: [(Int, [Seg])]           -- per clock domain
+    , msi_segIdx  :: M.Map String Int         -- node key -> segment index
+    , msi_execPos :: M.Map String Int         -- rule name -> local exec pos
+    , msi_disj    :: M.Map String (S.Set String) -- rule -> disjoint rules
+    }
+
+-- Segment lookup key for a schedule node ("S:rule" / "E:rule"), local
+-- (unqualified) name.
+nodeKey :: SchedNode -> String
+nodeKey (Sched i) = "S:" ++ getIdBaseString i
+nodeKey (Exec i) = "E:" ++ getIdBaseString i
+
+analyzeModule :: SimPackage -> ModSchedInfo
+analyzeModule pkg =
+    let asi = sp_schedule pkg
+        order = asi_sched_order asi
+
+        methodNames = S.fromList
+            [ getIdBaseString (aif_name f) | f <- sp_interface pkg ]
+
+        ruleDom :: M.Map String Int
+        ruleDom = M.fromList
+            [ (getIdBaseString (arule_id r), domOf (arule_wprops r))
+            | r <- sp_rules pkg ]
+        domOf wp = case wpClockDomain wp of
+                     Just (ClockDomain n) -> n
+                     Nothing -> 0
+
+        execPos = M.fromList
+            [ (getIdBaseString i, p)
+            | (Exec i, p) <- zip order [(0 :: Int) ..] ]
+
+        disj0 = exclRulesDBToDisjRulesDB (asi_exclusive_rules_db asi)
+        isRule s = M.member s ruleDom
+        disj = M.fromList
+            [ (rs, S.filter isRule (S.map getIdBaseString ds))
+            | (r, ds) <- M.toList disj0
+            , let rs = getIdBaseString r
+            , isRule rs ]
+
+        doms = nub (M.elems ruleDom)
+
+        -- Split this domain's rule nodes into segments at method positions.
+        segsFor :: Int -> [Seg]
+        segsFor d =
+            let step (segs, nodes, cut) node =
+                    let base = getIdBaseString (getSchedNodeId node)
+                    in  if base `S.member` methodNames
+                        then (segs, nodes, nub (cut ++ [base]))
+                        else if M.lookup base ruleDom == Just d
+                        then if null cut
+                             then (segs, nodes ++ [node], [])
+                             else (segs ++ [Seg nodes cut], [node], [])
+                        else (segs, nodes, cut)
+                (segs, nodes, cut) = foldl' step ([], [], []) order
+            in  if null nodes && null cut && not (null segs)
+                then segs
+                else segs ++ [Seg nodes cut]
+
+        domSegs = [ (d, segsFor d) | d <- doms ]
+
+        -- keyed per node, not per rule: a method cut can fall between a
+        -- rule's Sched and Exec, putting them in different segments
+        segIdx = M.fromList
+            [ (nodeKey n, i)
+            | (_, segs) <- domSegs
+            , (i, seg) <- zip [(0 :: Int) ..] segs
+            , n <- seg_nodes seg ]
+    in
+        ModSchedInfo { msi_domains = domSegs
+                     , msi_segIdx = segIdx
+                     , msi_execPos = execPos
+                     , msi_disj = disj }
+
+-- ===============
+-- Compositions
+
+-- Qualified rule path: "inst.path.RL_rule" (the merge stores the instance
+-- path in the Id qualifier, qualifyChildId).
+qualPath :: Id -> String
+qualPath i = case getIdQualString i of
+               ""  -> getIdBaseString i
+               q   -> q ++ "." ++ getIdBaseString i
+
+encComposition :: M.Map String String -> M.Map String (M.Map String Int)
+               -> SimSchedule -> EncM C.Encoding
+encComposition instToMod segmaps ss = do
+    let order = ss_sched_order ss
+
+        -- resolve a merged node to (instance path, segment index);
+        -- top-module method nodes resolve to Nothing and are skipped
+        resolve node =
+            let i = getSchedNodeId node
+                inst = getIdQualString i
+                key = case node of
+                        Sched _ -> "S:" ++ getIdBaseString i
+                        Exec _ -> "E:" ++ getIdBaseString i
+                modName = case M.lookup inst instToMod of
+                            Just m -> m
+                            Nothing -> internalError
+                              ("SimExportIR: unknown instance " ++ show inst)
+                segmap = M.findWithDefault M.empty modName segmaps
+            in  (,) inst <$> M.lookup key segmap
+
+        -- The flat merged order freely interleaves Sched and Exec nodes of
+        -- different instances, so it cannot be collapsed into segment runs
+        -- directly.  Instead, project the merged constraint graph onto
+        -- (instance, segment) units and topologically sort those; the
+        -- BIR.md section 4 argument (cross-instance constraints only
+        -- attach at method cut points) makes this projection acyclic.
+        units = nub (mapMaybe resolve order)
+        firstPos = M.fromList
+            (reverse [ (u, p)
+                     | (p, Just u) <- zip [(0 :: Int) ..] (map resolve order) ])
+
+        unitEdges = S.fromList
+            [ (pu, nu)
+            | (n, preds) <- ss_sched_graph ss
+            , Just nu <- [resolve n]
+            , p <- preds
+            , Just pu <- [resolve p]
+            , pu /= nu ]
+
+        -- Kahn's algorithm; ties broken by first appearance in the flat
+        -- order so the output tracks bsc's own choice.
+        succsOf u = [ b | (a, b) <- S.toList unitEdges, a == u ]
+        indeg0 = M.fromListWith (+)
+                   ([ (u, 0 :: Int) | u <- units ]
+                    ++ [ (b, 1) | (_, b) <- S.toList unitEdges ])
+        pickNext ready = case ready of
+            [] -> Nothing
+            _  -> Just (snd (minimum
+                    [ (M.findWithDefault maxBound u firstPos, u)
+                    | u <- ready ]))
+        kahn indeg done
+            | Just u <- pickNext
+                [ v | (v, d) <- M.toList indeg, d == 0 ] =
+                let indeg' = M.delete u indeg
+                    indeg'' = foldl' (\m v -> M.adjust (subtract 1) v m)
+                                     indeg' (succsOf u)
+                in  kahn indeg'' (u : done)
+            | M.null indeg = reverse done
+            | otherwise = internalError
+                ("SimExportIR: cyclic segment graph; a module boundary is "
+                 ++ "interleaved below method granularity: "
+                 ++ show (M.keys indeg))
+        entries = kahn indeg0 []
+
+        dups = length entries /= S.size (S.fromList entries)
+
+        execPos = M.fromList [ (qualPath i, p)
+                             | (Exec i, p) <- zip order [(0 :: Int) ..] ]
+
+        crossPairs =
+            [ (qualPath r, qualPath d)
+            | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
+            , d <- S.toList ds
+            , getIdQualString r /= getIdQualString d
+            , let pr = M.lookup (qualPath r) execPos
+            , let pd = M.lookup (qualPath d) execPos
+            , maybe False id ((<) <$> pr <*> pd) ]
+
+        ticks = [ (getIdQualString prim, getIdBaseString prim,
+                   getIdBaseString port)
+                | di <- M.elems (ss_domain_info_map ss)
+                , (prim, (port, _)) <- di_prims di ]
+
+    if dups
+      then internalError ("SimExportIR: non-contiguous segment interleaving; "
+                          ++ "composition needs graph-based derivation")
+      else do
+        clkId <- str (oscName (ss_clock ss))
+        entriesEnc <- mapM (\(inst, seg) -> do
+                              instE <- strE inst
+                              return $ encStruct
+                                [ ("instance", instE)
+                                , ("segment", encW32 (fromIntegral seg))
+                                ])
+                           entries
+        ticksEnc <- mapM (\(inst, prim, port) -> do
+                            iE <- strE inst
+                            pE <- strE prim
+                            oE <- strE port
+                            return $ encStruct
+                              [ ("instance", iE), ("prim", pE), ("port", oE) ])
+                         ticks
+        earlyEnc <- mapM (strE . qualPath) (ss_early_rules ss)
+        crossEnc <- mapM (\(a, b) -> encPair <$> strE a <*> strE b) crossPairs
+        return $ encStruct
+          [ ("clock", encW32 clkId)
+          , ("posedge", encBool (ss_posedge ss))
+          , ("entries", encList entriesEnc)
+          , ("ticks", encList ticksEnc)
+          , ("early", encList earlyEnc)
+          , ("cross_inhibits", encList crossEnc)
+          ]
+
+oscName :: AClock -> String
+oscName clk = case aclock_osc clk of
+                ASPort _ i -> getIdBaseString i
+                ASDef _ i -> getIdBaseString i
+                e -> ppReadable e
+
+-- ===============
 -- Modules
 
-encModule :: S.Set String -> SimPackage -> EncM C.Encoding
-encModule pkgNames pkg = do
+encModule :: S.Set String -> ModSchedInfo -> SimPackage -> EncM C.Encoding
+encModule pkgNames msi pkg = do
     nameId <- idE (sp_name pkg)
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
@@ -179,8 +410,9 @@ encModule pkgNames pkg = do
     instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
                      (M.elems (sp_state_instances pkg))
     defsEnc <- mapM encDef (M.elems (sp_local_defs pkg))
-    rulesEnc <- mapM encRule (sp_rules pkg)
+    rulesEnc <- mapM (encRule msi) (sp_rules pkg)
     methodsEnc <- concat <$> mapM encMethod (sp_interface pkg)
+    schedEnc <- encSchedule msi pkg
     return $ encStruct
       [ ("name", nameId)
       , ("content_hash", encList (replicate 32 (C.encodeWord8 0))) -- P0 TODO
@@ -191,17 +423,54 @@ encModule pkgNames pkg = do
       , ("defs", encList defsEnc)
       , ("rules", encList rulesEnc)
       , ("methods", encList methodsEnc)
-      , ("schedule", encSchedule)
+      , ("schedule", schedEnc)
       ]
 
--- P0 TODO: segmented per-(domain,edge) schedules (BIR.md section 4).
-encSchedule :: C.Encoding
-encSchedule =
-    encStruct
-      [ ("domains", encList [])
-      , ("conflicts", encList [])
-      , ("disjoint", encList [])
+encSchedule :: ModSchedInfo -> SimPackage -> EncM C.Encoding
+encSchedule msi pkg = do
+    domsEnc <- mapM encModSched (msi_domains msi)
+    let esposito = case asch_scheduler (asi_schedule (sp_schedule pkg)) of
+                     [ASchedEsposito pairs] -> pairs
+                     scheds -> concat [ ps | ASchedEsposito ps <- scheds ]
+    conflictsEnc <- mapM (\(r, blockers) -> do
+                            rE <- idE r
+                            bsE <- mapM idE blockers
+                            return (encPair rE (encList bsE)))
+                         esposito
+    disjEnc <- mapM (\(r, ds) -> do
+                       rE <- strE r
+                       dsE <- mapM strE (S.toList ds)
+                       return (encPair rE (encList dsE)))
+                    (M.toList (msi_disj msi))
+    return $ encStruct
+      [ ("domains", encList domsEnc)
+      , ("conflicts", encList conflictsEnc)
+      , ("disjoint", encList disjEnc)
       ]
+
+encModSched :: (Int, [Seg]) -> EncM C.Encoding
+encModSched (d, segs) = do
+    segsEnc <- mapM encSeg segs
+    return $ encStruct
+      [ ("domain", encW32 (fromIntegral d))
+      , ("posedge", encBool True)   -- P0 TODO: negedge-triggered domains
+      , ("segments", encList segsEnc)
+      -- P0 TODO: per-module tick order (composition carries ticks for now)
+      , ("ticks", encList [])
+      ]
+
+encSeg :: Seg -> EncM C.Encoding
+encSeg seg = do
+    nodesEnc <- mapM encSchedNode (seg_nodes seg)
+    cutEnc <- mapM strE (seg_cut seg)
+    return $ encStruct
+      [ ("nodes", encList nodesEnc)
+      , ("cut", encList cutEnc)
+      ]
+
+encSchedNode :: SchedNode -> EncM C.Encoding
+encSchedNode (Sched i) = encVariant "Sched" <$> idE i
+encSchedNode (Exec i) = encVariant "Exec" <$> idE i
 
 encClockDomain :: AClockDomain -> EncM C.Encoding
 encClockDomain (ClockDomain n, clocks) = do
@@ -289,8 +558,8 @@ encDef (ADef i t e _props) = do
           ])
       ]
 
-encRule :: ARule -> EncM C.Encoding
-encRule r = do
+encRule :: ModSchedInfo -> ARule -> EncM C.Encoding
+encRule msi r = do
     nameId <- idE (arule_id r)
     -- The predicate is a reference to the CAN_FIRE def after
     -- aAddScheduleDefs; recover the def names.
@@ -304,6 +573,15 @@ encRule r = do
                 Just (ClockDomain n) -> fromIntegral n
                 Nothing -> 0
         crossing = RPclockCrossingRule `elem` arule_pragmas r
+        -- disjoint rules of this module executing earlier in the module's
+        -- own order inhibit this rule (destructive-execution patch;
+        -- cross-module pairs live in the composition)
+        base = getIdBaseString (arule_id r)
+        myPos = M.findWithDefault maxBound base (msi_execPos msi)
+        earlier r' = M.findWithDefault maxBound r' (msi_execPos msi) < myPos
+        inhibits = filter earlier
+                     (S.toList (M.findWithDefault S.empty base (msi_disj msi)))
+    inhibitsEnc <- mapM strE inhibits
     return $ encStruct
       [ ("name", nameId)
       , ("can_fire", cf)
@@ -311,7 +589,7 @@ encRule r = do
       , ("body", encList bodyEnc)
       , ("clock_domain", encW32 dom)
       , ("crossing", encBool crossing)
-      , ("me_inhibits", encList [])   -- P0 TODO: with segmented schedules
+      , ("me_inhibits", encList inhibitsEnc)
       ]
 
 -- Interface methods.  Clock/reset/inout interface entries carry no

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -152,7 +152,8 @@ encDesign ssys =
         instmap = M.toList (ssys_instmap ssys)
 
         -- per-module schedule analysis (segments, exec order, disjointness)
-        msis = M.fromList [ (getIdBaseString (sp_name p), analyzeModule p)
+        msis = M.fromList [ (getIdBaseString (sp_name p),
+                             analyzeModule pkgNames p)
                           | p <- pkgs ]
         segmaps = M.map msi_segIdx msis
         instToMod = ssys_instmap ssys
@@ -211,13 +212,66 @@ nodeKey :: SchedNode -> String
 nodeKey (Sched i) = "S:" ++ getIdBaseString i
 nodeKey (Exec i) = "E:" ++ getIdBaseString i
 
-analyzeModule :: SimPackage -> ModSchedInfo
-analyzeModule pkg =
+analyzeModule :: S.Set String -> SimPackage -> ModSchedInfo
+analyzeModule pkgNames pkg =
     let asi = sp_schedule pkg
         order = asi_sched_order asi
 
         methodNames = S.fromList
             [ getIdBaseString (aif_name f) | f <- sp_interface pkg ]
+
+        -- Rules that call into user-submodule instances are fusion points:
+        -- the merge attaches cross-boundary constraints to them, so each
+        -- gets a singleton segment (a child's segments may have to run
+        -- between two such rules).  Primitive calls don't cut: primitives
+        -- are not scheduled modules.
+        userInsts = S.fromList
+            [ getIdBaseString (avi_vname avi)
+            | avi <- M.elems (sp_state_instances pkg)
+            , getVNameString (vName (avi_vmi avi)) `S.member` pkgNames ]
+
+        defmap = sp_local_defs pkg
+
+        -- transitive def closure from a seed set of ids
+        defClosure :: S.Set AId -> S.Set AId
+        defClosure = go S.empty
+          where go seen pending = case S.minView pending of
+                  Nothing -> seen
+                  Just (i, rest)
+                    | i `S.member` seen -> go seen rest
+                    | otherwise ->
+                        case M.lookup i defmap of
+                          Nothing -> go (S.insert i seen) rest
+                          Just (ADef _ _ e _) ->
+                              go (S.insert i seen)
+                                 (rest `S.union` S.fromList (aVars e))
+
+        exprTouches :: AExpr -> Bool
+        exprTouches (AMethCall _ o _ es) =
+            getIdBaseString o `S.member` userInsts || any exprTouches es
+        exprTouches (AMethValue _ o _) = getIdBaseString o `S.member` userInsts
+        exprTouches (APrim _ _ _ es) = any exprTouches es
+        exprTouches (AFunCall _ _ _ _ es) = any exprTouches es
+        exprTouches _ = False
+
+        defsTouch :: S.Set AId -> Bool
+        defsTouch ids = or [ exprTouches e
+                           | i <- S.toList ids
+                           , Just (ADef _ _ e _) <- [M.lookup i defmap] ]
+
+        actTouches :: AAction -> Bool
+        actTouches (ACall o _ es) =
+            getIdBaseString o `S.member` userInsts || any exprTouches es
+        actTouches a = any exprTouches (aact_args a)
+
+        touchingRules = S.fromList
+            [ getIdBaseString (arule_id r)
+            | r <- sp_rules pkg
+            , let seed = S.fromList
+                    (aVars (arule_pred r)
+                     ++ concatMap aVars (concatMap aact_args (arule_actions r)))
+            , any actTouches (arule_actions r)
+              || defsTouch (defClosure seed) ]
 
         ruleDom :: M.Map String Int
         ruleDom = M.fromList
@@ -241,18 +295,25 @@ analyzeModule pkg =
 
         doms = nub (M.elems ruleDom)
 
-        -- Split this domain's rule nodes into segments at method positions.
+        -- Split this domain's rule nodes into segments: cut at interface
+        -- method positions AND isolate child-calling rules as singletons.
         segsFor :: Int -> [Seg]
         segsFor d =
             let step (segs, nodes, cut) node =
                     let base = getIdBaseString (getSchedNodeId node)
                     in  if base `S.member` methodNames
                         then (segs, nodes, nub (cut ++ [base]))
-                        else if M.lookup base ruleDom == Just d
-                        then if null cut
-                             then (segs, nodes ++ [node], [])
-                             else (segs ++ [Seg nodes cut], [node], [])
-                        else (segs, nodes, cut)
+                        else if M.lookup base ruleDom /= Just d
+                        then (segs, nodes, cut)
+                        else if base `S.member` touchingRules
+                        then -- close any open segment, emit a singleton
+                             let closed = if null nodes && null cut
+                                          then segs
+                                          else segs ++ [Seg nodes cut]
+                             in  (closed ++ [Seg [node] []], [], [])
+                        else if null cut
+                        then (segs, nodes ++ [node], [])
+                        else (segs ++ [Seg nodes cut], [node], [])
                 (segs, nodes, cut) = foldl' step ([], [], []) order
             in  if null nodes && null cut && not (null segs)
                 then segs

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -49,11 +49,12 @@ import PPrint (ppReadable)
 import Prim (PrimOp(..))
 import Pragma (RulePragma(..))
 import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..), wpResets)
-import VModInfo (vName, getVNameString)
+import VModInfo (vName, getVNameString, VWireInfo(..), VClockInfo(..))
 import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
 import ASyntaxUtil (aVars)
 import SimCCBlock (SimCCFnStmt(..))
 import SimMakeCBlocks (cvtActions, mkAVMethTmpId)
+import SimPrimitiveModules (primMap, tickElem, tickIsPos, tickIsNeg)
 import SimDomainInfo (DomainInfo(..))
 import ASyntax
 import SimPackage
@@ -158,6 +159,11 @@ encDesign ssys =
         segmaps = M.map msi_segIdx msis
         instToMod = ssys_instmap ssys
 
+        -- gates of top-level input clocks are always on in simulation
+        -- (mkScheduleStmts top_gates)
+        top_pkg = findPkg (ssys_packages ssys) (ssys_top ssys)
+        topGates = [ gate | (AAI_Clock _ (Just gate)) <- sp_inputs top_pkg ]
+
         action :: EncM [(String, C.Encoding)]
         action = do
           topId <- str (getIdBaseString (ssys_top ssys))
@@ -165,8 +171,8 @@ encDesign ssys =
                                    (msis M.! getIdBaseString (sp_name p)) p)
                           pkgs
           instEnc <- mapM (\(p, m) -> encPair <$> strE p <*> strE m) instmap
-          compsEnc <- mapM (encComposition instToMod segmaps)
-                           (ssys_schedules ssys)
+          compsEnc <- concat <$> mapM (encComposition instToMod segmaps topGates)
+                                       (ssys_schedules ssys)
           clkId <- traverse str (ssys_default_clk ssys)
           rstId <- traverse str (ssys_default_rst ssys)
           return
@@ -201,7 +207,8 @@ data Seg = Seg { seg_nodes :: [SchedNode], seg_cut :: [String] }
 
 data ModSchedInfo = ModSchedInfo
     { msi_domains :: [(Int, [Seg])]           -- per clock domain
-    , msi_segIdx  :: M.Map String Int         -- node key -> segment index
+      -- node key -> ((domain, segment), position within segment)
+    , msi_segIdx  :: M.Map String ((Int, Int), Int)
     , msi_execPos :: M.Map String Int         -- rule name -> local exec pos
     , msi_disj    :: M.Map String (S.Set String) -- rule -> disjoint rules
     }
@@ -295,8 +302,18 @@ analyzeModule pkgNames pkg =
 
         doms = nub (M.elems ruleDom)
 
+        -- Rules in any ME (disjoint) relation also get per-node singleton
+        -- segments: bsc's merged graph carries no ordering edge between ME
+        -- rules, yet its flat order keeps every Sched ahead of the ME
+        -- partner's Exec — reproducing that needs the Sched and Exec
+        -- independently placeable (encComposition adds the unit edges).
+        meRules = S.unions (M.elems disj)
+                  `S.union` S.fromList [ r | (r, ds) <- M.toList disj
+                                           , not (S.null ds) ]
+
         -- Split this domain's rule nodes into segments: cut at interface
-        -- method positions AND isolate child-calling rules as singletons.
+        -- method positions AND isolate child-calling / ME rules as
+        -- singletons.
         segsFor :: Int -> [Seg]
         segsFor d =
             let step (segs, nodes, cut) node =
@@ -306,6 +323,7 @@ analyzeModule pkgNames pkg =
                         else if M.lookup base ruleDom /= Just d
                         then (segs, nodes, cut)
                         else if base `S.member` touchingRules
+                             || base `S.member` meRules
                         then -- close any open segment, emit a singleton
                              let closed = if null nodes && null cut
                                           then segs
@@ -324,10 +342,10 @@ analyzeModule pkgNames pkg =
         -- keyed per node, not per rule: a method cut can fall between a
         -- rule's Sched and Exec, putting them in different segments
         segIdx = M.fromList
-            [ (nodeKey n, i)
-            | (_, segs) <- domSegs
+            [ (nodeKey n, ((d, i), j))
+            | (d, segs) <- domSegs
             , (i, seg) <- zip [(0 :: Int) ..] segs
-            , n <- seg_nodes seg ]
+            , (j, n) <- zip [(0 :: Int) ..] (seg_nodes seg) ]
     in
         ModSchedInfo { msi_domains = domSegs
                      , msi_segIdx = segIdx
@@ -344,14 +362,16 @@ qualPath i = case getIdQualString i of
                ""  -> getIdBaseString i
                q   -> q ++ "." ++ getIdBaseString i
 
-encComposition :: M.Map String String -> M.Map String (M.Map String Int)
-               -> SimSchedule -> EncM C.Encoding
-encComposition instToMod segmaps ss = do
+encComposition :: M.Map String String
+               -> M.Map String (M.Map String ((Int, Int), Int))
+               -> [AId] -> SimSchedule -> EncM [C.Encoding]
+encComposition instToMod segmaps topGates ss = do
     let order = ss_sched_order ss
 
-        -- resolve a merged node to (instance path, segment index);
-        -- top-module method nodes resolve to Nothing and are skipped
-        resolve node =
+        -- resolve a merged node to (instance path, segment index) plus
+        -- the node's position inside the segment; top-module method nodes
+        -- resolve to Nothing and are skipped
+        resolveFull node =
             let i = getSchedNodeId node
                 inst = getIdQualString i
                 key = case node of
@@ -362,7 +382,8 @@ encComposition instToMod segmaps ss = do
                             Nothing -> internalError
                               ("SimExportIR: unknown instance " ++ show inst)
                 segmap = M.findWithDefault M.empty modName segmaps
-            in  (,) inst <$> M.lookup key segmap
+            in  (\(ds, j) -> ((inst, ds), j)) <$> M.lookup key segmap
+        resolve node = fst <$> resolveFull node
 
         -- The flat merged order freely interleaves Sched and Exec nodes of
         -- different instances, so it cannot be collapsed into segment runs
@@ -375,13 +396,47 @@ encComposition instToMod segmaps ss = do
             (reverse [ (u, p)
                      | (p, Just u) <- zip [(0 :: Int) ..] (map resolve order) ])
 
-        unitEdges = S.fromList
+        graphEdges = S.fromList
             [ (pu, nu)
             | (n, preds) <- ss_sched_graph ss
             , Just nu <- [resolve n]
             , p <- preds
             , Just pu <- [resolve p]
             , pu /= nu ]
+
+        -- ME (disjoint) rule pairs have no graph edge, but bsc's flat
+        -- order still fixes which state snapshot each guard observes: if
+        -- Sched r precedes Exec d there, r's guard must not see d's
+        -- writes.  Restore that as a unit edge (analyzeModule gives ME
+        -- rules singleton per-node segments so the endpoints are
+        -- independently placeable).  A same-unit pair is only legal if
+        -- the segment's internal order already agrees.
+        schedPosQ = M.fromList [ (qualPath i, p)
+                               | (Sched i, p) <- zip order [(0 :: Int) ..] ]
+        mePairs = nub ([ (r, d)
+                       | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
+                       , d <- S.toList ds ]
+                       ++ [ (d, r)
+                          | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
+                          , d <- S.toList ds ])
+        meEdges = S.fromList
+            [ (su, eu)
+            | (r, d) <- mePairs
+            , Just ps <- [M.lookup (qualPath r) schedPosQ]
+            , Just pe <- [M.lookup (qualPath d) execPos]
+            , ps < pe
+            , Just (su, sj) <- [resolveFull (Sched r)]
+            , Just (eu, ej) <- [resolveFull (Exec d)]
+            , if su == eu
+              then if sj < ej
+                   then False  -- ordered inside the segment already
+                   else internalError
+                     ("SimExportIR: ME pair straddles a segment against "
+                      ++ "its flat order: " ++ qualPath r ++ " / "
+                      ++ qualPath d)
+              else True ]
+
+        unitEdges = graphEdges `S.union` meEdges
 
         -- Kahn's algorithm; ties broken by first appearance in the flat
         -- order so the output tracks bsc's own choice.
@@ -404,7 +459,8 @@ encComposition instToMod segmaps ss = do
             | M.null indeg = reverse done
             | otherwise = internalError
                 ("SimExportIR: cyclic segment graph; a module boundary is "
-                 ++ "interleaved below method granularity: "
+                 ++ "interleaved below method granularity (or ME ordering "
+                 ++ "constraints interlock two multi-node segments): "
                  ++ show (M.keys indeg))
         entries = kahn indeg0 []
 
@@ -422,40 +478,107 @@ encComposition instToMod segmaps ss = do
             , let pd = M.lookup (qualPath d) execPos
             , maybe False id ((<) <$> pr <*> pd) ]
 
-        ticks = [ (getIdQualString prim, getIdBaseString prim,
-                   getIdBaseString port)
-                | di <- M.elems (ss_domain_info_map ss)
-                , (prim, (port, _)) <- di_prims di ]
+        -- direction-filter the primitive ticks against the primMap tick
+        -- specs (doTickCall): a posedge schedule also produces a
+        -- negedge tick function for Neg/Both ports (SyncBit05/15,
+        -- ClockInverter, GatedClock)
+        tickFor wantPos (prim, (port, clk)) =
+            let pname = M.findWithDefault "" (getIdQualString prim
+                                              ++ (if null (getIdQualString prim)
+                                                  then "" else ".")
+                                              ++ getIdBaseString prim)
+                                             instToMod
+                tick_specs = case [ l | (n, _, _, l) <- primMap, n == pname ] of
+                               (l : _) -> l
+                               [] -> []
+                dir_ok = if wantPos then tickIsPos else tickIsNeg
+            in  if any (\td -> tickElem td == getIdBaseString port && dir_ok td)
+                       tick_specs
+                then Just (getIdQualString prim, getIdBaseString prim,
+                           getIdBaseString port, aclock_gate clk)
+                else Nothing
+        all_prims = [ p | di <- M.elems (ss_domain_info_map ss)
+                        , p <- di_prims di ]
+        -- conditional reset ticks (mkResetTickStmt; posedge only), after
+        -- the regular ticks; each carries the prim's clock gate
+        -- (addGateInfo), with top-level input gates as constant true
+        inst_clk_map = M.fromList [ ((i, c), ac)
+                                  | di <- M.elems (ss_domain_info_map ss)
+                                  , (i, (c, ac)) <- di_prims di ]
+        rstGate prim clkarg =
+            case M.lookup (prim, clkarg) inst_clk_map of
+              Just ac -> case aclock_gate ac of
+                           (ASPort _ portId) | portId `elem` topGates -> aTrue
+                           g -> g
+              Nothing -> internalError
+                ("SimExportIR: no primitive info for " ++ ppReadable prim
+                 ++ " with clock " ++ ppReadable clkarg)
+        rst_ticks = [ (getIdQualString prim, getIdBaseString prim,
+                       getIdBaseString clkarg, rstGate prim clkarg)
+                    | di <- M.elems (ss_domain_info_map ss)
+                    , (prim, clkarg) <- di_prim_resets di ]
+        ticks = [ (i, p, o, False, g)
+                | (i, p, o, g) <- mapMaybe (tickFor True) all_prims ]
+                ++ [ (i, p, o, True, g) | (i, p, o, g) <- rst_ticks ]
+        neg_ticks = [ (i, p, o, False, g)
+                    | (i, p, o, g) <- mapMaybe (tickFor False) all_prims ]
 
     if dups
       then internalError ("SimExportIR: non-contiguous segment interleaving; "
                           ++ "composition needs graph-based derivation")
       else do
         clkId <- str (oscName (ss_clock ss))
-        entriesEnc <- mapM (\(inst, seg) -> do
+        entriesEnc <- mapM (\(inst, (dom, seg)) -> do
                               instE <- strE inst
                               return $ encStruct
                                 [ ("instance", instE)
+                                , ("domain", encW32 (fromIntegral dom))
                                 , ("segment", encW32 (fromIntegral seg))
                                 ])
                            entries
-        ticksEnc <- mapM (\(inst, prim, port) -> do
-                            iE <- strE inst
-                            pE <- strE prim
-                            oE <- strE port
-                            return $ encStruct
-                              [ ("instance", iE), ("prim", pE), ("port", oE) ])
-                         ticks
+        let encTick (inst, prim, port, rst, gate) = do
+              iE <- strE inst
+              pE <- strE prim
+              oE <- strE port
+              gateE <- case gate of
+                         -- constant-true gates encode as None
+                         ASInt _ _ il | ilValue il == 1 -> return C.encodeNull
+                         -- design-level gate wires carry the instance
+                         -- path in the qualifier; flatten it into the
+                         -- port name so the backend can resolve it
+                         ASPort _ i | not (null (getIdQualString i)) ->
+                           encVariant "Port"
+                             <$> (encW32 <$> str (getIdQualString i ++ "$"
+                                                  ++ getIdBaseString i))
+                         g -> encExpr g
+              return $ encStruct
+                [ ("instance", iE), ("prim", pE), ("port", oE)
+                , ("reset", encBool rst), ("gate", gateE) ]
+        ticksEnc <- mapM encTick ticks
+        negTicksEnc <- mapM encTick neg_ticks
         earlyEnc <- mapM (strE . qualPath) (ss_early_rules ss)
         crossEnc <- mapM (\(a, b) -> encPair <$> strE a <*> strE b) crossPairs
-        return $ encStruct
-          [ ("clock", encW32 clkId)
-          , ("posedge", encBool (ss_posedge ss))
-          , ("entries", encList entriesEnc)
-          , ("ticks", encList ticksEnc)
-          , ("early", encList earlyEnc)
-          , ("cross_inhibits", encList crossEnc)
-          ]
+        let posComp = encStruct
+              [ ("clock", encW32 clkId)
+              , ("posedge", encBool (ss_posedge ss))
+              , ("entries", encList entriesEnc)
+              , ("ticks", encList ticksEnc)
+              , ("early", encList earlyEnc)
+              , ("cross_inhibits", encList crossEnc)
+              ]
+            -- a posedge schedule also owns the opposite edge's tick
+            -- function (SimMakeCBlocks builds pos and neg tick stmts
+            -- from the same schedule); export the Neg/Both ticks as a
+            -- rule-less negedge composition
+            negComp = encStruct
+              [ ("clock", encW32 clkId)
+              , ("posedge", encBool (not (ss_posedge ss)))
+              , ("entries", encList [])
+              , ("ticks", encList negTicksEnc)
+              , ("early", encList [])
+              , ("cross_inhibits", encList [])
+              ]
+        return $ if null neg_ticks then [posComp] else [posComp, negComp]
 
 oscName :: AClock -> String
 oscName clk = case aclock_osc clk of
@@ -471,7 +594,7 @@ encModule pkgNames msi pkg = do
     nameId <- idE (sp_name pkg)
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
-    insEnc <- mapM encInput (sp_inputs pkg)
+    insEnc <- concat <$> mapM encInput (sp_inputs pkg)
     instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
                      (M.elems (sp_state_instances pkg))
     -- interface ActionValue return defs join the def table so the
@@ -482,12 +605,32 @@ encModule pkgNames msi pkg = do
     rulesEnc <- mapM (encRule msi pkg) (sp_rules pkg)
     methodsEnc <- concat <$> mapM (encMethod pkg) (sp_interface pkg)
     schedEnc <- encSchedule msi pkg
+    -- interface output clocks: external port name -> the internal osc
+    -- wire being re-exported (constant = noClock, never ticks)
+    let oclks = output_clocks (wClk (sp_external_wires pkg))
+        oclkPortName n = case lookup n oclks of
+                           Just (Just (vn, _)) -> getVNameString vn
+                           _ -> "CLK_" ++ getIdBaseString n
+        constZero = encVariant "Const" $ encStruct
+                      [ ("width", encW32 1), ("limbs", encList [encW32 0]) ]
+    ifcClksEnc <- sequence
+      [ do pn <- str (oclkPortName (aif_name f))
+           oscEnc <- case aclock_osc (aif_clock f) of
+                       ASPort _ i | not (null (getIdQualString i)) ->
+                           encVariant "Port" <$>
+                             (encW32 <$> str (getIdQualString i ++ "$"
+                                              ++ getIdBaseString i))
+                       p@(ASPort {}) -> encExpr p
+                       _ -> return constZero
+           return (encPair (encW32 pn) oscEnc)
+      | f@(AIClock {}) <- sp_interface pkg ]
     return $ encStruct
       [ ("name", nameId)
       , ("content_hash", encList (replicate 32 (C.encodeWord8 0))) -- P0 TODO
       , ("clock_domains", encList domsEnc)
       , ("resets", encList rstsEnc)
       , ("inputs", encList insEnc)
+      , ("ifc_clocks", encList ifcClksEnc)
       , ("instances", encList instsEnc)
       , ("defs", encList defsEnc)
       , ("rules", encList rulesEnc)
@@ -559,14 +702,20 @@ encReset (rid, rst) = do
       , ("wire", wireEnc)
       ]
 
-encInput :: AAbstractInput -> EncM C.Encoding
-encInput (AAI_Port (i, t)) = encPort (i, t) "MethodArg"
-encInput (AAI_Clock osc _mgate) = do
+encInput :: AAbstractInput -> EncM [C.Encoding]
+encInput (AAI_Port (i, t)) = (: []) <$> encPort (i, t) "MethodArg"
+encInput (AAI_Clock osc mgate) = do
     n <- idE osc
-    return $ encPortRaw n 1 "Clock"
+    -- a gated input clock also has a gate wire (e.g. CLK_GATE_gclk),
+    -- referenced by rule guards; it follows its Clock port so the
+    -- backend can bind both from one Clock{osc,gate} instantiation arg
+    gateEnc <- traverse (\g -> do gn <- idE g
+                                  return (encPortRaw gn 1 "ClockGate"))
+                        mgate
+    return (encPortRaw n 1 "Clock" : maybe [] (: []) gateEnc)
 encInput (AAI_Reset r) = do
     n <- idE r
-    return $ encPortRaw n 1 "Reset"
+    return [encPortRaw n 1 "Reset"]
 encInput (AAI_Inout {}) =
     internalError "SimExportIR.encInput: Inout not supported by Bluesim"
 

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -42,14 +42,18 @@ import Data.List (foldl', nub)
 import Data.Maybe (mapMaybe)
 
 import ErrorUtil (internalError)
-import Id (Id, getIdBaseString, getIdQualString, mkIdCanFire, mkIdWillFire)
+import Id (Id, getIdBaseString, getIdQualString, isSignedId,
+           mkIdCanFire, mkIdWillFire)
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
 import Pragma (RulePragma(..))
-import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..))
+import Wires (ClockDomain(..), ResetId, writeResetId, WireProps(..), wpResets)
 import VModInfo (vName, getVNameString)
 import AScheduleInfo (AScheduleInfo(..), SchedNode(..), getSchedNodeId)
+import ASyntaxUtil (aVars)
+import SimCCBlock (SimCCFnStmt(..))
+import SimMakeCBlocks (cvtActions)
 import SimDomainInfo (DomainInfo(..))
 import ASyntax
 import SimPackage
@@ -410,8 +414,8 @@ encModule pkgNames msi pkg = do
     instsEnc <- mapM (encInstance pkgNames (sp_method_order_map pkg))
                      (M.elems (sp_state_instances pkg))
     defsEnc <- mapM encDef (M.elems (sp_local_defs pkg))
-    rulesEnc <- mapM (encRule msi) (sp_rules pkg)
-    methodsEnc <- concat <$> mapM encMethod (sp_interface pkg)
+    rulesEnc <- mapM (encRule msi pkg) (sp_rules pkg)
+    methodsEnc <- concat <$> mapM (encMethod pkg) (sp_interface pkg)
     schedEnc <- encSchedule msi pkg
     return $ encStruct
       [ ("name", nameId)
@@ -558,8 +562,40 @@ encDef (ADef i t e _props) = do
           ])
       ]
 
-encRule :: ModSchedInfo -> ARule -> EncM C.Encoding
-encRule msi r = do
+-- The exact def/action interleaving that Bluesim executes: reuse the
+-- backend's own linearization (tsortActionsAndDefs via cvtActions) and
+-- encode its statement list.
+bodyStmts :: SimPackage -> Id -> WireProps -> S.Set AId -> [AAction]
+          -> [SimCCFnStmt]
+bodyStmts pkg rid wprops other_defs acts =
+    let reset_ids = [ ae_objid (areset_wire rst)
+                    | n <- wpResets wprops
+                    , Just rst <- [lookup n (sp_reset_list pkg)] ]
+    in  cvtActions (sp_name pkg) rid (sp_local_defs pkg)
+                   (sp_method_order_map pkg) other_defs acts reset_ids
+
+encStmt :: SimCCFnStmt -> EncM C.Encoding
+encStmt (SFSDef _ (_, i) (Just _)) = encVariant "Def" <$> idE i
+encStmt (SFSDef _ _ Nothing) =
+    -- declaration only (e.g. a task temp); the Task action fills it
+    return mempty
+encStmt (SFSAssign _ i _) = encVariant "Def" <$> idE i
+encStmt (SFSAction act) = encVariant "Action" <$> encAction act
+encStmt (SFSAssignAction _ i act _) = do
+    dE <- idE i
+    aE <- encAction act
+    return $ encVariant "AvAction" (encStruct [("def", dE), ("action", aE)])
+encStmt s = internalError ("SimExportIR.encStmt: " ++ ppReadable s)
+
+-- mempty markers from declaration-only stmts must not appear in the list
+encStmts :: [SimCCFnStmt] -> EncM C.Encoding
+encStmts stmts = do
+    let keep (SFSDef _ _ Nothing) = False
+        keep _ = True
+    encList <$> mapM encStmt (filter keep stmts)
+
+encRule :: ModSchedInfo -> SimPackage -> ARule -> EncM C.Encoding
+encRule msi pkg r = do
     nameId <- idE (arule_id r)
     -- The predicate is a reference to the CAN_FIRE def after
     -- aAddScheduleDefs; recover the def names.
@@ -568,7 +604,8 @@ encRule msi r = do
                  _         -> mkIdCanFire (arule_id r)
     cf <- idE cfId
     wf <- idE (mkIdWillFire (arule_id r))
-    bodyEnc <- mapM encAction (arule_actions r)
+    bodyEnc <- encStmts (bodyStmts pkg (arule_id r) (arule_wprops r)
+                                   S.empty (arule_actions r))
     let dom = case wpClockDomain (arule_wprops r) of
                 Just (ClockDomain n) -> fromIntegral n
                 Nothing -> 0
@@ -586,7 +623,7 @@ encRule msi r = do
       [ ("name", nameId)
       , ("can_fire", cf)
       , ("will_fire", wf)
-      , ("body", encList bodyEnc)
+      , ("body", bodyEnc)
       , ("clock_domain", encW32 dom)
       , ("crossing", encBool crossing)
       , ("me_inhibits", encList inhibitsEnc)
@@ -594,29 +631,37 @@ encRule msi r = do
 
 -- Interface methods.  Clock/reset/inout interface entries carry no
 -- executable content (they are in the clock/reset lists); skip them.
-encMethod :: AIFace -> EncM [C.Encoding]
-encMethod (AIDef name inputs props pred_ (ADef _ t e _) _ _) = do
-    m <- encMethodStruct name "Value" (concat inputs) (Just pred_) [] (Just (t, e)) props
+encMethod :: SimPackage -> AIFace -> EncM [C.Encoding]
+encMethod pkg (AIDef name inputs props pred_ (ADef _ t e _) _ _) = do
+    m <- encMethodStruct pkg name "Value" (concat inputs) (Just pred_) [] (Just (t, e))
+                         props
     return [m]
-encMethod (AIAction inputs props pred_ name body _) = do
-    m <- encMethodStruct name "Action" (concat inputs) (Just pred_)
+encMethod pkg (AIAction inputs props pred_ name body _) = do
+    m <- encMethodStruct pkg name "Action" (concat inputs) (Just pred_)
                          (concatMap arule_actions body) Nothing props
     return [m]
-encMethod (AIActionValue inputs props pred_ name body (ADef _ t e _) _) = do
-    m <- encMethodStruct name "ActionValue" (concat inputs) (Just pred_)
+encMethod pkg (AIActionValue inputs props pred_ name body (ADef _ t e _) _) = do
+    m <- encMethodStruct pkg name "ActionValue" (concat inputs) (Just pred_)
                          (concatMap arule_actions body) (Just (t, e)) props
     return [m]
-encMethod (AIClock {}) = return []
-encMethod (AIReset {}) = return []
-encMethod (AIInout {}) = return []
+encMethod _ (AIClock {}) = return []
+encMethod _ (AIReset {}) = return []
+encMethod _ (AIInout {}) = return []
 
-encMethodStruct :: Id -> String -> [AInput] -> Maybe APred -> [AAction]
-                -> Maybe (AType, AExpr) -> WireProps -> EncM C.Encoding
-encMethodStruct name kind inputs mpred body mresult props = do
+encMethodStruct :: SimPackage -> Id -> String -> [AInput] -> Maybe APred
+                -> [AAction] -> Maybe (AType, AExpr) -> WireProps
+                -> EncM C.Encoding
+encMethodStruct pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
     readyEnc <- traverse encExpr mpred
-    bodyEnc <- mapM encAction body
+    -- defs the result expression needs must be computed with the body
+    -- (an ActionValue's return can depend on the body's effects order)
+    let result_defs = case mresult of
+          Just (_, e) -> S.fromList
+              [ i | i <- aVars e, i `M.member` sp_local_defs pkg ]
+          Nothing -> S.empty
+    bodyEnc <- encStmts (bodyStmts pkg name props result_defs body)
     resultEnc <- traverse (encExpr . snd) mresult
     let dom = case wpClockDomain props of
                 Just (ClockDomain n) -> fromIntegral n
@@ -626,7 +671,7 @@ encMethodStruct name kind inputs mpred body mresult props = do
       , ("kind", encUnitVariant kind)
       , ("args", encList argsEnc)
       , ("ready", encMaybe id readyEnc)
-      , ("body", encList bodyEnc)
+      , ("body", bodyEnc)
       , ("result", encMaybe id resultEnc)
       , ("clock_domain", encW32 dom)
       ]
@@ -801,6 +846,7 @@ encAction (AFCall _ fun _ (cond : args) _) = do
       [ ("func", f)
       , ("cond", condEnc)
       , ("args", encList argsEnc)
+      , ("signed", encList (map (encBool . argSigned) args))
       ]
 encAction (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
     f <- strE fun
@@ -814,5 +860,12 @@ encAction (ATaskAction _ fun _ cookie (cond : args) mtemp mty _) = do
       , ("width", encW32 (aTypeWidth mty))
       , ("cond", condEnc)
       , ("args", encList argsEnc)
+      , ("signed", encList (map (encBool . argSigned) args))
       ]
 encAction a = internalError ("SimExportIR.encAction: " ++ ppReadable a)
+
+-- Signed-display flag for a system-task argument: matches encodeArgs's
+-- "-" prefix rule (ForeignFunctions.hs:256-262).
+argSigned :: AExpr -> Bool
+argSigned (ASDef _ aid) = isSignedId aid
+argSigned _ = False

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -1,4 +1,4 @@
-module SimMakeCBlocks ( simMakeCBlocks, cvtActions ) where
+module SimMakeCBlocks ( simMakeCBlocks, cvtActions, mkAVMethTmpId ) where
 
 import Flags
 import PPrint

--- a/src/comp/SimMakeCBlocks.hs
+++ b/src/comp/SimMakeCBlocks.hs
@@ -1,4 +1,4 @@
-module SimMakeCBlocks ( simMakeCBlocks ) where
+module SimMakeCBlocks ( simMakeCBlocks, cvtActions ) where
 
 import Flags
 import PPrint

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1306,8 +1306,23 @@ genModuleC errh flags dumpnames time0 toplevel abis =
        time <- dump errh flags time DFsimPackageOpt dumpnames sim_system_opt
 
        -- export the TRS IR when requested
-       when (genBir flags) $
-            writeBirFile (prefix ++ toplevel ++ ".bir") (keepFires flags) sim_system_opt
+       when (genBir flags) $ do
+            -- the debug-tier symbol set: defs surviving as C++
+            -- members (post-SimCOpt public defs, isOkId-filtered) —
+            -- blocks are recomputed here (pure) so the export stays
+            -- decoupled from the C++ generation path below
+            let (sbs, sscheds, scgs, sgis, _sbtop) =
+                    simMakeCBlocks flags sim_system_opt
+                (sbs_opt, _, _, _) =
+                    simCOpt flags (ssys_instmap sim_system_opt)
+                            (sbs, sscheds, scgs, sgis)
+                symMap = M.fromListWith S.union
+                    [ (sb_name sb,
+                       S.fromList [ i | (_, i) <- sb_publicDefs sb
+                                      , isOkId i ])
+                    | sb <- sbs_opt ]
+            writeBirFile (prefix ++ toplevel ++ ".bir") (keepFires flags)
+                         symMap sim_system_opt
 
        -- convert SimPackages and SimSchedules to SimCCBlocks and SimCCScheds
        start flags DFsimMakeCBlocks

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1307,7 +1307,7 @@ genModuleC errh flags dumpnames time0 toplevel abis =
 
        -- export the TRS IR when requested
        when (genBir flags) $
-            writeBirFile (prefix ++ toplevel ++ ".bir") sim_system_opt
+            writeBirFile (prefix ++ toplevel ++ ".bir") (keepFires flags) sim_system_opt
 
        -- convert SimPackages and SimSchedules to SimCCBlocks and SimCCScheds
        start flags DFsimMakeCBlocks

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -138,6 +138,7 @@ import SimCCBlock
 import SimExpand(simExpand, simCheckPackage)
 import SimPackage(SimSystem(..))
 import SimPackageOpt(simPackageOpt)
+import SimExportIR(writeBirFile)
 import SimMakeCBlocks(simMakeCBlocks)
 import SimCOpt(simCOpt)
 import SimBlocksToC(simBlocksToC)
@@ -1303,6 +1304,10 @@ genModuleC errh flags dumpnames time0 toplevel abis =
        start flags DFsimPackageOpt
        sim_system_opt <- simPackageOpt errh flags sim_system
        time <- dump errh flags time DFsimPackageOpt dumpnames sim_system_opt
+
+       -- export the TRS IR when requested
+       when (genBir flags) $
+            writeBirFile (prefix ++ toplevel ++ ".bir") sim_system_opt
 
        -- convert SimPackages and SimSchedules to SimCCBlocks and SimCCScheds
        start flags DFsimMakeCBlocks

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -29,6 +29,7 @@ Flags {
 	finalcleanup = 1,
 	genABin = False,
 	genABinVerilog = False,
+	genBir = False,
 	genName = [],
 	genSysC = False,
 	ifLift = True,


### PR DESCRIPTION
## What

The BIR exporter: `bsc -sim -bir` serializes the post-scheduling simulation system (the same `SimSystem` the Bluesim C++ generator consumes, post `simExpand`/`simPackageOpt`) as BIR — a CBOR format with one design-wide interned string table — consumed by the trs Rust simulator (next PRs in this series). 15 commits, one exporter capability each:

1. core module-body export (clock domains, resets, inputs, instances, defs, rules, interface methods; full expression/action trees; unhandled constructs fail loudly)
2. segmented schedules + graph-derived compositions
3. the `-bir` flag wiring (hidden; `genBir` in Flags; **GenABin Bin Flags extends to 135 binders on this base, count == record fields, tag `bsc-ba-20260805-4`**; cborg in Makefile PACKAGES + CI installs)
4. def/action interleaving in rule bodies; body-local def latching; signed display flags
5. reset-gated conditionals, RegFile, more primitives
6. segment cuts at child-calling rules; module parameters; time base
7. counter/file tasks; def-level sign props; PrimResetUnassertedVal
8. ActionValue returns linearized; AMethValue substitution
9. clock/reset modeling: multi-clock event loop, negedge ticks, gated clocks, clock-source resolution
10. noinline instances, ME inhibitors, string parameters, Real values, construction order, $finish fidelity
11. foreign-function (BDPI) signature export
12. interface hierarchy: ifc_resets, merge nodes, clock gates, per-node segments, tick order, fidelity fixes
13. exporter sym flag (debug-tier symbol set for exact `sim ls`)
14. method_order canonicalization
15. SplitPorts tuples (ATuple/ATupleSel + per-port args)

## Why

Everything the Rust simulator needs, exported at the seam where scheduling is complete but nothing C++-specific has happened — schedule merging and package optimization stay in this compiler; the simulator consumes one artifact.

## Base decision

Based on **plain upstream-main**, not staged-flow/6: the exporter compiles there (all dependencies — tupleElemRange, argInputPorts, cvtActions/mkAVMethTmpId, isOkId, ssys_instmap — are present upstream; verified by the head gate). Smaller is better; the staged-flow adaptations the source branch carried are dropped as duplicates of staged-flow/1..6 (#48–#53).

## Verification

`make -j16 GHCJOBS=8 install-src` exit 0 at the head. `SimExportIR.hs` at the head is **byte-identical** to `claude/trs-fst-rebased` (where the full suite ran 23,488/0 effective and the trs sweep ran 1008 PASS / 0 DIFF).

## Provenance

Re-cut of 226b73d5d, 1f53aae59, 05deaad93, 8816b70e0, 6e37b8357, 9491a0fbd, aba41a0f0, e5a9ecf8a, d5ecde386, d4ec49677, fe8c12d3d, 1a9af11cb, e165848fc, 67b054e63, 02f4e800a, 647d15f10, c1effdacb, 20776cd91, 2aec23a47, 78d73834c, 89b0b99e7, 8208cef08 (exporter half), 3dc8c5564, 6d46232ec, 266806cb2, fec5923cc, 16292f475, 4fb486191, 86e94fceb, 5fb41856c, 620652f7a, da49c1e4d from `claude/trs-fst-rebased`. Grain note: ~33 exporter iteration commits folded into 15 capability commits; intermediate commits are exporter snapshots from the source branch (the head, not each step, is the compile gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Ravi Nanavati <ravi@matx.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
