### PR TITLE
Judge the committable gate's given-check against the bound set

### DIFF
--- a/src/comp/TCMisc.hs
+++ b/src/comp/TCMisc.hs
@@ -499,17 +499,31 @@ sat dvs ps p =
                         stack_eps <- getExplPreds
                         let p_pred = apSub s_final (toPred p)
                             givens = concatMap bySuperE (ps ++ stack_eps)
-                            -- Modal check, so unify unguarded ([]): a
-                            -- given from an enclosing frame quantifies
-                            -- over its own rigid variables, which are
-                            -- distinct TyVars from (but instantiable
-                            -- to) this definition's; the bound-variable
-                            -- guards would hide such a given and let
-                            -- the commit freeze an instance reduction
-                            -- the outer given was meant to discharge
-                            -- whole.
+                            -- Could a given still discharge this
+                            -- predicate whole, later in THIS
+                            -- definition's derivation?  Unlike
+                            -- earlierInstanceMayCapture, which must
+                            -- range over call-site instantiations of
+                            -- the rigid variables, a given is a
+                            -- hypothesis of the derivation in
+                            -- progress: its rigid variables are
+                            -- pinned until generalization, so a given
+                            -- that needs one to change can never take
+                            -- the goal here, and barring the commit
+                            -- on its account strands the reduction
+                            -- (and discards numeric residuals that
+                            -- only the settlement batch could prove).
+                            -- Guarding with the bound set still keeps
+                            -- an enclosing frame's given visible to a
+                            -- meta-headed goal -- varUnify binds the
+                            -- free variable to the rigid one -- so
+                            -- those goals still defer.  A call site
+                            -- that instantiates the rigid to match
+                            -- the given agrees with the commit too:
+                            -- for a coherent class the caller's
+                            -- dictionary is this same instance.
                             unifiable (EPred _ gp) =
-                                predUnify [] p_pred gp
+                                predUnify bound_tyvars p_pred gp
                         return (if any unifiable givens
                                 then Provisional else Committable)
                     when (commitment == Committable) $ recordPackageUse mpkg

--- a/testsuite/bsc.typechecker/context-errors/ContextTooWeakDeferred.bsv.bsc-out.expected
+++ b/testsuite/bsc.typechecker/context-errors/ContextTooWeakDeferred.bsv.bsc-out.expected
@@ -1,17 +1,15 @@
 checking package dependencies
 compiling ContextTooWeakDeferred.bsv
-Error: "ContextTooWeakDeferred.bsv", line 14, column 41: (T0030)
-  The provisos for this expression are too general.
-  Given type:
-    Vector::Vector#(max_elems, elem_type)
-  The following provisos are needed:
-    Bits#(Vector::Vector#(max_elems, Vector::Vector#(e_bytes, Bit#(8))), a__)
-      Introduced at the following locations:
+Error: "ContextTooWeakDeferred.bsv", line 14, column 41: (T0033)
+  There is not enough explicit type information to deduce the types of all
+  expressions. Consider adding more type declarations to help resolve this
+  ambiguity.
+    An ambiguous type was introduced at "ContextTooWeakDeferred.bsv", line 16,
+    column 58
+    This type resulted from:
+      The proviso Mul#(max_elems, b__, a__) introduced in or at the following
+      locations:
 	"ContextTooWeakDeferred.bsv", line 16, column 58
-      The proviso could also be deduced from the following information:
-	Mul#(max_elems, TMul#(e_bytes, 8), a__)
-  The type variables are from the following positions:
-    "a__" at "ContextTooWeakDeferred.bsv", line 16, column 58
 Error: "ContextTooWeakDeferred.bsv", line 18, column 61: (T0020)
   Type error at:
     bs

--- a/testsuite/bsc.typechecker/context-errors/context-errors.exp
+++ b/testsuite/bsc.typechecker/context-errors/context-errors.exp
@@ -95,14 +95,15 @@ compile_fail_error ContextReductionRemoveImpliedCloseFD.bsv T0032
 compare_file ContextReductionRemoveImpliedCloseFD.bsv.bsc-out
 
 # --------------------
