### PR TITLE
Bluesim: invalidate reused objects when -unspecified-to changes

### DIFF
--- a/src/comp/SimFileUtils.hs
+++ b/src/comp/SimFileUtils.hs
@@ -35,7 +35,10 @@ codeGenOptionDescr :: Flags -> Bool -> String
 codeGenOptionDescr flags is_top =
     unwords $ [ "Generation options:" ] ++
               (if (keepFires flags) then ["keep-fires"] else []) ++
-              (if (is_top && (genSysC flags)) then ["sysc-top"] else [])
+              (if (is_top && (genSysC flags)) then ["sysc-top"] else []) ++
+              -- Remaining ASAny values are lowered during Bluesim codegen,
+              -- so changing -unspecified-to changes the generated object.
+              [ "unspec-" ++ unSpecTo flags ]
 
 readCodeGenOptionDescr :: FilePath -> IO (Maybe String)
 readCodeGenOptionDescr f =

--- a/testsuite/bsc.bugs/bluespec_inc/b1894/b1894.exp
+++ b/testsuite/bsc.bugs/bluespec_inc/b1894/b1894.exp
@@ -28,15 +28,13 @@ if { $ctest == 1 } {
     move mkTop.cxx mkTop.A.cxx
     find_regexp mkTop.A.cxx {if \(DEF_cond__h\d+\)\n +DEF_AVMeth_s_m = INST_s.METH_m\(\);\n +else\n +DEF_AVMeth_s_m = \(tUInt8\)2u;}
 
-    # workaround BSC's failure to recompile due to flags
-    erase mkTop.o
+    # Changing -unspecified-to must invalidate the Bluesim object.
     # Test with 0
     link_objects_pass {} mkTop {-unspecified-to 0}
     move mkTop.cxx mkTop.0.cxx
     find_regexp mkTop.0.cxx {if \(DEF_cond__h\d+\)\n +DEF_AVMeth_s_m = INST_s.METH_m\(\);\n +else\n +DEF_AVMeth_s_m = \(tUInt8\)0u;}
 
-    # workaround BSC's failure to recompile due to flags
-    erase mkTop.o
+    # Changing it again must invalidate the replacement object.
     # Test with 1
     link_objects_pass {} mkTop {-unspecified-to 1}
     move mkTop.cxx mkTop.1.cxx


### PR DESCRIPTION
## Summary

- Include `-unspecified-to` in Bluesim's generated-object reuse key.
- Exercise the fix by retaining the existing object across the `b1894` A/0/1 link sequence.

## Root cause

Bluesim lowers remaining `ASAny` expressions during C++ generation according to `unSpecTo`. Object reuse checks version/timestamps and `codeGenOptionDescr`, but that descriptor omitted the setting. Relinking unchanged `.ba` files with a different value could therefore silently reuse an object containing the previous lowering.

This affects Bluesim object reuse only. Verilog does not use this descriptor.

Existing generated objects rebuild once because their descriptor lacks the new field; the `.ba` format is unchanged.

This is a focused reimplementation of the reviewed fixes in 4975c60b5 and 68af341f3 on `upstream-main`.

## Testing

- `make -C testsuite b1894.check VTEST=0 SYSTEMCTEST=0 TEST_RELEASE=/home/ravi/bluespec/matx/bsc/inst` — 8 expected passes
