### PR TITLE
trs/3: the -trs backend flag and link plumbing

### DIFF
--- a/src/comp/Flags.hs
+++ b/src/comp/Flags.hs
@@ -53,6 +53,7 @@ data Flags = Flags {
         genABin :: Bool,
         genABinVerilog :: Bool,
         genBir :: Bool,
+        genTrs :: Bool,
         genName :: [String],
         genSysC :: Bool,
         ifcPathRaw :: [String],

--- a/src/comp/FlagsDecode.hs
+++ b/src/comp/FlagsDecode.hs
@@ -545,6 +545,7 @@ defaultFlags bluespecdir = Flags {
         genABin = False,
         genABinVerilog = False,
         genBir = False,
+        genTrs = False,
         genName = [],
         genSysC = False,
         -- The ifcPath value will be produced from the raw value,
@@ -1612,6 +1613,15 @@ externalFlags = [
          (Toggle (\f x -> f {tclShowHidden=x}) (showIfTrue tclShowHidden),
           "show hidden levels of instance hierarchy in bluetcl", Hidden)),
 
+        ("trs",
+         let setFn f = case setBackend f Bluesim of
+                         Left f' -> Left f' { genABin = True, genBir = True,
+                                              genTrs = True }
+                         Right e -> Right e
+             getFn f = genTrs f
+         in  (NoArg setFn (Just getFn),
+              "compile BSV generating a TRS simulation", Visible)),
+
         ("u",
          (Toggle (\f x -> f {updCheck=x}) (showIfTrue updCheck),
           "check and recompile packages that are not up to date", Visible)),
@@ -1857,6 +1867,7 @@ showFlagsRaw flags =
           ("genABin", show (genABin flags)),
           ("genABinVerilog", show (genABinVerilog flags)),
           ("genBir", show (genBir flags)),
+          ("genTrs", show (genTrs flags)),
           ("genName", show (genName flags)),
           ("genSysC", show (genSysC flags)),
           ("ifLift", show (ifLift flags)),

--- a/src/comp/GenABin.hs
+++ b/src/comp/GenABin.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString as B
 -- .ba file tag -- change this whenever the .ba format changes
 -- See also GenBin.header
 header :: [Byte]
-header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260805-4"
+header = B.unpack $ TE.encodeUtf8 $ T.pack "bsc-ba-20260805-5"
 
 headerBS :: B.ByteString
 headerBS = B.pack header
@@ -561,11 +561,11 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134) =
+                a_130 a_131 a_132 a_133 a_134 a_135) =
        do wr_chunk0; wr_chunk1; wr_chunk2; wr_chunk3; wr_chunk4;
           wr_chunk5; wr_chunk6; wr_chunk7; wr_chunk8
       where
