### PR TITLE
trs: engine-outcome telemetry and the first AOT-fallback closures

### DIFF
--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -157,6 +157,15 @@ pub struct InstEnv {
     /// EN_<m> port name -> arena slot; zeroed at composition dispatch,
     /// stored by compiled call sites (the C++ enable protocol)
     pub en_slot: HashMap<StrId, u32>,
+    /// constant-valued module input ports and instantiation
+    /// parameters: the compiled mirror of the interpreter's
+    /// Port/Param fallthrough — an uncalled method's arg reads 0,
+    /// unbound clock/gate/reset-kind input ports read 1, numeric
+    /// params read their bound value.  Dynamic bindings never land
+    /// here (bound gates evaluate in the parent; EN and reset ports
+    /// have arena slots; string params are marker values).  Part of
+    /// the exec dedup signature.
+    pub port_consts: HashMap<StrId, (u32, u64)>,
     /// any rule's CAN_FIRE/WILL_FIRE def name -> arena slot (this
     /// instance); reads of other rules' fire signals become slot loads
     pub cfwf_slot: HashMap<StrId, u32>,
@@ -725,7 +734,7 @@ impl Drop for AotModeGuard {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 6;
+pub const AOT_LAYOUT_REV: u64 = 7;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -1708,7 +1717,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             },
             Expr::Port(p) => match f.args.get(p) {
                 Some(&(_, w)) => Ok(w),
-                None => Ok(1), // reset/EN ports
+                None => Ok(self
+                    .ie(f.inst)?
+                    .port_consts
+                    .get(p)
+                    .map_or(1, |&(w, _)| w)), // reset/EN ports read 1 bit
+            },
+            Expr::Param(p) => match self.ie(f.inst)?.port_consts.get(p) {
+                Some(&(w, _)) => Ok(w),
+                None => nope("parameter not constant-lowerable"),
             },
             Expr::Const { width, .. }
             | Expr::MethCall { width, .. }
@@ -1943,7 +1960,19 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     let word = self.load_word(f, slot);
                     return Ok(self.to_w(word, 64, 1, false));
                 }
