### PR TITLE
Permit numeric provisos on Classic foreign functions

### DIFF
--- a/src/Libraries/Base1/Fork.bs
+++ b/src/Libraries/Base1/Fork.bs
@@ -11,8 +11,9 @@ import Vector
 --@ values to avoid CSE.
 --@
 
--- XXX m == 2*n, but we can't have contexts on foreign.
-foreign vfork :: Bit n -> Bit m = "Fork",("i","o")
+-- The proviso enforces the width relationship at every application
+-- (it is checked by the typechecker and then erased).
+foreign vfork :: (Add n n m) => Bit n -> Bit m = "Fork",("i","o")
 
 --@ Copy a value into two identical values.
 --@ \begin{libverbatim}

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -727,6 +727,7 @@ data ErrMsg =
             Position -- ^ previous decl position
 
         | EForeignNotBit String String
+        | EForeignCtxNotNumeric String String
         | EPartialTypeApp String Integer Integer -- synonym (# expected) (# given)
         | ENotStructId String
         | ENotStructUpd String
@@ -1942,6 +1943,14 @@ getErrorText (EMultipleDecl name prevPos) =
 getErrorText (EForeignNotBit i t) =
   (Type 12, empty, hdr $$ text "Type:" <+> nest 2 (text t))
   where hdr = s2par ("Foreign function " ++ ishow i ++ " has a non-Bit argument or result.")
+getErrorText (EForeignCtxNotNumeric i p) =
+  (Type 160, empty, hdr $$ text "Proviso:" <+> nest 2 (text p))
+  where hdr = s2par ("Foreign function " ++ ishow i ++ " has a proviso" ++
+                     " that is not a numeric relationship." ++
+                     " Only Add, Mul, Div, Log, Max, Min and NumEq" ++
+                     " provisos are permitted on foreign functions:" ++
+                     " they are checked at each application and then" ++
+                     " erased.")
 getErrorText (EPartialTypeApp i expected given) =
     (Type 13, empty,
      s2par ("Partially applied type synonym: " ++ ishow i) $$

--- a/src/comp/Error.hs
+++ b/src/comp/Error.hs
@@ -1944,7 +1944,7 @@ getErrorText (EForeignNotBit i t) =
   (Type 12, empty, hdr $$ text "Type:" <+> nest 2 (text t))
   where hdr = s2par ("Foreign function " ++ ishow i ++ " has a non-Bit argument or result.")
 getErrorText (EForeignCtxNotNumeric i p) =
-  (Type 160, empty, hdr $$ text "Proviso:" <+> nest 2 (text p))
+  (Type 163, empty, hdr $$ text "Proviso:" <+> nest 2 (text p))
   where hdr = s2par ("Foreign function " ++ ishow i ++ " has a proviso" ++
                      " that is not a numeric relationship." ++
                      " Only Add, Mul, Div, Log, Max, Min and NumEq" ++

--- a/src/comp/IConv.hs
+++ b/src/comp/IConv.hs
@@ -85,7 +85,17 @@ iConvVar flags r env i =
                 case findVar r i of
                 Just (VarInfo VarPrim (_ :>: sc) _ _) -> ICon i (ICPrim (iConvSc flags r sc) (toPrim i))
                 Just (VarInfo (VarForg name mps) (_ :>: sc) _ _) ->
-                        let t = iConvSc flags r sc
+                        let -- numeric contexts are checked at each
+                            -- application by the typechecker and their
+                            -- (content-free) dictionaries dropped at the
+                            -- CApply clause elsewhere, so the foreign's
+                            -- type is the base type without dictionary
+                            -- arrows; any other provisos (noinline's
+                            -- WrapField, pre-resolution) convert as-is
+                            Forall ks (ps :=> qt) = sc
+                            t = if all isNumericForeignPred ps
+                                then iConvSc flags r (Forall ks ([] :=> qt))
+                                else iConvSc flags r sc
                             -- inputs are grouped per argument;
                             -- foreign functions have one (unsplit) port per argument,
                             -- so each inner list is a singleton.
@@ -482,6 +492,15 @@ iConvE errh flags r env pvs eee@(CStructT ct fs@((f,_):_)) =
         ks = getKs n fty
         fty = lookupSelType flags ti f r
         st = argType (iInst fty tvs)
+-- Drop the dictionary arguments from applications of foreign functions
+-- declared with (numeric-only) contexts: the provisos are checked at
+-- each application by the typechecker, and the dictionaries carry no
+-- content (the numeric classes have no methods), so they are erased
+-- here, mirroring the dropDicts treatment of primitives below.
+iConvE errh flags r env pvs (CApply ct@(CTApply (CVar i) ts) es)
+    | Just n <- foreignPredCount r i =
+        iAps (iConvE errh flags r env pvs ct) []
+             (map (iConvE errh flags r env pvs) (drop n es))
 -- Get rid of dictionary argument to primConcat & co
 iConvE errh flags r env pvs (CApply (CTApply (CVar i) ts) (_: es))
     | (Just f) <- lookup i dropDicts =
@@ -639,6 +658,24 @@ ruleStrConcat e1 e2 =
 
 str_ :: CExpr
 str_ = CLitT tString (CLiteral noPosition (LString "_"))
+
+-- The number of dictionary arguments a foreign function's applications
+-- carry (the number of provisos on its declaration), or Nothing if it
+-- is not a foreign function or has none.
+foreignPredCount :: SymTab -> Id -> Maybe Int
+foreignPredCount r i =
+    case findVar r i of
+      Just (VarInfo (VarForg _ _) (_ :>: Forall _ (ps :=> _)) _ _)
+        | not (null ps), all isNumericForeignPred ps -> Just (length ps)
+      _ -> Nothing
+
+-- numeric provisos on a foreign declaration (checked at applications,
+-- then erased); must agree with the allowlist in MakeSymTab.chkTopDef
+isNumericForeignPred :: PredWithPositions -> Bool
+isNumericForeignPred pp =
+    let (IsIn cl _) = removePredPositions pp
+    in  any (qualEq (typeclassId (name cl)))
+            [idAdd, idMul, idDiv, idLog, idMax, idMin, idNumEq]
 
 dropDicts :: [(Id, IExpr a)]
 dropDicts = [(idPrimConcat, icPrimConcat),

--- a/src/comp/MakeSymTab.hs
+++ b/src/comp/MakeSymTab.hs
@@ -685,7 +685,22 @@ chkTopDef r mi src_pkg isDep (CIValueSign i ct) = do
     sc <- mkSchemeWithSymTab r ct
     return [(i, VarInfo VarDefn (i :>: sc) (isDep i) src_pkg)]
 chkTopDef r mi src_pkg isDep (Cforeign i qt on ops ni) = do
-    sc@(Forall _ (_ :=> t)) <- mkSchemeWithSymTab r qt
+    sc@(Forall _ (preds :=> t)) <- mkSchemeWithSymTab r qt
+    -- Only numeric provisos are permitted on foreign functions: they are
+    -- checked at each application and then erased (their dictionaries
+    -- carry no content), so the foreign implementation never sees them.
+    -- Anything else (e.g. Bits) would need real dictionary content or
+    -- coercion insertion, which a foreign body cannot provide.
+    let numericClassIds = [idAdd, idMul, idDiv, idLog, idMax, idMin, idNumEq]
+        isNumericPred p = let (IsIn cl _) = removePredPositions p
+                          in  any (qualEq (typeclassId (name cl))) numericClassIds
+    -- (noinline-created foreign functions carry WrapField provisos at
+    -- this stage; they are checked in typecheck, as before)
+    case filter (not . isNumericPred) preds of
+      (p:_) | not ni -> throwError (getPosition i,
+                            EForeignCtxNotNumeric (pfpString i)
+                                (pfpString (removePredPositions p)))
+      _ -> return ()
     let name = case on of
                 Just s -> s
                 Nothing -> getIdString i

--- a/testsuite/bsc.codegen/foreign/BDPICtx.bsv
+++ b/testsuite/bsc.codegen/foreign/BDPICtx.bsv
@@ -1,0 +1,22 @@
+// A numeric proviso on an import "BDPI" declaration: the relationship
+// between the widths is enforced by the typechecker at every
+// application and then erased -- the C side receives the sizes it
+// needs as explicit arguments, per the usual polymorphic-BDPI
+// convention.
+import "BDPI" function Bit#(m) bit_dup (Bit#(n) x, Bit#(32) nsz)
+   provisos(Add#(n, n, m));
+
+function Bit#(m) dup(Bit#(n) x) provisos(Add#(n, n, m));
+   return bit_dup(x, fromInteger(valueOf(n)));
+endfunction
+
+(* synthesize *)
+module mkBDPICtx();
+   rule r;
+      Bit#(16) y1 = dup(8'h5A);
+      Bit#(24) y2 = dup(12'hABC);
+      $display("dup8  = %h", y1);
+      $display("dup12 = %h", y2);
+      $finish(0);
+   endrule
+endmodule

--- a/testsuite/bsc.codegen/foreign/BDPICtxViolated.bsv
+++ b/testsuite/bsc.codegen/foreign/BDPICtxViolated.bsv
@@ -1,0 +1,10 @@
+import "BDPI" function Bit#(m) bit_dup (Bit#(n) x, Bit#(32) nsz)
+   provisos(Add#(n, n, m));
+
+(* synthesize *)
+module mkBDPICtxViolated();
+   rule r;
+      Bit#(15) y = bit_dup(8'h5A, 8);
+      $display("%h", y);
+   endrule
+endmodule

--- a/testsuite/bsc.codegen/foreign/dupctx.c.keep
+++ b/testsuite/bsc.codegen/foreign/dupctx.c.keep
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+/* Duplicate the low nsz bits of x: ret = {x, x} (2*nsz bits wide).
+   Polymorphic BDPI arguments and results are passed as word pointers;
+   this test keeps 2*nsz <= 32 so a single word suffices on each side. */
+void bit_dup(unsigned int* ret, unsigned int* x, unsigned int nsz)
+{
+  unsigned int v = x[0] & ((nsz >= 32) ? ~0u : ((1u << nsz) - 1));
+  ret[0] = (v << nsz) | v;
+}

--- a/testsuite/bsc.codegen/foreign/foreign.exp
+++ b/testsuite/bsc.codegen/foreign/foreign.exp
@@ -57,6 +57,19 @@ test_c_veri_bsv_multi BDPIActionValue_ mkBDPIActionValue_ $actionvaluemods1
 # ---------------
 # Functions with wide data
 
+# -----
+# Numeric provisos on BDPI imports: the width relationship is checked
+# by the typechecker at each application (and then erased); the sizes
+# reach the C side as explicit arguments, per the usual
+# polymorphic-BDPI convention.
+
+copy dupctx.c.keep dupctx.c
+test_c_veri_bsv_multi BDPICtx mkBDPICtx { bit_dup.ba dupctx.c }
+
+compile_verilog_fail BDPICtxViolated.bsv T0031
+
+# -----
+
 copy wide.c.keep wide.c
 test_c_veri_bsv_multi BDPIBit97 mkBDPIBit97 { popcount.ba wide.c }
 test_c_veri_bsv_multi BDPIWideResult mkBDPIWideResult { four_copies.ba wide.c }

--- a/testsuite/bsc.codegen/foreign/mkBDPICtx.out.expected
+++ b/testsuite/bsc.codegen/foreign/mkBDPICtx.out.expected
@@ -1,0 +1,2 @@
+dup8  = 5a5a
+dup12 = abcabc

--- a/testsuite/bsc.verilog/noinline/ForeignCtxBad.bs
+++ b/testsuite/bsc.verilog/noinline/ForeignCtxBad.bs
@@ -1,0 +1,9 @@
+package ForeignCtxBad(bad) where
+
+-- Only numeric provisos are permitted on foreign functions; a Bits
+-- proviso would need real dictionary content, which a foreign body
+-- cannot provide.
+foreign vbad :: (Bits a n) => a -> Bit n = "Bad",("i","o")
+
+bad :: Bit 4 -> Bit 4
+bad = vbad

--- a/testsuite/bsc.verilog/noinline/ForeignCtxGood.bs
+++ b/testsuite/bsc.verilog/noinline/ForeignCtxGood.bs
@@ -1,0 +1,16 @@
+package ForeignCtxGood(sysForeignCtxGood, Ifc) where
+
+{-# verilog sysForeignCtxGood #-}
+
+-- A numeric proviso on a foreign function: checked at applications,
+-- erased afterward; the width instance parameters still pass through.
+foreign vdup :: (Add iw iw ow) => Bit iw -> Bit ow = "Dup",("i","o")
+
+interface Ifc =
+  get :: Bit 16
+
+sysForeignCtxGood :: Module Ifc
+sysForeignCtxGood =
+  module
+    interface
+      get = vdup (8 :: Bit 8)

--- a/testsuite/bsc.verilog/noinline/ForeignCtxViolated.bs
+++ b/testsuite/bsc.verilog/noinline/ForeignCtxViolated.bs
@@ -1,0 +1,8 @@
+package ForeignCtxViolated(bad) where
+
+-- The declared proviso (ow == iw + iw) is enforced at applications:
+-- using the function at inconsistent widths is a type error.
+foreign vdup :: (Add iw iw ow) => Bit iw -> Bit ow = "Dup",("i","o")
+
+bad :: Bit 8 -> Bit 15
+bad = vdup

--- a/testsuite/bsc.verilog/noinline/noinline.exp
+++ b/testsuite/bsc.verilog/noinline/noinline.exp
@@ -79,6 +79,6 @@ compile_verilog_fail NoInline_Polymorphic.bsv T0111
 compile_verilog_pass ForeignCtxGood.bs
 find_regexp sysForeignCtxGood.v {Dup #\(8, 16\)}
 compile_verilog_fail ForeignCtxViolated.bs T0031
-compile_verilog_fail ForeignCtxBad.bs T0160
+compile_verilog_fail ForeignCtxBad.bs T0163
 }
 

--- a/testsuite/bsc.verilog/noinline/noinline.exp
+++ b/testsuite/bsc.verilog/noinline/noinline.exp
@@ -73,5 +73,12 @@ compile_verilog_fail NoInline_PredNotReducible.bsv T0110
 compile_verilog_pass NoInline_PredReducible.bsv
 
 compile_verilog_fail NoInline_Polymorphic.bsv T0111
+
+# Numeric provisos on foreign functions are permitted (checked at each
+# application, then erased); anything else is rejected
+compile_verilog_pass ForeignCtxGood.bs
+find_regexp sysForeignCtxGood.v {Dup #\(8, 16\)}
+compile_verilog_fail ForeignCtxViolated.bs T0031
+compile_verilog_fail ForeignCtxBad.bs T0160
 }
 


### PR DESCRIPTION
MatX twin of B-Lang-org/bsc#1023 (Permit numeric provisos on Classic foreign functions); completes the rc8-remainder set. This branch carries the rc8 weave's extra: the foreign-proviso half of the T0162/T0163 error-tag renumber.

## What

- **Numeric provisos on `foreign` declarations.** A module-bound Classic foreign function's width relationships could not be stated: `Fork.bs`'s `vfork` carried the comment "XXX ow == 2*iw, but we can't have contexts on foreign", and applying it at inconsistent widths silently produced a miswired netlist. Numeric provisos (`Add`, `Mul`, `Div`, `Log`, `Max`, `Min`, `NumEq`) are now permitted: the typechecker enforces them at every application, and they are then erased — the dictionaries carry no content (the classes have no methods), so IConv drops the dictionary arrows from the foreign's type and the dictionary arguments from its applications, mirroring the `dropDicts` treatment of primitives. `Fork.bs` declares its honest type, `(Add n n m) => Bit n -> Bit m`, and a violating application now fails with T0031 instead of producing wrong hardware.
- **Non-numeric provisos rejected** with a new error (T0163 here; introduced as T0160 in the upstream PR): anything else would need real dictionary content or coercion insertion, which a foreign body cannot provide. Noinline-created foreign functions are exempt (their WrapField proviso is checked in typecheck, as before), and IConv only strips when every proviso is numeric, so their conversion is unchanged.
- **`import "BDPI"`** already supports numeric provisos through the standard signature machinery; new tests pin that behavior (a width-doubling import whose `Add#(n,n,m)` proviso relates the widths, with a C implementation run under both backends) alongside the Classic foreign positive/violated/non-numeric cases. DPI-mode polymorphism is upstream PR #999's scope.

## Why

Width relationships on foreign functions were previously unenforceable, and getting them wrong failed silently as a miswired netlist. Checked-then-erased numeric provisos give the declaration an honest type at zero runtime/codegen cost.

## Verification

- Compile gate: `make -j16 GHCJOBS=8 install-src` exit 0 at head (worktree from `matx/upstream-main`).
- Full suite gate at head: `make -j24 -C testsuite fullparallel` (SystemC enabled, `CXXFLAGS=-O0`) — **20296 PASS / 0 FAIL / 134 XFAIL / 0 XPASS**, exit 0.
- Localchecks (worktree `inst/bin` on PATH), all with 0 unexpected failures:
  - `testsuite/bsc.typechecker/typeclasses`
  - Feature dirs: `bsc.codegen/foreign` (BDPICtx tests), `bsc.verilog/noinline` (ForeignCtx tests)
- Contamination greps (TypeShareFlags / DefProp / remapP / hack-ground-ctype) clean on the branch diff.

## Provenance

- Base: `matx/upstream-main` @ 941eecfe.
- Commit 1 is upstream PR #1023's feature commit (`6b9c37e5a`, carried in the rc8 weave as `6daf70f37`; separate-lineage copies `matx/cleaner-output` `5d8a3b562` and `matx/claude/trs-fst-rebased` `fb49323b6` are patch-id-identical — content fully converged, no refinement drift). Re-based here from the PR's stack parent (#1022, pass-by-name) onto plain `upstream-main`; the only deltas vs the PR head are that unstacking: `Fork.bs` keeps the `n`/`m` type variables (the `iw`/`ow` rename names Verilog instance parameters, a #1022 concern), `VarForg` has two fields (no `tvns`), MakeSymTab hooks the pre-#1022 code shape, and the `ForeignCtxGood` golden grep matches positional `Dup #(8, 16)` rather than named parameters.
- Commit 2 carries the weave's error-tag renumber (rc8 `3d79fe0e0` = upstream PR tip `a86b1a2b`, our half only): the typeclass-coherence series claims T0159-T0161, so the foreign-proviso error takes T0163. The commit's other half (foreign-width T0159→T0162) belongs to the named-instance-params feature and lives on `single/named-instance-params` (#114), which claims T0162 and deliberately leaves T0163 to this branch — the two compose without collision.
- No .bo/.ba format-tag bump: this branch changes library content (`Fork.bs`) but no serialized format.

Co-authored-by: Ravi Nanavati <ravi@matx.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRVtTNugutAyrTED4qHnrt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