-        -- The 135-field serialization is split into NOINLINE chunks so
+        -- The 136-field serialization is split into NOINLINE chunks so
         -- that GHC optimizes bounded pieces: compiling it as a single
         -- monadic chain needs more than 15GB of heap.
         {-# NOINLINE wr_chunk0 #-}
@@ -612,7 +612,8 @@ instance Bin Flags where
         wr_chunk8 =
           do toBin a_120; toBin a_121; toBin a_122; toBin a_123; toBin a_124;
              toBin a_125; toBin a_126; toBin a_127; toBin a_128; toBin a_129;
-             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134
+             toBin a_130; toBin a_131; toBin a_132; toBin a_133; toBin a_134;
+             toBin a_135
     readBytes =
        do (a_000, a_001, a_002, a_003, a_004, a_005, a_006, a_007,
            a_008, a_009, a_010, a_011, a_012, a_013, a_014) <- rd_chunk0
@@ -631,7 +632,8 @@ instance Bin Flags where
           (a_105, a_106, a_107, a_108, a_109, a_110, a_111, a_112,
            a_113, a_114, a_115, a_116, a_117, a_118, a_119) <- rd_chunk7
           (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-           a_128, a_129, a_130, a_131, a_132, a_133, a_134) <- rd_chunk8
+           a_128, a_129, a_130, a_131, a_132, a_133, a_134,
+           a_135) <- rd_chunk8
           return (Flags
                 a_000 a_001 a_002 a_003 a_004 a_005 a_006 a_007 a_008 a_009
                 a_010 a_011 a_012 a_013 a_014 a_015 a_016 a_017 a_018 a_019
@@ -646,7 +648,7 @@ instance Bin Flags where
                 a_100 a_101 a_102 a_103 a_104 a_105 a_106 a_107 a_108 a_109
                 a_110 a_111 a_112 a_113 a_114 a_115 a_116 a_117 a_118 a_119
                 a_120 a_121 a_122 a_123 a_124 a_125 a_126 a_127 a_128 a_129
-                a_130 a_131 a_132 a_133 a_134)
+                a_130 a_131 a_132 a_133 a_134 a_135)
       where
         {-# NOINLINE rd_chunk0 #-}
         rd_chunk0 =
@@ -709,9 +711,9 @@ instance Bin Flags where
           do a_120 <- fromBin; a_121 <- fromBin; a_122 <- fromBin; a_123 <- fromBin; a_124 <- fromBin;
              a_125 <- fromBin; a_126 <- fromBin; a_127 <- fromBin; a_128 <- fromBin; a_129 <- fromBin;
              a_130 <- fromBin; a_131 <- fromBin; a_132 <- fromBin; a_133 <- fromBin;
-             a_134 <- fromBin
+             a_134 <- fromBin; a_135 <- fromBin
              return (a_120, a_121, a_122, a_123, a_124, a_125, a_126, a_127,
-                     a_128, a_129, a_130, a_131, a_132, a_133, a_134)
+                     a_128, a_129, a_130, a_131, a_132, a_133, a_134, a_135)
 
 -- ----------
 

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -11,7 +11,8 @@ import System.FilePath(takeDirectory)
 import System.IO(hFlush, stdout, hPutStr, stderr, hGetContents, hClose, hSetBuffering, BufferMode(LineBuffering))
 import System.IO(hSetEncoding, utf8)
 import System.Posix.Files(fileMode,  unionFileModes, ownerExecuteMode, groupExecuteMode, setFileMode, getFileStatus, fileAccess)