-                nope("port read outside args/reset/EN")
+                if let Some(&(w, v)) = ie.port_consts.get(p) {
+                    return Ok(self.cval(w, &[v as u32, (v >> 32) as u32]));
+                }
+                nope("port read outside args/reset/EN/consts")
+            }
+            Expr::Param(p) => {
+                let ie = self.ie(f.inst)?;
+                match ie.port_consts.get(p) {
+                    Some(&(w, v)) => {
+                        Ok(self.cval(w, &[v as u32, (v >> 32) as u32]))
+                    }
+                    None => nope("parameter not constant-lowerable"),
+                }
             }
             Expr::MethCall { width, instance, method, port, args } => {
                 self.value_call(f, *width, *instance, *method, *port, args)

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -734,7 +734,7 @@ impl Drop for AotModeGuard {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 7;
+pub const AOT_LAYOUT_REV: u64 = 8;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2455,6 +2455,12 @@ impl Interp {
             // parent (MCD), EN/reset ports have arena slots, string
             // params are marker values, and unslotted method enables
             // stay ineligible rather than folding to a wrong constant.
+            // A BOUND value the u64 fold cannot carry (wide args,
+            // Real's marker width) must stay out of the unbound-port
+            // arms below too — the interp resolves `params` before any
+            // read-as-1/0 fallthrough, so folding such a name as
+            // "unbound" bakes a wrong constant (sysWideModArgPortTest,
+            // sysTwoLevelReal2); unfolded means Ineligible -> interp.
             let mut port_consts: HashMap<StrId, (u32, u64)> = HashMap::new();
             for (&pn, pv) in params {
                 if pv.width >= 1 && pv.width <= 64 {
@@ -2463,6 +2469,7 @@ impl Interp {
             }
             for (&pn, &(w, kind)) in &self.mods[module].ports {
                 if port_consts.contains_key(&pn)
+                    || params.contains_key(&pn)
                     || en_slot.contains_key(&pn)
                     || reset_slot.contains_key(&pn)
                     || gates.contains_key(&pn)

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2145,11 +2145,13 @@ impl Interp {
                     }
                     let module = self.module_of(en.inst);
                     let mir = self.mods[module].ir;
+                    // interface-method node in a segment: nothing to
+                    // latch — the interp skips these identically (an
+                    // external caller latches EN/args at call time;
+                    // uncalled methods read EN as 0 through their
+                    // arena slots), so the compiled walk omits them
                     let Some(&ri) = self.mods[module].rules.get(&r) else {
-                        if trace {
-                            eprintln!("trs jit: off (method node in schedule)");
-                        }
-                        return None;
+                        continue;
                     };
                     let shared =
                         owned_so_far.get(&en.inst).cloned().unwrap_or_default();
@@ -2306,7 +2308,9 @@ impl Interp {
                 }
                 Walk::Enter(i) => i,
             };
-            let InstKind::User { module, children, resets, .. } = &self.insts[i].kind
+            let InstKind::User {
+                module, children, resets, params, str_params, gates, ..
+            } = &self.insts[i].kind
             else {
                 continue;
             };
@@ -2443,6 +2447,39 @@ impl Interp {
                     stack.push(Walk::Enter(c));
                 }
             }
+            // constant-valued input ports and parameters — the compiled
+            // mirror of the interpreter's Port/Param fallthrough
+            // (uncalled MethodArg reads 0, unbound clock/gate/reset-kind
+            // ports read 1, numeric params read their bound value).
+            // Dynamic bindings stay out: bound gates evaluate in the
+            // parent (MCD), EN/reset ports have arena slots, string
+            // params are marker values, and unslotted method enables
+            // stay ineligible rather than folding to a wrong constant.
+            let mut port_consts: HashMap<StrId, (u32, u64)> = HashMap::new();
+            for (&pn, pv) in params {
+                if pv.width >= 1 && pv.width <= 64 {
+                    port_consts.insert(pn, (pv.width, pv.as_u64()));
+                }
+            }
+            for (&pn, &(w, kind)) in &self.mods[module].ports {
+                if port_consts.contains_key(&pn)
+                    || en_slot.contains_key(&pn)
+                    || reset_slot.contains_key(&pn)
+                    || gates.contains_key(&pn)
+                    || str_params.contains_key(&pn)
+                {
+                    continue;
+                }
+                match kind {
+                    trs_ir::PortKind::MethodArg => {
+                        port_consts.insert(pn, (w.max(1), 0));
+                    }
+                    trs_ir::PortKind::MethodEnable => {}
+                    _ => {
+                        port_consts.insert(pn, (w.max(1), 1));
+                    }
+                }
+            }
             inst_envs.insert(
                 i,
                 InstEnv {
@@ -2458,6 +2495,7 @@ impl Interp {
                     cfwf_slot,
                     eager_slot,
                     memo_slot,
+                    port_consts,
                     region: (region_start, 0),
                 },
             );
@@ -2526,6 +2564,13 @@ impl Interp {
                     e.memo_slot.iter().map(|(&k, &(b, w))| (k, b - r0, w)).collect();
                 m9.sort_unstable();
                 m9.hash(&mut h);
+                // params/const-ports are baked into compiled bodies:
+                // instances of one module type with different param
+                // values must not share exec code
+                let mut m11: Vec<_> =
+                    e.port_consts.iter().map(|(&k, &(w, v))| (k, w, v)).collect();
+                m11.sort_unstable();
+                m11.hash(&mut h);
                 // the sig must cover every input the exec lowering
                 // reads (handoff rule): regfile regions included
                 let mut m10: Vec<_> = e
@@ -2547,11 +2592,17 @@ impl Interp {
             sigs
         };
 
-        // any Exec node must belong to a scheduled rule above
+        // any Exec node of a RULE must belong to a scheduled rule
+        // above; interface-method Exec nodes are no-ops (skipped by
+        // the interp and by comp_nodes below)
         for rc in rcomps {
             for en in &rc.entries {
+                let module = self.module_of(en.inst);
                 for &node in &en.nodes {
                     let SchedNode::Exec(r) = node else { continue };
+                    if !self.mods[module].rules.contains_key(&r) {
+                        continue; // method exec node
+                    }
                     if !rule_ord.contains_key(&(en.inst, r)) {
                         if trace {
                             eprintln!("trs jit: off (exec without sched)");
@@ -2836,7 +2887,13 @@ impl Interp {
                             SchedNode::Sched(r) => (r, true),
                             SchedNode::Exec(r) => (r, false),
                         };
-                        let ord = rule_ord[&(en.inst, r)] as u32;
+                        // interface-method nodes have no ordinal:
+                        // they are no-ops in the edge walk (interp
+                        // parity — nothing to latch or execute)
+                        let Some(&ord) = rule_ord.get(&(en.inst, r)) else {
+                            continue;
+                        };
+                        let ord = ord as u32;
                         nodes.push(if is_sched {
                             JitNode::Sched(ord)
                         } else {

--- a/src/trs/tools/diffsweep.py
+++ b/src/trs/tools/diffsweep.py
@@ -227,15 +227,28 @@ def one_test(job):
     # asked to beat a budget Bluesim itself did not meet.
     limit = max(limit, ref_build_secs + ref_secs)
     trs_link_secs = 0.0
+    engine_note = ""
     if AOT:
         cexe = os.path.join(wk, top + ".aot.cexe")
+        # engine-outcome telemetry: trace makes every plan gate and
+        # trial-lower refusal name itself on stderr, so the sweep
+        # records WHY a design runs interpreted, not just that it does
+        link_env = dict(ENV)
+        link_env["TRS_JIT_TRACE"] = "1"
         tl0 = _time.monotonic()
-        lk = run([TRS, "link", bir, "-o", cexe], cwd=wk, timeout=300)
+        lk = run([TRS, "link", bir, "-o", cexe], cwd=wk, timeout=300, env=link_env)
         trs_link_secs = _time.monotonic() - tl0
         if lk is None or lk.returncode != 0:
             msg = "" if lk is None else (lk.stderr + lk.stdout)
             return (rel, top, "AOT_LINK_FAIL",
                     "timeout" if lk is None else first_error(msg))
+        # the wrapper is the durable record: --code => compiled
+        try:
+            compiled = "--code" in open(cexe).read()
+        except OSError:
+            compiled = False
+        engine_note = " engine=aot" if compiled else (
+            " engine=interp why=" + link_fallback_reason(lk.stderr))
         env = dict(ENV)
         env["PATH"] = os.path.dirname(TRS) + os.pathsep + env.get("PATH", "")
         tr0 = _time.monotonic()
@@ -261,9 +274,26 @@ def one_test(job):
         # bsc -sim link phase (C++ codegen + cc), the fair comparand
         # for trs_link.
         timing = (f"t ref_build={ref_build_secs:.2f} ref_run={ref_secs:.3f}"
-                  f" trs_link={trs_link_secs:.2f} trs_run={trs_run_secs:.3f}")
+                  f" trs_link={trs_link_secs:.2f} trs_run={trs_run_secs:.3f}"
+                  f"{engine_note}")
         return (rel, top, "PASS", timing)
     return (rel, top, "DIFF", diff_summary(ref.stdout, inp.stdout))
+
+
+def link_fallback_reason(stderr):
+    """Fallback reason from a traced `trs link`: prefer the specific
+    `trs jit: off (...)` line (the last one wins — trial lower may
+    follow a plan gate), else the CLI's compiled-mode-unavailable
+    note.  Whitespace collapses to _ so the note stays one token."""
+    reason = ""
+    for line in stderr.splitlines():
+        l = line.strip()
+        if l.startswith("trs jit: off (") and l.endswith(")"):
+            reason = l[len("trs jit: off ("):-1]
+        elif "compiled mode unavailable (" in l and not reason:
+            reason = l.split("compiled mode unavailable (", 1)[1]
+            reason = reason.split(");", 1)[0]
+    return re.sub(r"\s+", "_", reason)[:100] or "unknown"
 
 
 def first_error(msg):
@@ -363,8 +393,14 @@ def main():
         cost = {}
         for rel, top, status, note in prior:
             if status == "PASS" and note.startswith("t "):
-                fv = dict(kv.split("=") for kv in note[2:].split())
-                cost[(rel, top)] = sum(float(v) for v in fv.values())
+                total = 0.0
+                for kv in note[2:].split():
+                    _, _, v = kv.partition("=")
+                    try:
+                        total += float(v)
+                    except ValueError:
+                        pass  # non-timing columns (engine=, why=)
+                cost[(rel, top)] = total
         def jobkey(j):
             rel = os.path.relpath(j[0], REPO)
             return -cost.get((rel, j[1]), 0.0)
@@ -413,8 +449,14 @@ def main():
     timings = {}
     for (rel, top, status, note) in results:
         if status == "PASS" and note.startswith("t "):
-            fv = dict(kv.split("=") for kv in note[2:].split())
-            timings[f"{rel}:{top}"] = {k: float(v) for k, v in fv.items()}
+            t = {}
+            for kv in note[2:].split():
+                k, _, v = kv.partition("=")
+                try:
+                    t[k] = float(v)
+                except ValueError:
+                    pass  # non-timing columns (engine=, why=)
+            timings[f"{rel}:{top}"] = t
     def _ratios(t):
         out = {}
         if t["ref_run"] >= 0.10:


### PR DESCRIPTION
First slice of the trs full-AOT push — makes the compiled/interp split measurable, then closes the first two fallback classes.

## Commits
1. **diffsweep records the engine outcome per corpus design** — `trs link` runs under `TRS_JIT_TRACE=1`; PASS rows carry `engine=aot` or `engine=interp why=<reason>`; both note parsers hardened against non-numeric tokens.
2. **compile designs whose schedules contain interface methods and input ports** — the compiled walk skips interface-method Sched/Exec nodes exactly as the interpreter does; `InstEnv::port_consts` mirrors the interpreter's Port/Param fallthrough (uncalled MethodArg reads 0, unbound clock/gate/reset-kind ports read 1, numeric params ≤64 bits read their bound value); port_consts joins the exec dedup signature; `AOT_LAYOUT_REV` 6→7.
3. **bound values the u64 fold cannot carry must not fold as unbound ports** — the sweep (not unit tests) caught the two DIFFs this introduced: a 65-bit module argument and a Real parameter fell through to the unbound-port arms and compiled as constant 1 (`sysWideModArgPortTest`, `sysTwoLevelReal2`). Names bound in `params` are now excluded from the unbound fold; unfoldable means ineligible → byte-identical interp degrade. REV 7→8.

## Validation
Sealed by a frozen-binary full `--aot` diffsweep: **996 PASS / 0 DIFF**, perf fence clean, non-PASS all upstream-class (COMPILE_FAIL 27, NO_SOURCE 20, NOT_SUPPORTED 14, LINK_FAIL 3). First exact engine census: **875 compiled / 121 interp (87.8%)**, replacing HANDOFF's ~825/~120 estimate. Unit tests 26/26.

Base of the stack; #125 (trs/7-av-task-values) builds on this.