-# Test that deferred contexts are used when reporting TooWeak errors
-# (bug 1716)
+# Originally a pin for deferred contexts in TooWeak errors (bug 1716).
+# Under the guarded given-check the two Bits goals commit (the rigid
+# `e'-headed given cannot take them), their Mul residuals stream, and
+# the program's deliberate wrong-variable bug now surfaces as an
+# ambiguity: the packed size a__ is demanded by two unrelated Mul
+# provisos and cannot be determined.
 
-# (There is also a T0020 error, which is due to a missing "pack" that is
-# necessary to trigger the T0030 error.)
-compile_fail_error ContextTooWeakDeferred.bsv T0030
-# XXX The error could report the deferred contexts which mention variables
-# XXX in the message (showing how they are further constrained)
+# (There is also a T0020 error, which is due to a missing "pack".)
+compile_fail_error ContextTooWeakDeferred.bsv T0033
 compare_file ContextTooWeakDeferred.bsv.bsc-out
 
 # --------------------

--- a/testsuite/bsc.typechecker/instances/commit/DualDirection.bsv
+++ b/testsuite/bsc.typechecker/instances/commit/DualDirection.bsv
@@ -1,0 +1,28 @@
+// Pin for the corner where the guarded and unguarded given-checks
+// disagree in the OTHER direction: judged eagerly (unguarded), the
+// given CC#(4,8) clashes on literals once r is substituted and is
+// provably unreachable; judged guarded, both numeric positions defer
+// as equalities ((r,4),(r,8)) whose conjunction is unsatisfiable, yet
+// a bare isJust would count them "unifiable" and bar the commit.
+//
+// Today the program is accepted on every path for a prior reason:
+// the diagonal instance's Mul proviso is a SAT validity in w, so the
+// settlement batch proves and erases it AT THE INSTANCE DECLARATION,
+// and the use-site goal CC#(r,r) reduces completely -- the gate never
+// judges a partial reduction here.  This file pins that acceptance:
+// if instance-proviso erasure or the gate's deferred-equality
+// handling ever changes, an unreachable contradictory given must
+// still not reject this program.
+typeclass CC#(numeric type a, numeric type b);
+   function Bit#(b) ccv(Bit#(a) x);
+endtypeclass
+
+instance CC#(w, w)
+   provisos (Mul#(TDiv#(w,8), 8,
+                  TAdd#(TSub#(TMul#(TDiv#(w,8), 8), w), w)));
+   function ccv(x) = x;
+endinstance
+
+function Bit#(r) f(Bit#(r) x) provisos (CC#(4,8));
+   return ccv(x);
+endfunction

--- a/testsuite/bsc.typechecker/instances/commit/MetaGivenDefers.bs
+++ b/testsuite/bsc.typechecker/instances/commit/MetaGivenDefers.bs
@@ -1,0 +1,31 @@
+-- Pin for the deferring half of the guarded given-check: guarding
+-- the gate with the bound set must NOT hide an enclosing frame's
+-- given from a metavariable-headed goal (a FREE variable may still
+-- bind to a RIGID one; only rigid-vs-structure is conclusive).
+--
+-- Inside `innerF' the goal is MyC m k with both positions still
+-- metavariables (the argument is unannotated): no clause can adopt
+-- it there, and `MyC s r' -- the enclosing frame's given, alive
+-- because no instance head matches a bare rigid input -- unifies
+-- with it by binding m := s, k := r.  The goal must defer whole
+-- across the local frame; the application `innerF x' then pins the
+-- variables and the given takes it.  Any judgment along that chain
+-- that treated free-vs-rigid as conclusive would break the pin: the
+-- goal either gets captured by the sole instance (m := T, k := Conc,
+-- clashing the rigid `s' with T at the application) or is orphaned
+-- from the given and reported as an unresolvable context.
+package MetaGivenDefers where
+
+data T = MkT
+data Conc = MkConc
+
+class MyC a b | a -> b where
+  toB :: a -> b
+
+instance MyC T Conc where
+  toB _ = MkConc
+
+outer :: (MyC s r) => s -> r
+outer x =
+  let innerF y = toB y
+  in  innerF x

--- a/testsuite/bsc.typechecker/instances/commit/RigidGivenCommit.bs
+++ b/testsuite/bsc.typechecker/instances/commit/RigidGivenCommit.bs
@@ -1,0 +1,36 @@
+-- Pin for the commitment gate's given-check being guarded (judged
+-- with the definition's bound variables).
+--
+-- Inside `readAll', repacking the Vector demands
+-- Bits (Vector (TDiv aSize 32) (Bit 32)) _sz, a coherent unique match
+-- of the Vector Bits instance.  The signature's given `Bits a aSize'
+-- is same-class but can never take that goal: `a' is rigid here, and
+-- a hypothesis's rigid variable is pinned for the whole derivation.
+-- Judged unguarded, the given LOOKS unifiable (a := Vector ...), the
+-- commit is barred, and the put-aside discards the reduction's queued
+-- numeric residual
+--   Mul (TDiv aSize 32) 32 (TAdd (TSub (TMul (TDiv aSize 32) 32) aSize) aSize)
+-- which is SAT-only (no instance or given can discharge it); the
+-- definition then fails T0030.  Judged guarded, the commit stands and
+-- the residual rides to the definition boundary, where the settlement
+-- batch proves it -- there is no per-site solver call.
+--
+-- The dual variant pins that the batch (not some other path) proves
+-- the residual: with the solver disabled the same file must fail.
+package RigidGivenCommit where
+
+import Vector
+
+struct Pad t n =
+  padding :: Bit n
+  value :: t
+ deriving (Bits)
+
+repack :: (Bits a x, Bits b x) => a -> b
+repack x = unpack (pack x)
+
+readAll :: (Bits a aSize) => Vector (TDiv aSize 32) (Bit 32) -> a
+readAll pieces =
+  let padded :: Pad a (TSub (TMul (TDiv aSize 32) 32) aSize)
+      padded = repack pieces
+  in padded.value

--- a/testsuite/bsc.typechecker/instances/commit/commit.exp
+++ b/testsuite/bsc.typechecker/instances/commit/commit.exp
@@ -80,3 +80,40 @@ compile_pass DeferCommittedResidualTwoInstances.bs
 # true obligation (and the uncovered catch-all's T0160 is pinned too)
 compile_fail ModalCapture.bs
 compare_file ModalCapture.bs.bsc-out
+
+# --------------------
+# Pins for the guarded given-check in the commitment gate: a given is
+# a hypothesis of THIS definition's derivation, so its rigid variables
+# are judged pinned (unlike earlier-instance capture, which must range
+# over call-site instantiations).
+
+# an unreachable rigid same-class given must not bar a coherent
+# commit: the put-aside would discard the reduction's queued numeric
+# residual, which only the definition-boundary settlement batch can
+# prove (regression: a Vector read repacked through a padded struct)
+erase RigidGivenCommit.bo
+compile_pass RigidGivenCommit.bs
+
+# dual pin (as in ../../numeric-settle): the residual is provable
+# ONLY by the solver, so the same file must fail with the solver
+# disabled -- a variant that still passed would not be exercising
+# the settlement batch
+erase RigidGivenCommit.bo
+compile_fail_error RigidGivenCommit.bs T0030 1 {-no-use-proviso-sat}
+
+# the deferring half stays guarded, not blinded: a metavariable-headed
+# goal still sees the enclosing frame's given (free may bind rigid),
+# defers whole across the local frame, and the given takes it once the
+# application pins the variables
+erase MetaGivenDefers.bo
+compile_pass MetaGivenDefers.bs
+
+# a same-class given with mutually contradictory concrete arguments
+# (CC#(4,8)) is unreachable from any goal and must not disturb the
+# diagonal instance's discharge; today the instance's SAT-valid
+# proviso is proved and erased at the instance declaration, so the
+# use-site reduction is complete and the gate never fires -- pinned
+# so a change to proviso erasure or to the gate's deferred-equality
+# handling cannot turn an unreachable given into a rejection
+erase DualDirection.bo
+compile_pass DualDirection.bsv


### PR DESCRIPTION
Fixes an acceptance regression present in rc3 through rc8: programs whose coherent instance reduction carries a SAT-only numeric residual are rejected (T0030) whenever a same-class given with rigid variables is in scope, even though that given provably cannot discharge the goal.

## Reproducer

```bluespec
readAll :: (Bits a aSize) => Vector (TDiv aSize 32) (Bit 32) -> a
```

Repacking the vector through a `Bits`-derived padded struct demands `Bits (Vector (TDiv aSize 32) (Bit 32)) nsa`, whose reduction leaves the residual `Mul (TDiv aSize 32) 32 (TAdd (TSub (TMul (TDiv aSize 32) 32) aSize) aSize)` — provable only by the proviso SAT solver. Accepted by upstream 2026.01, upstream main @`941eecfe`, and every MatX release through rc-2026.07; rejected with T0030 by rc3, rc4, rc6, rc8.

## Root cause

The commitment gate barred the coherent commit whenever any same-class given unified with the goal under a fully unguarded `predUnify []`, which treats rigid, signature-quantified variables as instantiable — so `Bits a aSize` "unifies" with `Bits (Vector …) nsa` via `a := Vector …`, a substitution that can never happen inside the definition. The Provisional put-aside then discards the partial reduction **including its queued numeric residual**; post-settlement-rework (the batched-SAT design), nothing downstream can recover it, and the un-reduced `Bits` goal fails generalization.

The gate was born guarded in "Ordered-clause fundep semantics: outputs never bar a match"; the bound-variable-discipline commit (`a6a042ea` in this lineage, upstream PR B-Lang-org/bsc#1037) unguarded it in the same change that introduced the strict unifier the guard needs. This PR restores the guarded form with a comment recording the asymmetry: a given is a hypothesis of the derivation in progress (rigids pinned until generalization), unlike `earlierInstanceMayCapture`, which must stay modal because instance-vs-instance capture ranges over call-site instantiations.

No solver work is added or moved: the residual of the now-committed reduction streams to `batchSolveNumericPreds` at the definition boundary, exactly as the settlement design intends (verified by trace: one batch, zero per-site sessions).

## Verification

- Reproducer and its explicit-proviso variant flip to accepted; concrete-width, no-given, SAT-sanity, and must-reject controls all keep their verdicts across upstream 2026.01, upstream main, 2026.05.1, the PR-955 series, rc-2026.07, rc3, rc8, and the fixed build.
- Full `bsc.typechecker` suite, stock rc8 vs fixed: outcome-identical except `ContextTooWeakDeferred.bsv` (regolded here — its deliberate wrong-variable bug now commits and surfaces as the size ambiguity T0033 instead of the un-reduced goal T0030).
- Prelude and the full library corpus rebuild cleanly with the fixed compiler; the a6a042ea commit-message scenario (Generic-default catch-all for `PrimDeepSeqCond`) does not recur, and its `ModalCapture` pin still passes.
- New pins (second commit): `RigidGivenCommit` fails on stock rc8 exactly at "should compile" — the suite gap that let this ship. Its dual `-no-use-proviso-sat` leg pins that only the boundary batch proves the residual. `MetaGivenDefers` pins the deferring half (meta-headed goal still defers to an enclosing rigid given — the case the unguarding comment feared; `varUnify` binds free := bound, so guarding does not hide it). `DualDirection` pins the contradictory-concrete-given corner.
- Upstream-lineage full CI (fork run of the same series on the #1037 branch): 20,285 passes / 134 expected failures / 4 unexpected — all four were T0043 wrapper-diagnostic renderings (a duplicated T0043 with an empty offender list collapsing to one T0043 plus a T0032 naming the `WrapMethod → PrimSeqTupleBits/NonEmptyBits/Bits` chain; `ExpSizeOf_VectorIfc` gaining the module-site report). Regolded on that branch to the same goldens this release lineage already blessed in its `e5e3bcd9` regold; on THIS lineage those three tests are byte-identical stock-vs-fixed (no change needed).

## Notes

- The same two commits, cherry-picked onto `claude/bound-variable-discipline` (PR #1037's head, where the fix logically belongs), plus the T0043 regold, are pushed to nanavati/bsc `claude/numeric-proviso-sat-regression-rc4xk1` for the upstream lineage.
- Applies cleanly to any later release line carrying the rework; base here is `release-2026.07.rc8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kq1xiCSvgkUxd3xadpEW6A