-import System.Directory(getDirectoryContents, doesFileExist, getCurrentDirectory)
+import System.Directory(getDirectoryContents, doesFileExist, getCurrentDirectory,
+                        makeAbsolute)
 import System.Time(getClockTime, ClockTime(TOD)) -- XXX: from old-time package
 import Data.Char(isSpace, toLower, ord)
 import Data.List(intersect, nub, partition, intersperse, sort,
@@ -1913,10 +1914,18 @@ trsLink errh flags toplevel user_cfiles user_ofiles = do
         outFile = oFile flags
         soFile = outFile ++ ".bdpi.so"
     -- place the .bir next to the executable, where the wrapper (and the
-    -- runtime's .bdpi.so search) expect it
-    when (outFile ++ ".bir" /= birFile) $ do
+    -- runtime's .bdpi.so search) expect it.  Textual inequality is not
+    -- file identity (a relative -o names the exported .bir relatively,
+    -- e.g. plain `-o <top>`), so compare absolute paths -- and read
+    -- strictly so that even an aliased self-copy (symlinked directory)
+    -- rewrites the file instead of truncating it mid-read.
+    let outBir = outFile ++ ".bir"
+    absBir <- makeAbsolute birFile
+    absOut <- makeAbsolute outBir
+    when (absOut /= absBir) $ do
         contents <- L.readFile birFile
-        L.writeFile (outFile ++ ".bir") contents
+        CE.evaluate (L.length contents)
+        L.writeFile outBir contents
     -- compile the user's BDPI C files (with the C compiler, so symbols
     -- keep C linkage) and link the objects into one dlopen-able object
     when (not (null user_cfiles) || not (null user_ofiles)) $ do

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -139,6 +139,7 @@ import SimExpand(simExpand, simCheckPackage)
 import SimPackage(SimSystem(..))
 import SimPackageOpt(simPackageOpt)
 import SimExportIR(writeBirFile)
+import qualified Data.ByteString.Lazy as L
 import SimMakeCBlocks(simMakeCBlocks)
 import SimCOpt(simCOpt)
 import SimBlocksToC(simBlocksToC)
@@ -1324,6 +1325,26 @@ genModuleC errh flags dumpnames time0 toplevel abis =
             writeBirFile (prefix ++ toplevel ++ ".bir") (keepFires flags)
                          symMap sim_system_opt
 
+       -- the -trs backend stops here: the .bir plus the user's C files
+       -- (compiled separately for dlopen) are the whole simulation
+       if (genTrs flags)
+        then do let TimeInfo _ t_TOD = time
+                _ <- return t_TOD
+                return (time, [], [], time)
+        else genModuleC_cxx errh flags dumpnames time toplevel prefix reused
+                            sim_system_opt
+
+genModuleC_cxx :: ErrorHandle
+               -> Flags
+               -> DumpNames
+               -> TimeInfo
+               -> String
+               -> String
+               -> [String]
+               -> SimSystem
+               -> IO (TimeInfo, [String], [String], TimeInfo)
+genModuleC_cxx errh flags dumpnames time toplevel prefix reused sim_system_opt =
+    do
        -- convert SimPackages and SimSchedules to SimCCBlocks and SimCCScheds
        start flags DFsimMakeCBlocks
        let (simblocks, simCCscheds, clk_groups, gate_info, top_id) =
@@ -1481,13 +1502,26 @@ simLink errh flags toplevel afilenames cfilenames = do
     let ofiles = gen_ofiles ++
                  user_ofiles ++ compiled_user_ofiles ++
                  ofiles_reused
+
+    -- under -bir, also package the user's BDPI objects for the trs
+    -- runtime (dlopen), named next to the .bir
+    when (genBir flags && not (genTrs flags)
+          && not (null (user_ofiles ++ compiled_user_ofiles))) $ do
+        pwd3 <- getCurrentDirectory
+        let name3 = createEncodedFullFilePath "placeholder" pwd3
+            prefix3 = (dirName name3) ++ "/"
+            so3 = prefix3 ++ toplevel ++ ".bdpi.so"
+        cxxCompile errh flags (["-shared", "-fPIC", "-o", so3])
+                   (map show (user_ofiles ++ compiled_user_ofiles))
     t <- dump errh flags t_before_compilations DFbluesimcompile dumpnames
               ofiles
 
     -- if not generating a SystemC model, link to a Bluesim executable
     start flags DFbluesimlink
-    when (not (genSysC flags)) $
-      cxxLink errh flags toplevel ofiles creation_time
+    if (genTrs flags)
+      then trsLink errh flags toplevel user_cfiles user_ofiles
+      else when (not (genSysC flags)) $
+             cxxLink errh flags toplevel ofiles creation_time
     t <- dump errh flags t DFbluesimlink dumpnames toplevel
 
     -- final verbose message
@@ -1864,6 +1898,59 @@ cleanseSharedLib errh flags soFile = do
     case rc of
         ExitSuccess   -> return ()
         ExitFailure n -> exitFailWith errh n
+
+-- ===============
+-- trsLink: the TRS backend's link step.  The simulation is the
+-- exported .bir executed by the trs runtime; user BDPI C files are
+-- compiled into a companion shared object that the runtime dlopens.
+
+trsLink :: ErrorHandle -> Flags -> String -> [String] -> [String] -> IO ()
+trsLink errh flags toplevel user_cfiles user_ofiles = do
+    pwd <- getCurrentDirectory
+    let name = createEncodedFullFilePath "placeholder" pwd
+        prefix = (dirName name) ++ "/"
+        birFile = prefix ++ toplevel ++ ".bir"
+        outFile = oFile flags
+        soFile = outFile ++ ".bdpi.so"
+    -- place the .bir next to the executable, where the wrapper (and the
+    -- runtime's .bdpi.so search) expect it
+    when (outFile ++ ".bir" /= birFile) $ do
+        contents <- L.readFile birFile
+        L.writeFile (outFile ++ ".bir") contents
+    -- compile the user's BDPI C files (with the C compiler, so symbols
+    -- keep C linkage) and link the objects into one dlopen-able object
+    when (not (null user_cfiles) || not (null user_ofiles)) $ do
+        cofs <- mapM (compileUserCFile errh flags False) user_cfiles
+        cxxCompile errh flags
+                   (["-shared", "-fPIC", "-o", soFile])
+                   (map show (cofs ++ user_ofiles))
+        unless (quiet flags) $
+            putStrLnF ("BDPI shared library created: " ++ soFile)
+    -- AOT: let the trs driver compile the design and write the
+    -- artifact (wrapper script + model .so + pinned options) — the
+    -- same amortization as the C++ backend's g++ link, at a fraction
+    -- of the cost.  Any failure (trs not on PATH, built without the
+    -- jit feature, infra error) falls back to the interpreter wrapper.
+    let linkCmd = "\"${TRS:-trs}\" link \"" ++ outFile ++ ".bir\" -o \""
+                  ++ outFile ++ "\""
+    rc <- system linkCmd
+    case rc of
+      ExitSuccess ->
+        unless (quiet flags) $
+            putStrLnF ("TRS simulation created (compiled): " ++ outFile)
+      _ -> do
+        writeFileCatch errh outFile $
+            unlines [ "#!/bin/sh"
+                    , ""
+                    , "TRS=${TRS:-trs}"
+                    , "exec \"$TRS\" run \"$0.bir\" \"$@\""
+                    ]
+        stat <- getFileStatus outFile
+        let mode = fileMode stat
+            mode' = foldl1 unionFileModes [mode, ownerExecuteMode, groupExecuteMode]
+        setFileMode outFile mode'
+        unless (quiet flags) $
+            putStrLnF ("TRS simulation created: " ++ outFile)
 
 -- ===============
 -- vLink

--- a/testsuite/bsc.options/bsc.help.out.expected
+++ b/testsuite/bsc.options/bsc.help.out.expected
@@ -74,6 +74,7 @@ Compiler flags:
 -steps-warn-interval n  issue a warning each time this many unfolding steps are executed
 -suppress-warnings list ignore a list of warnings (``:'' sep list of tags)
 -systemc                generate a SystemC model
+-trs                    compile BSV generating a TRS simulation
 -u                      check and recompile packages that are not up to date
 -unspecified-to val     remaining unspecified values are set to: 'X', '0', '1', 'Z', or 'A'
 -use-dpi                use DPI instead of VPI in generated Verilog

--- a/testsuite/bsc.options/bsc.print-flags-raw.out.expected
+++ b/testsuite/bsc.options/bsc.print-flags-raw.out.expected
@@ -30,6 +30,7 @@ Flags {
 	genABin = False,
 	genABinVerilog = False,
 	genBir = False,
+	genTrs = False,
 	genName = [],
 	genSysC = False,
 	ifLift = True,


### PR DESCRIPTION
## What

The `-trs` backend flag and its link plumbing, stacked on the engine (#109). Two commits:

1. **`-trs` flag**: selects the TRS backend — compile phase identical to `-sim` (same `.ba`); implies `-sim -elab -bir`. `genTrs` in Flags; **GenABin Bin Flags extends to 136 binders, count == record fields, `.ba` tag `bsc-ba-20260805-5`**; help/print-flags-raw goldens.
2. **trsLink + BDPI companions**: the link phase exports the `.bir`, compiles user BDPI C files (C linkage) into `<out>.bdpi.so`, and writes `<out>` — AOT-linked by the trs driver when available (wrapper + .bir + model .so), interpreter-wrapper fallback otherwise. `genModuleC` splits at the export seam (`genModuleC_cxx` carries the C++ half); `-sim -bir` also packages BDPI objects so a differential sweep exercises the same path.

## Verification

`make -j16 GHCJOBS=8 install-src` exit 0 at the head. Binder count re-verified mechanically at this head (136 == record fields). On the source branch the -trs flow carried the 1008/0 diffsweep.

## Provenance

Re-cut of 8208cef08 (backend half), a6c648d72, 6d46232ec (link halves), 53001b36b (flag position), f51f52919 (goldens) from `claude/trs-fst-rebased`. Dropped here with a ledger note: the branch's unused `getForeignFunctions`/DPIInst export additions in ForeignFunctions.hs (dead — no consumer in the final tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Ravi Nanavati <ravi@matx.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt
