### PR TITLE
trs: close the AOT gap — 974/995 designs compiled, sealed at 0 DIFF

### DIFF
--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -444,11 +444,16 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
                 let tag = r(b, i)?;
                 let a = r(b, i)?;
                 let sg = r(b, i)?;
+                // exact tags only: an unknown tag is a corrupted or
+                // future-format artifact — fail CLOSED, or the callback
+                // buffer walk desynchronizes on a garbage width
+                // (review finding: unknown tags fell open as Num)
                 args.push(match tag {
                     0 => FArgSpec::Str(a),
+                    1 => FArgSpec::Num { width: a, signed: sg != 0 },
                     2 => FArgSpec::Real,
                     3 => FArgSpec::StrDyn,
-                    _ => FArgSpec::Num { width: a, signed: sg != 0 },
+                    _ => return None,
                 });
             }
             v.push(ForeignSpec { inst, func, ret_width, args });
@@ -829,7 +834,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 12;
+pub const AOT_LAYOUT_REV: u64 = 13;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -1884,8 +1889,13 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
     }
 
-    /// i1 truthiness of a width-w value.
+    /// i1 truthiness of a width-w value.  A zero-width value is the
+    /// empty bit-vector — constant false, whatever bit its i1 carrier
+    /// happens to hold.
     fn nonzero(&self, v: IntValue<'ctx>, w: u32) -> IntValue<'ctx> {
+        if w == 0 {
+            return self.ctx.bool_type().const_zero();
+        }
         self.builder
             .build_int_compare(IntPredicate::NE, v, self.ity(w).const_zero(), "nz")
             .unwrap()
@@ -2098,6 +2108,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return Ok(self.to_w(word, 64, 1, false));
                 }
                 if let Some(&(w, v)) = ie.port_consts.get(p) {
+                    if w == 0 {
+                        return Ok(self.ity(0).const_zero()); // empty bit-vector
+                    }
                     return Ok(self.cval(w, &[v as u32, (v >> 32) as u32]));
                 }
                 if let Some(&bits) = ie.real_consts.get(p) {
@@ -2135,6 +2148,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return Ok(self.cval(w, &limbs));
                 }
                 match ie.port_consts.get(p) {
+                    Some(&(0, _)) => Ok(self.ity(0).const_zero()),
                     Some(&(w, v)) => {
                         Ok(self.cval(w, &[v as u32, (v >> 32) as u32]))
                     }
@@ -2914,8 +2928,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             arg_widths.push(wa);
             vals.push((v, wa));
         }
+        // physical layout is w.max(1) words per argument, matching the
+        // callback decode exactly — a zero-width argument occupies one
+        // stored zero word (review finding: a 0-word argument
+        // desynchronized the buffer walk into an out-of-bounds read)
         let total_words: u32 =
-            arg_widths.iter().map(|&w| words_for(w)).sum::<u32>().max(1);
+            arg_widths.iter().map(|&w| words_for(w.max(1))).sum::<u32>().max(1);
         let out_words = words_for(ret_width.max(1));
         let i64t = self.ctx.i64_type();
         let abuf = self
@@ -2928,9 +2946,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             .unwrap();
         let mut off = 0u32;
         for (v, wa) in vals {
-            let words = words_for(wa);
-            let t = self.ity(wa.max(64 * words.min(1)).max(wa));
-            let _ = t;
+            let words = words_for(wa.max(1));
             for k in 0..words {
                 let sh = self.ity(wa).const_int((64 * k) as u64, false);
                 let piece = if k == 0 {
@@ -3489,6 +3505,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         width: u32,
         args: &[Expr],
     ) -> Result<IntValue<'ctx>, Ineligible> {
+        // a zero-width result is the empty bit-vector, always 0: the
+        // interp masks every op back to zero at width 0.  A central
+        // early return keeps the invariant where per-op lowering would
+        // break it (Not of i1 0 is i1 1; Sra computes width-1, which
+        // underflows) — prim exprs are pure, so skipping the args is
+        // safe (review finding)
+        if width == 0 {
+            return Ok(self.ity(0).const_zero());
+        }
         // string equality: the interp compares marker limbs, i.e. the
         // ids — an i64 id compare is the exact mirror (both engines
         // treat distinct ids as unequal regardless of text)
@@ -4107,6 +4132,42 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
     }
 
+    /// Does a string expression contain a StringConcat anywhere —
+    /// including through Def table expansion?  Concat interns per
+    /// evaluation, so it must never run on an unselected mux arm.
+    fn contains_concat(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        match e {
+            Expr::Prim { op: PrimOp::StringConcat, .. } => true,
+            Expr::Prim { args, .. } => {
+                args.iter().any(|a| self.contains_concat(f, a))
+            }
+            Expr::If { cond, then_, else_, .. } => {
+                self.contains_concat(f, cond)
+                    || self.contains_concat(f, then_)
+                    || self.contains_concat(f, else_)
+            }
+            Expr::Case { scrutinee, arms, default, .. } => {
+                self.contains_concat(f, scrutinee)
+                    || arms.iter().any(|(_, a)| self.contains_concat(f, a))
+                    || self.contains_concat(f, default)
+            }
+            Expr::Def(n) => {
+                // a positioned binding is already a pure id; only an
+                // unbound def's table expansion could re-run a concat
+                if f.ssa.contains_key(n) {
+                    return false;
+                }
+                let Ok(ie) = self.ie(f.inst) else { return false };
+                let m = &self.env.d.modules[ie.mir];
+                m.defs
+                    .iter()
+                    .find(|d| d.name == *n)
+                    .is_some_and(|d| self.contains_concat(f, &d.expr))
+            }
+            _ => false,
+        }
+    }
+
     /// Lower a string-typed expression to its i64 string id (the
     /// compiled carrier for the interp's str_ref marker Value).
     fn str_expr(
@@ -4125,11 +4186,18 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
             }
             Expr::If { cond, then_, else_, .. } => {
+                // arms evaluate eagerly (select), which is only sound
+                // for PURE ids — a StringConcat in an arm would intern
+                // on the unselected path too, diverging from the
+                // interp's selected-arm-only evaluation (review
+                // finding); such shapes stay ineligible until arms get
+                // real control flow
+                if self.contains_concat(f, then_) || self.contains_concat(f, else_) {
+                    return nope("string concat under a mux arm");
+                }
                 let wc = self.expr_width(f, cond)?;
                 let c = self.expr(f, cond)?;
                 let cz = self.nonzero(c, wc);
-                // string values are pure ids — both arms evaluate
-                // eagerly (no effects), select picks one
                 let tv = self.str_expr(f, then_, stop_bb)?;
                 let ev = self.str_expr(f, else_, stop_bb)?;
                 Ok(self
@@ -4139,6 +4207,11 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     .into_int_value())
             }
             Expr::Case { scrutinee, arms, default, .. } => {
+                if arms.iter().any(|(_, a)| self.contains_concat(f, a))
+                    || self.contains_concat(f, default)
+                {
+                    return nope("string concat under a mux arm");
+                }
                 let ws = self.expr_width(f, scrutinee)?;
                 let sv = self.expr(f, scrutinee)?;
                 let mut acc = self.str_expr(f, default, stop_bb)?;
@@ -4158,13 +4231,40 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 Ok(acc)
             }
             Expr::Def(n) => {
+                // same resolution order as numeric def(): the POSITIONED
+                // ssa binding wins (a Stmt::Def bound the id at its
+                // statement position — table re-expansion would observe
+                // later state mutations and re-run concat effects), then
+                // dead-def refusal, then table expansion (review finding)
+                if let Some(v) = f.ssa.get(n) {
+                    return Ok(*v);
+                }
+                if f.dead_defs.contains(n) {
+                    if let Some(&(p, w)) = f.av_slots.get(n) {
+                        let out = self
+                            .builder
+                            .build_load(self.ity(w), p, "savesc")
+                            .unwrap()
+                            .into_int_value();
+                        return Ok(out);
+                    }
+                    return nope("string def escaped conditional arm");
+                }
                 let ie = self.ie(f.inst)?;
                 let m = &self.env.d.modules[ie.mir];
                 let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
                     return nope("unknown string def");
                 };
+                if f.expanding.contains(n) {
+                    return nope("string def cycle");
+                }
                 let dex = d.expr.clone();
-                self.str_expr(f, &dex, stop_bb)
+                f.expanding.push(*n);
+                let r = self.str_expr(f, &dex, stop_bb);
+                f.expanding.pop();
+                let v = r?;
+                f.ssa.insert(*n, v);
+                Ok(v)
             }
             Expr::Prim { op: PrimOp::ZeroExt | PrimOp::SignExt, args, .. } => {
                 // marker passthrough: width adjustments of string
@@ -4618,6 +4718,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         stop_bb: inkwell::basic_block::BasicBlock<'ctx>,
     ) -> Result<IntValue<'ctx>, Ineligible> {
         let w = width.max(1);
+        // join-safe slots FIRST (undet-initialized at entry): the
+        // interp binds nothing on a false condition, so a later read
+        // sees undet (or a previous execution's value) — the stores
+        // happen only on the TAKEN path (review finding: the old
+        // unconditional store of the phi wrote 0 over undet on skip)
+        let ck = 0x8000_0000u32 | cookie;
+        let cp = self.av_slot(f, ck, w);
+        let tp = temp.map(|t| self.av_slot(f, t, w));
         let wc = self.expr_width(f, cond)?;
         let c = self.expr(f, cond)?;
         let cz = self.nonzero(c, wc);
@@ -4629,28 +4737,25 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         let v = self
             .emit_foreign(f, tf, args, signed, w, stop_bb)?
             .expect("task returns");
-        let g_end = self.builder.get_insert_block().unwrap();
+        self.builder.build_store(cp, v).unwrap();
+        if let Some(tp) = tp {
+            self.builder.build_store(tp, v).unwrap();
+        }
         self.builder.build_unconditional_branch(jn_bb).unwrap();
         self.builder.position_at_end(sk_bb);
-        let z = self.ity(w).const_zero();
-        let s_end = self.builder.get_insert_block().unwrap();
         self.builder.build_unconditional_branch(jn_bb).unwrap();
         self.builder.position_at_end(jn_bb);
-        let phi = self.builder.build_phi(self.ity(w), "tphi").unwrap();
-        phi.add_incoming(&[(&v, g_end), (&z, s_end)]);
-        let out = phi.as_basic_value().into_int_value();
+        // the slot is the single source of truth at the join: executed
+        // value, or the preserved previous/undet contents on skip —
+        // exactly the interp's locals-then-latched-then-undet order
+        let out = self
+            .builder
+            .build_load(self.ity(w), cp, "tval")
+            .unwrap()
+            .into_int_value();
         f.tasks.insert(cookie, (out, w));
-        // join-safe mirror of the interp's body-wide ctx.locals: store
-        // the result under the cookie's synthetic key (interp
-        // cookie_key) and the temp so references after an enclosing
-        // Cond join load the executed value instead of going Ineligible
-        let ck = 0x8000_0000u32 | cookie;
-        let cp = self.av_slot(f, ck, w);
-        self.builder.build_store(cp, out).unwrap();
         if let Some(t) = temp {
             f.ssa.insert(t, out);
-            let tp = self.av_slot(f, t, w);
-            self.builder.build_store(tp, out).unwrap();
         }
         Ok(out)
     }
@@ -5222,5 +5327,44 @@ mod tests {
     #[test]
     fn jit_round_trip() {
         assert_eq!(super::llvm_smoke_test().unwrap(), 42);
+    }
+
+    #[test]
+    fn proto_tags_round_trip_and_fail_closed() {
+        use super::{decode_protos, encode_protos, FArgSpec, FnProtos, ForeignSpec};
+        let protos = vec![FnProtos {
+            sched_foreign: vec![ForeignSpec {
+                inst: 3,
+                func: 7,
+                ret_width: 64,
+                args: vec![
+                    FArgSpec::Str(11),
+                    FArgSpec::Num { width: 0, signed: false },
+                    FArgSpec::Num { width: 65, signed: true },
+                    FArgSpec::Real,
+                    FArgSpec::StrDyn,
+                ],
+            }],
+            sched_prims: vec![],
+            exec_foreign: vec![],
+            exec_prims: vec![],
+        }];
+        let bytes = encode_protos(&protos);
+        let back = decode_protos(&bytes).expect("round trip");
+        assert_eq!(back.len(), 1);
+        let args = &back[0].sched_foreign[0].args;
+        assert!(matches!(args[0], FArgSpec::Str(11)));
+        assert!(matches!(args[1], FArgSpec::Num { width: 0, signed: false }));
+        assert!(matches!(args[2], FArgSpec::Num { width: 65, signed: true }));
+        assert!(matches!(args[3], FArgSpec::Real));
+        assert!(matches!(args[4], FArgSpec::StrDyn));
+        // an unknown tag is a corrupted or future-format artifact:
+        // decode must fail CLOSED, never fall open as Num
+        let mut bad = encode_protos(&protos);
+        // first arg record's tag word: protos_count(4) foreign_count(4)
+        // inst(4) func(4) ret(4) argc(4) -> tag at byte offset 24
+        let tag_off = 4 + 4 + 4 + 4 + 4 + 4;
+        bad[tag_off] = 9;
+        assert!(super::decode_protos(&bad).is_none());
     }
 }

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -852,7 +852,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 15;
+pub const AOT_LAYOUT_REV: u64 = 16;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -2154,7 +2154,13 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // values get schedule-time slots (mcd_Rand measured a
                 // cross-domain divergence with live re-expansion)
                 if let Some((owner, g)) = ie.gates.get(p) {
-                    if !gate_static(g) {
+                    // eligible dynamic cones: prim Gate chases are LIVE
+                    // reads on both engines, and a Port link recurses
+                    // through this same checked resolution in the owner
+                    // (terminating at a const, a further chase, or nope)
+                    if !gate_static(g)
+                        && !matches!(g, Expr::Gate { .. } | Expr::Port(_))
+                    {
                         return nope("dynamic input gate (latch semantics)");
                     }
                     let (owner, g) = (*owner, g.clone());
@@ -2693,7 +2699,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             return match mname.as_str() {
                 "first" if fw == width => {
                     let fst = load(2);
-                    Ok(self.load_val_dyn(f, base + 6, fst, fw))
+                    Ok(self.load_val_dyn(f, base + 7, fst, fw))
                 }
                 "notFull" if width == 1 => {
                     Ok(cmp_w1(self, IntPredicate::ULT, load(0), i64t.const_int(_size as u64, false)))
@@ -5286,6 +5292,19 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         } else {
                             bad
                         };
+                        // in-reset suppress (post-clear, until deassert):
+                        // bounce to the boxed prim, whose action_method
+                        // no-ops — the fast path must not stamp or write
+                        let sup = self
+                            .builder
+                            .build_int_compare(
+                                IntPredicate::NE,
+                                self.load_word(f, base + 6),
+                                i64t.const_zero(),
+                                "fsp",
+                            )
+                            .unwrap();
+                        let warn = self.builder.build_or(warn, sup, "fws").unwrap();
                         self.builder
                             .build_conditional_branch(warn, warn_bb, fast_bb)
                             .unwrap();
@@ -5338,7 +5357,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                                 Some(v) => v,
                                 None => self.ity(1).const_zero(),
                             };
-                            self.store_val_dyn(f, base + 6, idx, fw.max(1), dv);
+                            self.store_val_dyn(f, base + 7, idx, fw.max(1), dv);
                             let e2 = self
                                 .builder
                                 .build_int_add(elems, i64t.const_int(1, false), "fe2")

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -172,6 +172,12 @@ pub struct InstEnv {
     /// spec marks the argument Real (decode rebuilds Arg::Real).  Part
     /// of the exec dedup signature.
     pub real_consts: HashMap<StrId, u64>,
+    /// Input clock-gate ports bound at instantiation: port name ->
+    /// (owner instance, gate expr) — reads lower the expr in the
+    /// OWNER's frame, mirroring the interp's parent-context gate
+    /// evaluation.  Part of the exec dedup signature (owner slots are
+    /// absolute in deduped bodies, so gate wiring must pin the sig).
+    pub gates: HashMap<StrId, (usize, Expr)>,
     /// any rule's CAN_FIRE/WILL_FIRE def name -> arena slot (this
     /// instance); reads of other rules' fire signals become slot loads
     pub cfwf_slot: HashMap<StrId, u32>,
@@ -769,10 +775,35 @@ impl Drop for AotModeGuard {
     }
 }
 
+/// Sentinel method id in a PrimCallSpec: not a method call — the
+/// trampoline answers the prim's gate_out() (compiled Expr::Gate).
+pub const GATE_OUT_METHOD: StrId = u32::MAX;
+
+/// A gate expression a compiled read may re-expand: static cones only
+/// (constants, parameters, and pure combinationals over them).  Defs
+/// are excluded because the interp's gate eval prefers their LATCHED
+/// values; prim-state chases (Gate, method reads, flattened
+/// $CLK_GATE_OUT ports) are excluded pending schedule-time gate slots.
+fn gate_static(e: &Expr) -> bool {
+    match e {
+        Expr::Const { .. } | Expr::Param(_) => true,
+        Expr::Prim { args, .. } => args.iter().all(gate_static),
+        Expr::If { cond, then_, else_, .. } => {
+            gate_static(cond) && gate_static(then_) && gate_static(else_)
+        }
+        Expr::Case { scrutinee, arms, default, .. } => {
+            gate_static(scrutinee)
+                && arms.iter().all(|(_, a)| gate_static(a))
+                && gate_static(default)
+        }
+        _ => false,
+    }
+}
+
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 10;
+pub const AOT_LAYOUT_REV: u64 = 11;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -1783,6 +1814,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
             }
             Expr::Real(_) => Ok(64), // f64 bits carrier
+            Expr::Gate { .. } => Ok(1),
             Expr::Const { width, .. }
             | Expr::MethCall { width, .. }
             | Expr::MethValue { width, .. }
@@ -2031,6 +2063,22 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 if let Some(&bits) = ie.real_consts.get(p) {
                     return Ok(self.ctx.i64_type().const_int(bits, false));
                 }
+                // input clock-gate port bound at instantiation: the
+                // interp evaluates the recorded gate expr in the OWNER
+                // instance's context, where LATCHED defs win over
+                // recomputation — a compiled re-expansion only matches
+                // when the cone is static (no defs, no prim-state
+                // chases), so dynamic gates stay interp until gate
+                // values get schedule-time slots (mcd_Rand measured a
+                // cross-domain divergence with live re-expansion)
+                if let Some((owner, g)) = ie.gates.get(p) {
+                    if !gate_static(g) {
+                        return nope("dynamic input gate (latch semantics)");
+                    }
+                    let (owner, g) = (*owner, g.clone());
+                    let mut of = self.child_frame(f, owner, None)?;
+                    return self.expr(&mut of, &g);
+                }
                 nope("port read outside args/reset/EN/consts")
             }
             Expr::Param(p) => {
@@ -2050,6 +2098,56 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // args (and real params) consume them, so the bits never
                 // mix into integer arithmetic
                 Ok(self.ctx.i64_type().const_int(r.to_bits(), false))
+            }
+            Expr::Gate { instance, clock } => {
+                // a submodule's output clock gate (AMGate): prim
+                // children answer gate_out() through the trampoline
+                // (GATE_OUT_METHOD sentinel); user children evaluate
+                // their recorded ifc gate expr in the child's frame; no
+                // recorded gate = ungated (constant 1) — all three
+                // mirror the interp's Expr::Gate
+                let ie = self.ie(f.inst)?;
+                let Some(&child) = ie.children.get(instance) else {
+                    return nope("gate read on unknown child");
+                };
+                if self.env.insts.contains_key(&child) {
+                    let cie = self.ie(child)?;
+                    let cmod = &self.env.d.modules[cie.mir];
+                    let g = cmod
+                        .ifc_clock_gates
+                        .iter()
+                        .find(|(n, _)| n == clock)
+                        .map(|(_, e)| e.clone());
+                    return match g {
+                        Some(e) => {
+                            // same latch-semantics restriction as bound
+                            // input gates, except a direct child prim
+                            // gate chase (Expr::Gate) is a LIVE read on
+                            // both engines and stays eligible
+                            if !gate_static(&e)
+                                && !matches!(e, Expr::Gate { .. })
+                            {
+                                return nope(
+                                    "dynamic ifc gate (latch semantics)",
+                                );
+                            }
+                            let mut cf = self.child_frame(f, child, None)?;
+                            self.expr(&mut cf, &e)
+                        }
+                        None => Ok(self.ity(1).const_int(1, false)),
+                    };
+                }
+                match self.emit_prim_call(
+                    f,
+                    child,
+                    GATE_OUT_METHOD,
+                    &[],
+                    1,
+                    false,
+                )? {
+                    Some(v) => Ok(v),
+                    None => nope("gate_out returned no value"),
+                }
             }
             Expr::MethCall { width, instance, method, port, args } => {
                 self.value_call(f, *width, *instance, *method, *port, args)

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -1422,6 +1422,7 @@ fn lower_edge_ssa<'ctx>(
                     av_widths: HashMap::new(),
             dead_defs: Default::default(),
                     tasks: HashMap::new(),
+                    av_slots: HashMap::new(),
                     is_exec: true,
                     depth: 0,
                 };
@@ -1440,6 +1441,7 @@ fn lower_edge_ssa<'ctx>(
                 av_widths: HashMap::new(),
             dead_defs: Default::default(),
                 tasks: HashMap::new(),
+                av_slots: HashMap::new(),
                 is_exec,
                 depth: 0,
             };
@@ -1667,6 +1669,13 @@ struct Frame<'ctx> {
     /// ActionValue task results by cookie (Expr::TaskValue reads):
     /// (value, width)
     tasks: HashMap<u32, (IntValue<'ctx>, u32)>,
+    /// join-safe ActionValue task results (value alloca, width), keyed
+    /// by the bound def/temp name and by the cookie's synthetic key:
+    /// the interp's ctx.locals persists past a Cond join, so a task
+    /// executed inside an arm is readable after it — the alloca
+    /// initializes to the undet pattern (what a never-run arm's read
+    /// yields) and stores at task execution
+    av_slots: HashMap<StrId, (PointerValue<'ctx>, u32)>,
     /// effectful-eval def memos (value alloca, valid-flag alloca):
     /// evaluate at FIRST dynamic reference this invocation, reuse
     /// after — even across Cond joins where the ssa binding dies
@@ -1753,6 +1762,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             },
             Expr::Const { width, .. }
             | Expr::MethCall { width, .. }
+            | Expr::MethValue { width, .. }
+            | Expr::TaskValue { width, .. }
+            | Expr::ForeignCall { width, .. }
             | Expr::Prim { width, .. }
             | Expr::If { width, .. }
             | Expr::Case { width, .. } => {
@@ -2084,10 +2096,23 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 Ok(phi.as_basic_value().into_int_value())
             }
-            Expr::TaskValue { width, cookie } => match f.tasks.get(cookie) {
-                Some(&(v, vw)) => Ok(self.to_w(v, vw, (*width).max(1), false)),
-                None => nope("task value before its task"),
-            },
+            Expr::TaskValue { width, cookie } => {
+                // load the join-safe slot when the task has one — valid
+                // from any block, unlike the tphi value, which only
+                // dominates its own arm
+                if let Some(&(p, vw)) = f.av_slots.get(&(0x8000_0000u32 | *cookie)) {
+                    let v = self
+                        .builder
+                        .build_load(self.ity(vw), p, "tval")
+                        .unwrap()
+                        .into_int_value();
+                    return Ok(self.to_w(v, vw, (*width).max(1), false));
+                }
+                match f.tasks.get(cookie) {
+                    Some(&(v, vw)) => Ok(self.to_w(v, vw, (*width).max(1), false)),
+                    None => nope("task value before its task"),
+                }
+            }
             Expr::Prim { op, width, args } => self.prim(f, *op, *width, args),
             Expr::ForeignCall { width, func, args } => {
                 self.bdpi_value_call(f, (*width).max(1), *func, args)
@@ -2806,6 +2831,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             av_widths: HashMap::new(),
             dead_defs: Default::default(),
             tasks: HashMap::new(),
+            av_slots: HashMap::new(),
             is_exec: f.is_exec,
             depth: f.depth + 1,
         })
@@ -3046,11 +3072,62 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         Ok(out)
     }
 
+    /// Join-safe slot for an ActionValue task binding: an entry alloca
+    /// initialized to the undet pattern (Value::undet — what the interp
+    /// yields when the binding arm never ran), stored at task execution.
+    /// Post-join references load it, mirroring the interp's body-wide
+    /// ctx.locals.
+    fn av_slot(&mut self, f: &mut Frame<'ctx>, n: StrId, w: u32) -> PointerValue<'ctx> {
+        if let Some(&(p, _)) = f.av_slots.get(&n) {
+            return p;
+        }
+        let ty = self.ity(w);
+        let p = self.entry_alloca(ty, 1, "avsl");
+        // undet init must dominate every reference site (same
+        // discipline as the thunk valid-flag init)
+        let mut words = vec![0xAAAA_AAAA_AAAA_AAAAu64; words_for(w) as usize];
+        let rem = w % 64;
+        if rem != 0 {
+            let last = words.len() - 1;
+            words[last] &= (1u64 << rem) - 1;
+        }
+        let undet = ty.const_int_arbitrary_precision(&words);
+        let b = self.ctx.create_builder();
+        match p.as_instruction().and_then(|i| i.get_next_instruction()) {
+            Some(next) => b.position_before(&next),
+            None => {
+                let entry = self
+                    .builder
+                    .get_insert_block()
+                    .unwrap()
+                    .get_parent()
+                    .unwrap()
+                    .get_first_basic_block()
+                    .unwrap();
+                b.position_at_end(entry);
+            }
+        }
+        b.build_store(p, undet).unwrap();
+        f.av_slots.insert(n, (p, w));
+        p
+    }
+
     fn def(&mut self, f: &mut Frame<'ctx>, n: StrId) -> Result<IntValue<'ctx>, Ineligible> {
         if let Some(v) = f.ssa.get(&n) {
             return Ok(*v);
         }
         if f.dead_defs.contains(&n) {
+            // an ActionValue task binding survives the join through its
+            // slot (interp parity: ctx.locals is body-wide; undet when
+            // the arm never ran)
+            if let Some(&(p, w)) = f.av_slots.get(&n) {
+                let out = self
+                    .builder
+                    .build_load(self.ity(w), p, "avesc")
+                    .unwrap()
+                    .into_int_value();
+                return Ok(out);
+            }
             return Err(Ineligible(format!(
                 "def escaped conditional arm: {}",
                 self.env.d.strings[n as usize]
@@ -3502,6 +3579,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             av_widths: HashMap::new(),
             dead_defs: Default::default(),
             tasks: HashMap::new(),
+            av_slots: HashMap::new(),
             is_exec: false,
             depth: 0,
         };
@@ -3617,6 +3695,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             av_widths: HashMap::new(),
             dead_defs: Default::default(),
             tasks: HashMap::new(),
+            av_slots: HashMap::new(),
             is_exec: true,
             depth: 0,
         };
@@ -3722,6 +3801,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             av_widths: HashMap::new(),
             dead_defs: Default::default(),
             tasks: HashMap::new(),
+            av_slots: HashMap::new(),
             is_exec: true,
             depth: 0,
         };
@@ -3905,6 +3985,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         f.av_widths.insert(*def, (*width).max(1));
                         f.dead_defs.remove(def);
                         f.ssa.insert(*def, v);
+                        // join-safe binding for the AvAction def itself
+                        let dp = self.av_slot(f, *def, (*width).max(1));
+                        self.builder.build_store(dp, v).unwrap();
                     }
                     Action::MethCall { instance, method, port, cond, args } => {
                         // ActionValue method on a prim child (trampoline)
@@ -4182,8 +4265,17 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         phi.add_incoming(&[(&v, g_end), (&z, s_end)]);
         let out = phi.as_basic_value().into_int_value();
         f.tasks.insert(cookie, (out, w));
+        // join-safe mirror of the interp's body-wide ctx.locals: store
+        // the result under the cookie's synthetic key (interp
+        // cookie_key) and the temp so references after an enclosing
+        // Cond join load the executed value instead of going Ineligible
+        let ck = 0x8000_0000u32 | cookie;
+        let cp = self.av_slot(f, ck, w);
+        self.builder.build_store(cp, out).unwrap();
         if let Some(t) = temp {
             f.ssa.insert(t, out);
+            let tp = self.av_slot(f, t, w);
+            self.builder.build_store(tp, out).unwrap();
         }
         Ok(out)
     }

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -184,6 +184,10 @@ pub struct InstEnv {
     /// Eq, and the StringConcat intern callback.  Part of the exec
     /// dedup signature.
     pub str_consts: HashMap<StrId, StrId>,
+    /// Instantiation values wider than 64 bits: name -> (width, LE
+    /// 32-bit limbs), lowered as wide constants (cval).  Part of the
+    /// exec dedup signature.
+    pub wide_consts: HashMap<StrId, (u32, Vec<u32>)>,
     /// any rule's CAN_FIRE/WILL_FIRE def name -> arena slot (this
     /// instance); reads of other rules' fire signals become slot loads
     pub cfwf_slot: HashMap<StrId, u32>,
@@ -1822,6 +1826,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     if ie.real_consts.contains_key(p) {
                         return Ok(64); // f64 bits carrier
                     }
+                    if let Some(&(w, _)) = ie.wide_consts.get(p) {
+                        return Ok(w);
+                    }
                     Ok(ie.port_consts.get(p).map_or(1, |&(w, _)| w)) // reset/EN ports read 1 bit
                 }
             },
@@ -1829,6 +1836,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 let ie = self.ie(f.inst)?;
                 if ie.real_consts.contains_key(p) {
                     return Ok(64); // f64 bits carrier
+                }
+                if let Some(&(w, _)) = ie.wide_consts.get(p) {
+                    return Ok(w);
                 }
                 match ie.port_consts.get(p) {
                     Some(&(w, _)) => Ok(w),
@@ -2093,6 +2103,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 if let Some(&bits) = ie.real_consts.get(p) {
                     return Ok(self.ctx.i64_type().const_int(bits, false));
                 }
+                if let Some((w, limbs)) = ie.wide_consts.get(p) {
+                    let (w, limbs) = (*w, limbs.clone());
+                    return Ok(self.cval(w, &limbs));
+                }
                 // input clock-gate port bound at instantiation: the
                 // interp evaluates the recorded gate expr in the OWNER
                 // instance's context, where LATCHED defs win over
@@ -2115,6 +2129,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 let ie = self.ie(f.inst)?;
                 if let Some(&bits) = ie.real_consts.get(p) {
                     return Ok(self.ctx.i64_type().const_int(bits, false));
+                }
+                if let Some((w, limbs)) = ie.wide_consts.get(p) {
+                    let (w, limbs) = (*w, limbs.clone());
+                    return Ok(self.cval(w, &limbs));
                 }
                 match ie.port_consts.get(p) {
                     Some(&(w, v)) => {
@@ -2181,6 +2199,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             }
             Expr::MethCall { width, instance, method, port, args } => {
                 self.value_call(f, *width, *instance, *method, *port, args)
+            }
+            Expr::MethValue { width, instance, method } => {
+                // the returned value of an ActionValue method: the
+                // interp calls call_value with no args — identical to a
+                // no-arg value method read (port 0)
+                self.value_call(f, *width, *instance, *method, 0, &[])
             }
             Expr::If { width, cond, then_, else_ } => {
                 let wc = self.expr_width(f, cond)?;

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -426,6 +426,9 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
 /// Inverse of encode_protos; None on truncation/garbage.
 pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
     let mut i = 0usize;
+    // artifact-supplied counts must never drive an allocation larger
+    // than the bytes backing them: every record is >= 4 bytes, so any
+    // count above b.len()/4 is corruption — reject before reserving
     fn r(b: &[u8], i: &mut usize) -> Option<u32> {
         let v = u32::from_le_bytes(b.get(*i..*i + 4)?.try_into().ok()?);
         *i += 4;
@@ -433,12 +436,18 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
     }
     fn rf(b: &[u8], i: &mut usize) -> Option<Vec<ForeignSpec>> {
         let n = r(b, i)?;
+        if n as usize > b.len() / 4 {
+            return None;
+        }
         let mut v = Vec::with_capacity(n as usize);
         for _ in 0..n {
             let inst = r(b, i)? as usize;
             let func = r(b, i)?;
             let ret_width = r(b, i)?;
             let argc = r(b, i)?;
+            if argc as usize > b.len() / 4 {
+                return None;
+            }
             let mut args = Vec::with_capacity(argc as usize);
             for _ in 0..argc {
                 let tag = r(b, i)?;
@@ -462,6 +471,9 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
     }
     fn rp(b: &[u8], i: &mut usize) -> Option<Vec<PrimCallSpec>> {
         let n = r(b, i)?;
+        if n as usize > b.len() / 4 {
+            return None;
+        }
         let mut v = Vec::with_capacity(n as usize);
         for _ in 0..n {
             let inst = r(b, i)? as usize;
@@ -469,6 +481,9 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
             let ret_width = r(b, i)?;
             let is_action = r(b, i)? != 0;
             let argc = r(b, i)?;
+            if argc as usize > b.len() / 4 {
+                return None;
+            }
             let mut arg_widths = Vec::with_capacity(argc as usize);
             for _ in 0..argc {
                 arg_widths.push(r(b, i)?);
@@ -478,6 +493,9 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
         Some(v)
     }
     let n = r(b, &mut i)?;
+    if n as usize > b.len() / 4 {
+        return None;
+    }
     let mut out = Vec::with_capacity(n as usize);
     for _ in 0..n {
         out.push(FnProtos {
@@ -834,7 +852,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 13;
+pub const AOT_LAYOUT_REV: u64 = 14;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -2258,6 +2276,17 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // phi at the merge
                 let w = (*width).max(1);
                 let ws = self.expr_width(f, scrutinee)?;
+                // interp semantics (lib.rs Case eval): a scrutinee wider
+                // than 64 bits NEVER matches an arm (as_u64 compare is
+                // gated on width <= 64) — lower the default only.  Keys
+                // outside ws bits can't match either (the interp compares
+                // the untruncated u64), and truncating them into the
+                // switch could alias or duplicate cases.
+                if ws > 64 {
+                    let wd = self.expr_width(f, default)?;
+                    let dv = self.expr(f, default)?;
+                    return Ok(self.to_w(dv, wd, w, false));
+                }
                 let sv = self.expr(f, scrutinee)?;
                 let func =
                     self.builder.get_insert_block().unwrap().get_parent().unwrap();
@@ -2267,9 +2296,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     .iter()
                     .map(|_| self.ctx.append_basic_block(func, "ca"))
                     .collect();
+                let representable =
+                    |k: u64| ws >= 64 || k < (1u64 << ws);
                 let cases: Vec<_> = arms
                     .iter()
                     .zip(&arm_bbs)
+                    .filter(|((k, _), _)| representable(*k))
                     .map(|((k, _), &bb)| {
                         (self.ity(ws).const_int_arbitrary_precision(&[*k]), bb)
                     })
@@ -2843,7 +2875,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         );
                 ok.then_some(2)
             }
-            E::Prim { args, .. } => {
+            E::Prim { op, args, .. } => {
+                // Quot/Rem lower with an unconditional divisor-zero trap
+                // check: speculating them in an unselected arm SIGFPEs
+                // where the interp (evaluating only the taken arm) does
+                // not — the canonical `b == 0 ? 0 : a % b` guard
+                if matches!(op, PrimOp::Quot | PrimOp::Rem) {
+                    return None;
+                }
                 let mut total = 1u32;
                 for a in args {
                     total += self.pure_size(f, a, cap.checked_sub(total)?)?;
@@ -2965,6 +3004,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
         let token_const =
             self.token_kind | self.prim_calls.len() as u64;
+        if self.prim_calls.len() >= 1 << 16 {
+            return nope("prim call-site count exceeds the 16-bit token field");
+        }
         let token = self.spec.token_base | token_const;
         self.prim_calls.push(PrimCallSpec {
             inst: prim_inst,
@@ -3283,6 +3325,21 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// yields when the binding arm never ran), stored at task execution.
     /// Post-join references load it, mirroring the interp's body-wide
     /// ctx.locals.
+    /// The interp's Value::undet pattern (0xAA..., masked to width) as
+    /// an LLVM constant.
+    fn undet_const(&self, w: u32) -> IntValue<'ctx> {
+        let mut words = vec![0xAAAA_AAAA_AAAA_AAAAu64; words_for(w.max(1)) as usize];
+        let rem = w % 64;
+        if w != 0 && rem != 0 {
+            let last = words.len() - 1;
+            words[last] &= (1u64 << rem) - 1;
+        }
+        if w == 0 {
+            words = vec![0];
+        }
+        self.ity(w).const_int_arbitrary_precision(&words)
+    }
+
     fn av_slot(&mut self, f: &mut Frame<'ctx>, n: StrId, w: u32) -> PointerValue<'ctx> {
         if let Some(&(p, _)) = f.av_slots.get(&n) {
             return p;
@@ -3722,26 +3779,42 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     .into_int_value())
             }
             PrimOp::Concat => {
-                // left-to-right, first arg highest
+                // left-to-right, first arg highest.  Zero-width members
+                // contribute nothing and are skipped; the first real
+                // member seeds acc UNSHIFTED — otherwise a full-width
+                // member (its siblings all zero-width) would emit
+                // `shl iW acc, W`, which is LLVM poison
                 let t = self.ity(width);
-                let mut acc = t.const_zero();
+                let mut acc: Option<IntValue<'ctx>> = None;
                 let mut total = 0u32;
                 for a in args {
                     let wa = self.expr_width(f, a)?;
                     let v0 = self.expr(f, a)?;
+                    if wa == 0 {
+                        continue;
+                    }
                     let v = self.to_w(v0, wa, width, false);
                     total += wa;
                     if total > width {
                         return nope("concat width overflow");
                     }
-                    let sh = t.const_int(wa as u64, false);
-                    let shifted = self.builder.build_left_shift(acc, sh, "cc").unwrap();
-                    acc = self.builder.build_or(shifted, v, "co").unwrap();
+                    acc = Some(match acc {
+                        None => v,
+                        Some(prev) => {
+                            // prev holds >= 1 bit, so wa <= width - 1
+                            let sh = t.const_int(wa as u64, false);
+                            let shifted = self
+                                .builder
+                                .build_left_shift(prev, sh, "cc")
+                                .unwrap();
+                            self.builder.build_or(shifted, v, "co").unwrap()
+                        }
+                    });
                 }
                 if total != width {
                     return nope("concat width mismatch");
                 }
-                Ok(acc)
+                Ok(acc.unwrap_or_else(|| t.const_zero()))
             }
             PrimOp::ZeroExt => {
                 let ws = self.expr_width(f, &args[0])?;
@@ -4073,6 +4146,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// Reals reach simulation only as literals, parameters, and muxes/
     /// defs over those, so the classification is decidable at lowering.
     fn expr_is_real(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        self.expr_is_real_in(f, e, &mut Vec::new())
+    }
+
+    fn expr_is_real_in(
+        &self,
+        f: &Frame<'ctx>,
+        e: &Expr,
+        seen: &mut Vec<StrId>,
+    ) -> bool {
         match e {
             Expr::Real(_) => true,
             Expr::Param(p) | Expr::Port(p) => self
@@ -4080,19 +4162,26 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 .map(|ie| ie.real_consts.contains_key(p))
                 .unwrap_or(false),
             Expr::If { then_, else_, .. } => {
-                self.expr_is_real(f, then_) || self.expr_is_real(f, else_)
+                self.expr_is_real_in(f, then_, seen)
+                    || self.expr_is_real_in(f, else_, seen)
             }
             Expr::Case { arms, default, .. } => {
-                arms.iter().any(|(_, a)| self.expr_is_real(f, a))
-                    || self.expr_is_real(f, default)
+                arms.iter().any(|(_, a)| self.expr_is_real_in(f, a, seen))
+                    || self.expr_is_real_in(f, default, seen)
             }
             Expr::Def(n) => {
+                if seen.contains(n) {
+                    return false; // cycle guard
+                }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                m.defs
-                    .iter()
-                    .find(|d| d.name == *n)
-                    .is_some_and(|d| self.expr_is_real(f, &d.expr))
+                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                    return false;
+                };
+                seen.push(*n);
+                let r = self.expr_is_real_in(f, &d.expr, seen);
+                seen.pop();
+                r
             }
             _ => false,
         }
@@ -4103,6 +4192,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// Strings are literals, string params, muxes/defs over those,
     /// marker-passthrough width adjustments, and StringConcat results.
     fn expr_is_str(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        self.expr_is_str_in(f, e, &mut Vec::new())
+    }
+
+    fn expr_is_str_in(
+        &self,
+        f: &Frame<'ctx>,
+        e: &Expr,
+        seen: &mut Vec<StrId>,
+    ) -> bool {
         match e {
             Expr::Str(_) => true,
             Expr::Param(p) | Expr::Port(p) => self
@@ -4110,23 +4208,31 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 .map(|ie| ie.str_consts.contains_key(p))
                 .unwrap_or(false),
             Expr::If { then_, else_, .. } => {
-                self.expr_is_str(f, then_) || self.expr_is_str(f, else_)
+                self.expr_is_str_in(f, then_, seen)
+                    || self.expr_is_str_in(f, else_, seen)
             }
             Expr::Case { arms, default, .. } => {
-                arms.iter().any(|(_, a)| self.expr_is_str(f, a))
-                    || self.expr_is_str(f, default)
+                arms.iter().any(|(_, a)| self.expr_is_str_in(f, a, seen))
+                    || self.expr_is_str_in(f, default, seen)
             }
             Expr::Def(n) => {
+                if seen.contains(n) {
+                    return false; // cycle guard
+                }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                m.defs
-                    .iter()
-                    .find(|d| d.name == *n)
-                    .is_some_and(|d| self.expr_is_str(f, &d.expr))
+                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                    return false;
+                };
+                seen.push(*n);
+                let r = self.expr_is_str_in(f, &d.expr, seen);
+                seen.pop();
+                r
             }
             Expr::Prim { op: PrimOp::StringConcat, .. } => true,
             Expr::Prim { op: PrimOp::ZeroExt | PrimOp::SignExt, args, .. } => {
-                args.first().is_some_and(|a| self.expr_is_str(f, a))
+                args.first()
+                    .is_some_and(|a| self.expr_is_str_in(f, a, seen))
             }
             _ => false,
         }
@@ -4136,20 +4242,31 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// including through Def table expansion?  Concat interns per
     /// evaluation, so it must never run on an unselected mux arm.
     fn contains_concat(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        self.contains_concat_in(f, e, &mut Vec::new())
+    }
+
+    fn contains_concat_in(
+        &self,
+        f: &Frame<'ctx>,
+        e: &Expr,
+        seen: &mut Vec<StrId>,
+    ) -> bool {
         match e {
             Expr::Prim { op: PrimOp::StringConcat, .. } => true,
             Expr::Prim { args, .. } => {
-                args.iter().any(|a| self.contains_concat(f, a))
+                args.iter().any(|a| self.contains_concat_in(f, a, seen))
             }
             Expr::If { cond, then_, else_, .. } => {
-                self.contains_concat(f, cond)
-                    || self.contains_concat(f, then_)
-                    || self.contains_concat(f, else_)
+                self.contains_concat_in(f, cond, seen)
+                    || self.contains_concat_in(f, then_, seen)
+                    || self.contains_concat_in(f, else_, seen)
             }
             Expr::Case { scrutinee, arms, default, .. } => {
-                self.contains_concat(f, scrutinee)
-                    || arms.iter().any(|(_, a)| self.contains_concat(f, a))
-                    || self.contains_concat(f, default)
+                self.contains_concat_in(f, scrutinee, seen)
+                    || arms
+                        .iter()
+                        .any(|(_, a)| self.contains_concat_in(f, a, seen))
+                    || self.contains_concat_in(f, default, seen)
             }
             Expr::Def(n) => {
                 // a positioned binding is already a pure id; only an
@@ -4157,12 +4274,18 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 if f.ssa.contains_key(n) {
                     return false;
                 }
+                if seen.contains(n) {
+                    return false; // cycle guard
+                }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                m.defs
-                    .iter()
-                    .find(|d| d.name == *n)
-                    .is_some_and(|d| self.contains_concat(f, &d.expr))
+                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                    return false;
+                };
+                seen.push(*n);
+                let r = self.contains_concat_in(f, &d.expr, seen);
+                seen.pop();
+                r
             }
             _ => false,
         }
@@ -4213,9 +4336,16 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return nope("string concat under a mux arm");
                 }
                 let ws = self.expr_width(f, scrutinee)?;
+                // interp mirror: wide scrutinees never match an arm
+                if ws > 64 {
+                    return self.str_expr(f, default, stop_bb);
+                }
                 let sv = self.expr(f, scrutinee)?;
                 let mut acc = self.str_expr(f, default, stop_bb)?;
                 for (k, a) in arms {
+                    if ws < 64 && *k >= (1u64 << ws) {
+                        continue; // key not representable: never matches
+                    }
                     let kv = self.ity(ws).const_int(*k, false);
                     let hit = self
                         .builder
@@ -4372,6 +4502,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
         let token =
             self.spec.token_base | self.token_kind | self.foreign_stmts.len() as u64;
+        if self.foreign_stmts.len() >= 1 << 16 {
+            return nope("foreign call-site count exceeds the 16-bit token field");
+        }
         let token_const = self.token_kind | (self.foreign_stmts.len() as u64);
         self.foreign_stmts.push(ForeignSpec {
             inst: f.inst,
@@ -4549,7 +4682,11 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             let g_end = self.builder.get_insert_block().unwrap();
                             self.builder.build_unconditional_branch(jn_bb).unwrap();
                             self.builder.position_at_end(sk_bb);
-                            let undet = self.ity(wd).const_zero();
+                            // the interp binds Value::undet (the masked
+                            // 0xAA... pattern) when the call condition is
+                            // false — NOT zero (review finding: the old
+                            // comment claimed parity while binding 0)
+                            let undet = self.undet_const(wd);
                             let s_end = self.builder.get_insert_block().unwrap();
                             self.builder.build_unconditional_branch(jn_bb).unwrap();
                             self.builder.position_at_end(jn_bb);
@@ -4570,6 +4707,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         let jn_bb = self.ctx.append_basic_block(func, "avjn");
                         self.builder.build_conditional_branch(cz, go_bb, sk_bb).unwrap();
                         self.builder.position_at_end(go_bb);
+                        // the trampoline routes is_action to call_action,
+                        // which never writes the out buffer, and no prim
+                        // implements an AV method (the interp panics):
+                        // refuse rather than read uninitialized words
+                        return nope("prim actionvalue method (no trampoline AV path)");
+                        #[allow(unreachable_code)]
                         let v = self
                             .emit_prim_call(f, child, *method, args, wd, true)?
                             .expect("av prim call returns");

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -166,6 +166,12 @@ pub struct InstEnv {
     /// have arena slots; string params are marker values).  Part of
     /// the exec dedup signature.
     pub port_consts: HashMap<StrId, (u32, u64)>,
+    /// Real-valued instantiation parameters, as f64 bits: reals reach
+    /// simulation only as task arguments and module parameters, so the
+    /// compiled carrier is an i64 of the double's bits and the foreign
+    /// spec marks the argument Real (decode rebuilds Arg::Real).  Part
+    /// of the exec dedup signature.
+    pub real_consts: HashMap<StrId, u64>,
     /// any rule's CAN_FIRE/WILL_FIRE def name -> arena slot (this
     /// instance); reads of other rules' fire signals become slot loads
     pub cfwf_slot: HashMap<StrId, u32>,
@@ -228,12 +234,15 @@ pub struct ForeignSpec {
     pub args: Vec<FArgSpec>,
 }
 
-/// One foreign argument: a string literal (no marshaled words) or a
-/// numeric value of the given width with its signed-display flag.
+/// One foreign argument: a string literal (no marshaled words), a
+/// numeric value of the given width with its signed-display flag, or a
+/// real value (one marshaled word carrying the f64 bits — the decode
+/// rebuilds the interp's Arg::Real so formatting is identical).
 #[derive(Clone)]
 pub enum FArgSpec {
     Str(StrId),
     Num { width: u32, signed: bool },
+    Real,
 }
 
 /// A compiled rule sched function (kept alive by the leaked engine).
@@ -357,6 +366,11 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
                         w(o, *width);
                         w(o, *signed as u32);
                     }
+                    FArgSpec::Real => {
+                        w(o, 2);
+                        w(o, 0);
+                        w(o, 0);
+                    }
                 }
             }
         }
@@ -405,10 +419,10 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
                 let tag = r(b, i)?;
                 let a = r(b, i)?;
                 let sg = r(b, i)?;
-                args.push(if tag == 0 {
-                    FArgSpec::Str(a)
-                } else {
-                    FArgSpec::Num { width: a, signed: sg != 0 }
+                args.push(match tag {
+                    0 => FArgSpec::Str(a),
+                    2 => FArgSpec::Real,
+                    _ => FArgSpec::Num { width: a, signed: sg != 0 },
                 });
             }
             v.push(ForeignSpec { inst, func, ret_width, args });
@@ -758,7 +772,7 @@ impl Drop for AotModeGuard {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 9;
+pub const AOT_LAYOUT_REV: u64 = 10;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -1750,16 +1764,25 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             },
             Expr::Port(p) => match f.args.get(p) {
                 Some(&(_, w)) => Ok(w),
-                None => Ok(self
-                    .ie(f.inst)?
-                    .port_consts
-                    .get(p)
-                    .map_or(1, |&(w, _)| w)), // reset/EN ports read 1 bit
+                None => {
+                    let ie = self.ie(f.inst)?;
+                    if ie.real_consts.contains_key(p) {
+                        return Ok(64); // f64 bits carrier
+                    }
+                    Ok(ie.port_consts.get(p).map_or(1, |&(w, _)| w)) // reset/EN ports read 1 bit
+                }
             },
-            Expr::Param(p) => match self.ie(f.inst)?.port_consts.get(p) {
-                Some(&(w, _)) => Ok(w),
-                None => nope("parameter not constant-lowerable"),
-            },
+            Expr::Param(p) => {
+                let ie = self.ie(f.inst)?;
+                if ie.real_consts.contains_key(p) {
+                    return Ok(64); // f64 bits carrier
+                }
+                match ie.port_consts.get(p) {
+                    Some(&(w, _)) => Ok(w),
+                    None => nope("parameter not constant-lowerable"),
+                }
+            }
+            Expr::Real(_) => Ok(64), // f64 bits carrier
             Expr::Const { width, .. }
             | Expr::MethCall { width, .. }
             | Expr::MethValue { width, .. }
@@ -2005,16 +2028,28 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 if let Some(&(w, v)) = ie.port_consts.get(p) {
                     return Ok(self.cval(w, &[v as u32, (v >> 32) as u32]));
                 }
+                if let Some(&bits) = ie.real_consts.get(p) {
+                    return Ok(self.ctx.i64_type().const_int(bits, false));
+                }
                 nope("port read outside args/reset/EN/consts")
             }
             Expr::Param(p) => {
                 let ie = self.ie(f.inst)?;
+                if let Some(&bits) = ie.real_consts.get(p) {
+                    return Ok(self.ctx.i64_type().const_int(bits, false));
+                }
                 match ie.port_consts.get(p) {
                     Some(&(w, v)) => {
                         Ok(self.cval(w, &[v as u32, (v >> 32) as u32]))
                     }
                     None => nope("parameter not constant-lowerable"),
                 }
+            }
+            Expr::Real(r) => {
+                // reals ride as i64 f64-bits; only Real-marked foreign
+                // args (and real params) consume them, so the bits never
+                // mix into integer arithmetic
+                Ok(self.ctx.i64_type().const_int(r.to_bits(), false))
             }
             Expr::MethCall { width, instance, method, port, args } => {
                 self.value_call(f, *width, *instance, *method, *port, args)
@@ -3842,6 +3877,36 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// Marshal a foreign call site: numeric args as word runs (strings
     /// ride the spec table), call, optionally read back result words.
     /// Returns the result value for tasks (ret_width > 0).
+    /// Statically real-typed expressions: the shapes whose interp
+    /// evaluation yields a REAL_MARKER Value (val_arg -> Arg::Real).
+    /// Reals reach simulation only as literals, parameters, and muxes/
+    /// defs over those, so the classification is decidable at lowering.
+    fn expr_is_real(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        match e {
+            Expr::Real(_) => true,
+            Expr::Param(p) | Expr::Port(p) => self
+                .ie(f.inst)
+                .map(|ie| ie.real_consts.contains_key(p))
+                .unwrap_or(false),
+            Expr::If { then_, else_, .. } => {
+                self.expr_is_real(f, then_) || self.expr_is_real(f, else_)
+            }
+            Expr::Case { arms, default, .. } => {
+                arms.iter().any(|(_, a)| self.expr_is_real(f, a))
+                    || self.expr_is_real(f, default)
+            }
+            Expr::Def(n) => {
+                let Ok(ie) = self.ie(f.inst) else { return false };
+                let m = &self.env.d.modules[ie.mir];
+                m.defs
+                    .iter()
+                    .find(|d| d.name == *n)
+                    .is_some_and(|d| self.expr_is_real(f, &d.expr))
+            }
+            _ => false,
+        }
+    }
+
     fn emit_foreign(
         &mut self,
         f: &mut Frame<'ctx>,
@@ -3860,6 +3925,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         for (i, a) in args.iter().enumerate() {
             if let Expr::Str(sid) = a {
                 spec_args.push(FArgSpec::Str(*sid));
+                continue;
+            }
+            if self.expr_is_real(f, a) {
+                // i64 f64-bits value, one marshaled word; the spec's
+                // Real tag makes the decode rebuild Arg::Real
+                let v = self.expr(f, a)?;
+                spec_args.push(FArgSpec::Real);
+                vals.push((v, 64));
                 continue;
             }
             let wa = self.expr_width(f, a)?;

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -758,7 +758,7 @@ impl Drop for AotModeGuard {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 8;
+pub const AOT_LAYOUT_REV: u64 = 9;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -1734,7 +1734,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         let m = &self.env.d.modules[ie.mir];
         match m.defs.iter().find(|d| d.name == name) {
             Some(d) if d.width >= 1 => Ok(d.width),
-            Some(_) => nope("zero-width def"),
+            Some(_) => Ok(0), // zero-width def: the empty bit-vector
             None => Err(Ineligible(format!(
                 "unknown def (width): {}",
                 self.env.d.strings[name as usize]
@@ -1767,13 +1767,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             | Expr::ForeignCall { width, .. }
             | Expr::Prim { width, .. }
             | Expr::If { width, .. }
-            | Expr::Case { width, .. } => {
-                if *width >= 1 {
-                    Ok(*width)
-                } else {
-                    nope("zero-width expression")
-                }
-            }
+            | Expr::Case { width, .. } => Ok(*width), // 0 = empty bit-vector
             _ => nope(format!(
                 "expression kind not compilable: {}",
                 expr_kind(e)
@@ -1784,6 +1778,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// Resize `v` (of width `from`) to width `to`.
     fn to_w(&self, v: IntValue<'ctx>, from: u32, to: u32, signed: bool) -> IntValue<'ctx> {
         use std::cmp::Ordering::*;
+        // zero-width values are the constant empty bit-vector: any
+        // resize of one is 0, and a resize TO width 0 is the i1-carried
+        // zero (ity(0) = i1).  from.max(1) is v's actual LLVM type.
+        if from == 0 || to == 0 {
+            return self.ity(to).const_zero();
+        }
         match from.cmp(&to) {
             Equal => v,
             Greater => self.builder.build_int_truncate(v, self.ity(to), "tr").unwrap(),
@@ -1981,7 +1981,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         match e {
             Expr::Const { width, limbs } => {
                 if *width == 0 {
-                    return nope("zero-width constant");
+                    // the empty bit-vector: value is always 0, carried
+                    // as i1 (ity(0)); the interp's Value width-0 masks
+                    // every op to 0 identically
+                    return Ok(self.ity(0).const_zero());
                 }
                 Ok(self.cval(*width, limbs))
             }
@@ -3867,8 +3870,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             });
             vals.push((v, wa));
         }
+        // the foreign decode reads w.max(1) words per numeric arg, so a
+        // zero-width arg still occupies ONE (zero) word in the buffer —
+        // its spec width stays 0 so the formatter sees the interp's
+        // width-0 Value
         let total_words: u32 =
-            vals.iter().map(|&(_, w)| words_for(w)).sum::<u32>().max(1);
+            vals.iter().map(|&(_, w)| words_for(w.max(1))).sum::<u32>().max(1);
         let out_words = words_for(ret_width.max(1));
         let abuf = self
             .builder
@@ -3880,7 +3887,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             .unwrap();
         let mut off = 0u32;
         for (v, wa) in vals {
-            for k in 0..words_for(wa) {
+            for k in 0..words_for(wa.max(1)) {
                 let sh = self.ity(wa).const_int((64 * k) as u64, false);
                 let piece = if k == 0 {
                     v
@@ -3893,7 +3900,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     unsafe { self.builder.build_gep(i64t, abuf, &[idx], "fap").unwrap() };
                 self.builder.build_store(p, word).unwrap();
             }
-            off += words_for(wa);
+            off += words_for(wa.max(1));
         }
         let token =
             self.spec.token_base | self.token_kind | self.foreign_stmts.len() as u64;

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -852,7 +852,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 14;
+pub const AOT_LAYOUT_REV: u64 = 15;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -2383,7 +2383,24 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         let Some(ff) = self.bdpi_import(func) else {
             return nope("foreign value call without BDPI import");
         };
-        self.bdpi_emit(f, width, &ff, args)
+        if Self::bdpi_lits_ok(&ff, args) {
+            return self.bdpi_emit(f, width, &ff, args);
+        }
+        // dynamic CString arg: boxed trampoline call — the interp's
+        // foreign_value falls through to bdpi_call, which marshals
+        // Arg::Str for CString params
+        match self.emit_foreign(f, func, args, &[], width, None)? {
+            Some(v) => Ok(v),
+            None => nope("BDPI value call returned no value"),
+        }
+    }
+
+    /// Every FT::CString parameter is bound to a literal Expr::Str —
+    /// the precondition for the direct bdpi_emit fast path.
+    fn bdpi_lits_ok(ff: &trs_ir::ForeignFunc, args: &[Expr]) -> bool {
+        ff.args.iter().zip(args).all(|(t, a)| {
+            !matches!(t, trs_ir::ForeignType::CString) || matches!(a, Expr::Str(_))
+        })
     }
 
     /// The design's BDPI import for `func`, if any (system tasks and
@@ -4436,18 +4453,16 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             }
             Expr::Prim { op: PrimOp::StringConcat, args, .. } => {
                 // per-evaluation intern through the callback, exactly
-                // the interp's intern_dyn; needs a stop block (task
-                // context) — pure value cones (e.g. string Eq) nope
-                let Some(sb) = stop_bb else {
-                    return nope("string concat outside task context");
-                };
+                // the interp's intern_dyn; pure value cones (e.g.
+                // string Eq) have no stop block, and the concat
+                // callback never requests a stop
                 match self.emit_foreign(
                     f,
                     STRING_CONCAT_FUNC,
                     args,
                     &[],
                     64,
-                    sb,
+                    stop_bb,
                 )? {
                     Some(v) => Ok(v),
                     None => nope("string concat returned no value"),
@@ -4464,7 +4479,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         args: &[Expr],
         signed: &[bool],
         ret_width: u32,
-        stop_bb: inkwell::basic_block::BasicBlock<'ctx>,
+        stop_bb: Option<inkwell::basic_block::BasicBlock<'ctx>>,
     ) -> Result<Option<IntValue<'ctx>>, Ineligible> {
         let Some(envp) = f.envp else {
             return nope("foreign call without env pointer");
@@ -4488,7 +4503,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             if self.expr_is_str(f, a) {
                 // i64 string id, one marshaled word; the spec's StrDyn
                 // tag makes the decode resolve it to Arg::Str
-                let v = self.str_expr(f, a, Some(stop_bb))?;
+                let v = self.str_expr(f, a, stop_bb)?;
                 spec_args.push(FArgSpec::StrDyn);
                 vals.push((v, 64));
                 continue;
@@ -4565,19 +4580,25 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         let inkwell::values::ValueKind::Basic(rv) = call.try_as_basic_value() else {
             return nope("callback returned void");
         };
-        let stop = self
-            .builder
-            .build_int_compare(
-                IntPredicate::NE,
-                rv.into_int_value(),
-                self.ctx.i32_type().const_int(0, false),
-                "fst",
-            )
-            .unwrap();
-        let func = self.builder.get_insert_block().unwrap().get_parent().unwrap();
-        let cont_bb = self.ctx.append_basic_block(func, "fcont");
-        self.builder.build_conditional_branch(stop, stop_bb, cont_bb).unwrap();
-        self.builder.position_at_end(cont_bb);
+        // outside a task context there is no abort target; the callback
+        // contract reserves the nonzero return for genuine aborts and
+        // nothing requests one today, so the result is ignored there
+        if let Some(sb) = stop_bb {
+            let stop = self
+                .builder
+                .build_int_compare(
+                    IntPredicate::NE,
+                    rv.into_int_value(),
+                    self.ctx.i32_type().const_int(0, false),
+                    "fst",
+                )
+                .unwrap();
+            let func =
+                self.builder.get_insert_block().unwrap().get_parent().unwrap();
+            let cont_bb = self.ctx.append_basic_block(func, "fcont");
+            self.builder.build_conditional_branch(stop, sb, cont_bb).unwrap();
+            self.builder.position_at_end(cont_bb);
+        }
         if ret_width == 0 {
             return Ok(None);
         }
@@ -4924,7 +4945,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         self.builder.build_conditional_branch(cz, go_bb, sk_bb).unwrap();
         self.builder.position_at_end(go_bb);
         let v = self
-            .emit_foreign(f, tf, args, signed, w, stop_bb)?
+            .emit_foreign(f, tf, args, signed, w, Some(stop_bb))?
             .expect("task returns");
         self.builder.build_store(cp, v).unwrap();
         if let Some(tp) = tp {
@@ -5415,12 +5436,33 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 else {
                     return nope("unknown action method on child");
                 };
-                if m.kind != trs_ir::MethodKind::Action {
-                    return nope("actionvalue method call");
+                // a plain Action call may target an ActionValue method
+                // with its result discarded — the interp's call_action
+                // executes the body either way
+                if !matches!(
+                    m.kind,
+                    trs_ir::MethodKind::Action | trs_ir::MethodKind::ActionValue
+                ) {
+                    return nope("value method as action");
                 }
-                if m.always_enabled {
-                    return nope("always_enabled method (RDY-gated body)");
-                }
+                // (* always_enabled *): the caller-side RDY was dropped,
+                // so the body is gated on the sibling RDY_<m> value
+                // method at call time (the C++ check_rdy wrapper); EN
+                // still lands when the caller fires. No RDY method
+                // exported = constant ready.
+                let rdy_id = if m.always_enabled {
+                    let rdy_name =
+                        format!("RDY_{}", self.env.d.strings[*method as usize]);
+                    self.env
+                        .d
+                        .strings
+                        .iter()
+                        .position(|x| x == &rdy_name)
+                        .map(|id| id as StrId)
+                        .filter(|id| cmod.methods.iter().any(|mm| mm.name == *id))
+                } else {
+                    None
+                };
                 if args.len() != m.args.len() {
                     return nope("method arg count mismatch");
                 }
@@ -5450,6 +5492,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     let one = self.ctx.i64_type().const_int(1, false);
                     self.store_word(&cf, slot, one);
                 }
+                if let Some(rid) = rdy_id {
+                    // EN is already latched; only the body waits on RDY
+                    let r = self.value_call(f, 1, *instance, rid, 0, &[])?;
+                    let rz = self.nonzero(r, 1);
+                    let bd_bb = self.ctx.append_basic_block(func, "mrdy");
+                    self.builder.build_conditional_branch(rz, bd_bb, sk_bb).unwrap();
+                    self.builder.position_at_end(bd_bb);
+                }
                 // the inlined body executes inside a conditional block:
                 // caller-frame defs expanded here must not leak either —
                 // cf is fresh, so only its own scope is at stake
@@ -5466,11 +5516,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 let sk_bb = self.ctx.append_basic_block(func, "fsk");
                 self.builder.build_conditional_branch(cz, go_bb, sk_bb).unwrap();
                 self.builder.position_at_end(go_bb);
-                if let Some(imp) = self.bdpi_import(*ff) {
-                    // user BDPI action: direct call (task #22)
-                    self.bdpi_emit(f, 1, &imp, args)?;
-                } else {
-                    self.emit_foreign(f, *ff, args, signed, 0, stop_bb)?;
+                match self.bdpi_import(*ff) {
+                    // user BDPI action: direct call (task #22); dynamic
+                    // CString args take the boxed trampoline instead
+                    Some(imp) if Self::bdpi_lits_ok(&imp, args) => {
+                        self.bdpi_emit(f, 1, &imp, args)?;
+                    }
+                    _ => {
+                        self.emit_foreign(f, *ff, args, signed, 0, Some(stop_bb))?;
+                    }
                 }
                 self.builder.build_unconditional_branch(sk_bb).unwrap();
                 self.builder.position_at_end(sk_bb);

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -1517,6 +1517,7 @@ fn lower_edge_ssa<'ctx>(
             dead_defs: Default::default(),
                     tasks: HashMap::new(),
                     av_slots: HashMap::new(),
+                    av_args: HashMap::new(),
                     is_exec: true,
                     depth: 0,
                 };
@@ -1536,6 +1537,7 @@ fn lower_edge_ssa<'ctx>(
             dead_defs: Default::default(),
                 tasks: HashMap::new(),
                 av_slots: HashMap::new(),
+                av_args: HashMap::new(),
                 is_exec,
                 depth: 0,
             };
@@ -1763,6 +1765,11 @@ struct Frame<'ctx> {
     /// ActionValue task results by cookie (Expr::TaskValue reads):
     /// (value, width)
     tasks: HashMap<u32, (IntValue<'ctx>, u32)>,
+    /// method arg values latched at inline AV call sites, gated on the
+    /// call condition (select(cond, v, 0) — the interp's per-edge
+    /// latched-if-called-else-0), keyed by (child instance name, arg
+    /// port name).  Expr::MethValue result cones read them.
+    av_args: HashMap<(StrId, StrId), (IntValue<'ctx>, u32)>,
     /// join-safe ActionValue task results (value alloca, width), keyed
     /// by the bound def/temp name and by the cookie's synthetic key:
     /// the interp's ctx.locals persists past a Cond join, so a task
@@ -2789,17 +2796,39 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         else {
             return nope("unknown method on child");
         };
-        if m.kind != trs_ir::MethodKind::Value {
+        // the interp's call_value evaluates the method's RESULT expr
+        // for Value and ActionValue methods alike; an Expr::MethValue
+        // read arrives with NO args (the action side carried them).
+        // The one asymmetry: the interp may see caller-latched arg
+        // values in its Port fallthrough, which a fully-compiled design
+        // never latches — so an AV result whose cone reads its own arg
+        // ports stays ineligible.
+        if m.kind != trs_ir::MethodKind::Value
+            && !(m.kind == trs_ir::MethodKind::ActionValue && args.is_empty())
+        {
             return nope("non-value method in expression");
         }
         let Some(res) = m.result.clone() else {
             return nope("value method without result");
         };
-        if args.len() != m.args.len() {
+        if !args.is_empty() && args.len() != m.args.len() {
             return nope("method arg count mismatch");
         }
         let margs = m.args.clone();
         let mut cf = self.child_frame(f, child, Some(mi))?;
+        if m.kind == trs_ir::MethodKind::ActionValue {
+            // arg ports in the result cone read exactly what the interp
+            // reads at THIS evaluation site: the per-edge latch when the
+            // call was inlined earlier in this frame (select(cond, v, 0)
+            // captured at the call site), else the uncalled-MethodArg
+            // 0-fold via the Port fallthrough — sched-position hoists
+            // evaluate BEFORE the call and legitimately read 0
+            for pa in &margs {
+                if let Some(&(lv, lw)) = f.av_args.get(&(instance, pa.name)) {
+                    cf.args.insert(pa.name, (lv, lw));
+                }
+            }
+        }
         for (a, p) in args.iter().zip(&margs) {
             let wa = self.expr_width(f, a)?;
             let v0 = self.expr(f, a)?;
@@ -3080,6 +3109,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             dead_defs: Default::default(),
             tasks: HashMap::new(),
             av_slots: HashMap::new(),
+            av_args: HashMap::new(),
             is_exec: f.is_exec,
             depth: f.depth + 1,
         })
@@ -3882,6 +3912,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             dead_defs: Default::default(),
             tasks: HashMap::new(),
             av_slots: HashMap::new(),
+            av_args: HashMap::new(),
             is_exec: false,
             depth: 0,
         };
@@ -3998,6 +4029,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             dead_defs: Default::default(),
             tasks: HashMap::new(),
             av_slots: HashMap::new(),
+            av_args: HashMap::new(),
             is_exec: true,
             depth: 0,
         };
@@ -4104,6 +4136,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             dead_defs: Default::default(),
             tasks: HashMap::new(),
             av_slots: HashMap::new(),
+            av_args: HashMap::new(),
             is_exec: true,
             depth: 0,
         };
@@ -4653,15 +4686,28 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                                 .position(|x| x == &en_name)
                                 .and_then(|id| cie.en_slot.get(&(id as StrId)).copied());
                             let mut cf = self.child_frame(f, child, Some(mi))?;
+                            let wc = self.expr_width(f, cond)?;
+                            let c = self.expr(f, cond)?;
+                            let cz = self.nonzero(c, wc);
                             for (a, pa) in args.iter().zip(&margs) {
                                 let wa = self.expr_width(f, a)?;
                                 let v0 = self.expr(f, a)?;
                                 let v = self.to_w(v0, wa, pa.width, false);
                                 cf.args.insert(pa.name, (v, pa.width));
+                                // per-edge arg latch for later
+                                // Expr::MethValue reads: the interp's
+                                // latched map holds the value iff the
+                                // method was CALLED this edge, else the
+                                // uncalled-MethodArg fallthrough reads 0
+                                let z = self.ity(pa.width.max(1)).const_zero();
+                                let lv = self
+                                    .builder
+                                    .build_select(cz, v, z, "avarg")
+                                    .unwrap()
+                                    .into_int_value();
+                                f.av_args
+                                    .insert((*instance, pa.name), (lv, pa.width));
                             }
-                            let wc = self.expr_width(f, cond)?;
-                            let c = self.expr(f, cond)?;
-                            let cz = self.nonzero(c, wc);
                             let go_bb = self.ctx.append_basic_block(func, "avmgo");
                             let sk_bb = self.ctx.append_basic_block(func, "avmsk");
                             let jn_bb = self.ctx.append_basic_block(func, "avmjn");

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -178,6 +178,12 @@ pub struct InstEnv {
     /// evaluation.  Part of the exec dedup signature (owner slots are
     /// absolute in deduped bodies, so gate wiring must pin the sig).
     pub gates: HashMap<StrId, (usize, Expr)>,
+    /// String-valued instantiation parameters: name -> string id.  The
+    /// compiled carrier for strings is an i64 of the id (the interp's
+    /// str_ref marker value), consumed by StrDyn foreign args, string
+    /// Eq, and the StringConcat intern callback.  Part of the exec
+    /// dedup signature.
+    pub str_consts: HashMap<StrId, StrId>,
     /// any rule's CAN_FIRE/WILL_FIRE def name -> arena slot (this
     /// instance); reads of other rules' fire signals become slot loads
     pub cfwf_slot: HashMap<StrId, u32>,
@@ -249,6 +255,10 @@ pub enum FArgSpec {
     Str(StrId),
     Num { width: u32, signed: bool },
     Real,
+    /// A dynamically-selected string: one marshaled word carrying the
+    /// string id (static table or runtime-interned) — the decode
+    /// resolves it to the interp's Arg::Str.
+    StrDyn,
 }
 
 /// A compiled rule sched function (kept alive by the leaked engine).
@@ -377,6 +387,11 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
                         w(o, 0);
                         w(o, 0);
                     }
+                    FArgSpec::StrDyn => {
+                        w(o, 3);
+                        w(o, 0);
+                        w(o, 0);
+                    }
                 }
             }
         }
@@ -428,6 +443,7 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
                 args.push(match tag {
                     0 => FArgSpec::Str(a),
                     2 => FArgSpec::Real,
+                    3 => FArgSpec::StrDyn,
                     _ => FArgSpec::Num { width: a, signed: sg != 0 },
                 });
             }
@@ -779,6 +795,12 @@ impl Drop for AotModeGuard {
 /// trampoline answers the prim's gate_out() (compiled Expr::Gate).
 pub const GATE_OUT_METHOD: StrId = u32::MAX;
 
+/// Sentinel func id in a ForeignSpec: not a foreign function — the
+/// callback concatenates its (StrDyn) arguments' texts and interns the
+/// result, returning the new string id (compiled PrimOp::StringConcat,
+/// mirroring the interp's per-evaluation intern_dyn).
+pub const STRING_CONCAT_FUNC: StrId = u32::MAX - 1;
+
 /// A gate expression a compiled read may re-expand: static cones only
 /// (constants, parameters, and pure combinationals over them).  Defs
 /// are excluded because the interp's gate eval prefers their LATCHED
@@ -803,7 +825,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 11;
+pub const AOT_LAYOUT_REV: u64 = 12;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -2033,6 +2055,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
     /// Lower an expression to an iN value of its BSV width.
     fn expr(&mut self, f: &mut Frame<'ctx>, e: &Expr) -> Result<IntValue<'ctx>, Ineligible> {
+        // string-typed expressions lower uniformly as i64 ids wherever
+        // they appear (def bindings, cones, muxes) — the consumers
+        // (StrDyn foreign args, string Eq, concat) understand the
+        // carrier; concat inside a pure value cone stays ineligible
+        // (no task context)
+        if self.expr_is_str(f, e) {
+            return self.str_expr(f, e, None);
+        }
         match e {
             Expr::Const { width, limbs } => {
                 if *width == 0 {
@@ -3435,6 +3465,20 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         width: u32,
         args: &[Expr],
     ) -> Result<IntValue<'ctx>, Ineligible> {
+        // string equality: the interp compares marker limbs, i.e. the
+        // ids — an i64 id compare is the exact mirror (both engines
+        // treat distinct ids as unequal regardless of text)
+        if op == PrimOp::Eq
+            && args.len() == 2
+            && self.expr_is_str(f, &args[0])
+        {
+            let a = self.str_expr(f, &args[0], None)?;
+            let b = self.str_expr(f, &args[1], None)?;
+            return Ok(self
+                .builder
+                .build_int_compare(IntPredicate::EQ, a, b, "seq")
+                .unwrap());
+        }
         match op {
             PrimOp::And | PrimOp::Or | PrimOp::Xor | PrimOp::Add | PrimOp::Sub | PrimOp::Mul => {
                 let mut it = args.iter();
@@ -4005,6 +4049,127 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
     }
 
+    /// Statically string-typed expressions: the shapes whose interp
+    /// evaluation yields a STR_MARKER Value (val_arg -> Arg::Str).
+    /// Strings are literals, string params, muxes/defs over those,
+    /// marker-passthrough width adjustments, and StringConcat results.
+    fn expr_is_str(&self, f: &Frame<'ctx>, e: &Expr) -> bool {
+        match e {
+            Expr::Str(_) => true,
+            Expr::Param(p) | Expr::Port(p) => self
+                .ie(f.inst)
+                .map(|ie| ie.str_consts.contains_key(p))
+                .unwrap_or(false),
+            Expr::If { then_, else_, .. } => {
+                self.expr_is_str(f, then_) || self.expr_is_str(f, else_)
+            }
+            Expr::Case { arms, default, .. } => {
+                arms.iter().any(|(_, a)| self.expr_is_str(f, a))
+                    || self.expr_is_str(f, default)
+            }
+            Expr::Def(n) => {
+                let Ok(ie) = self.ie(f.inst) else { return false };
+                let m = &self.env.d.modules[ie.mir];
+                m.defs
+                    .iter()
+                    .find(|d| d.name == *n)
+                    .is_some_and(|d| self.expr_is_str(f, &d.expr))
+            }
+            Expr::Prim { op: PrimOp::StringConcat, .. } => true,
+            Expr::Prim { op: PrimOp::ZeroExt | PrimOp::SignExt, args, .. } => {
+                args.first().is_some_and(|a| self.expr_is_str(f, a))
+            }
+            _ => false,
+        }
+    }
+
+    /// Lower a string-typed expression to its i64 string id (the
+    /// compiled carrier for the interp's str_ref marker Value).
+    fn str_expr(
+        &mut self,
+        f: &mut Frame<'ctx>,
+        e: &Expr,
+        stop_bb: Option<inkwell::basic_block::BasicBlock<'ctx>>,
+    ) -> Result<IntValue<'ctx>, Ineligible> {
+        let i64t = self.ctx.i64_type();
+        match e {
+            Expr::Str(sid) => Ok(i64t.const_int(*sid as u64, false)),
+            Expr::Param(p) | Expr::Port(p) => {
+                match self.ie(f.inst)?.str_consts.get(p) {
+                    Some(&sid) => Ok(i64t.const_int(sid as u64, false)),
+                    None => nope("non-string port in string context"),
+                }
+            }
+            Expr::If { cond, then_, else_, .. } => {
+                let wc = self.expr_width(f, cond)?;
+                let c = self.expr(f, cond)?;
+                let cz = self.nonzero(c, wc);
+                // string values are pure ids — both arms evaluate
+                // eagerly (no effects), select picks one
+                let tv = self.str_expr(f, then_, stop_bb)?;
+                let ev = self.str_expr(f, else_, stop_bb)?;
+                Ok(self
+                    .builder
+                    .build_select(cz, tv, ev, "ssel")
+                    .unwrap()
+                    .into_int_value())
+            }
+            Expr::Case { scrutinee, arms, default, .. } => {
+                let ws = self.expr_width(f, scrutinee)?;
+                let sv = self.expr(f, scrutinee)?;
+                let mut acc = self.str_expr(f, default, stop_bb)?;
+                for (k, a) in arms {
+                    let kv = self.ity(ws).const_int(*k, false);
+                    let hit = self
+                        .builder
+                        .build_int_compare(IntPredicate::EQ, sv, kv, "scse")
+                        .unwrap();
+                    let av = self.str_expr(f, a, stop_bb)?;
+                    acc = self
+                        .builder
+                        .build_select(hit, av, acc, "scsl")
+                        .unwrap()
+                        .into_int_value();
+                }
+                Ok(acc)
+            }
+            Expr::Def(n) => {
+                let ie = self.ie(f.inst)?;
+                let m = &self.env.d.modules[ie.mir];
+                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                    return nope("unknown string def");
+                };
+                let dex = d.expr.clone();
+                self.str_expr(f, &dex, stop_bb)
+            }
+            Expr::Prim { op: PrimOp::ZeroExt | PrimOp::SignExt, args, .. } => {
+                // marker passthrough: width adjustments of string
+                // values are identity in the interp
+                self.str_expr(f, &args[0], stop_bb)
+            }
+            Expr::Prim { op: PrimOp::StringConcat, args, .. } => {
+                // per-evaluation intern through the callback, exactly
+                // the interp's intern_dyn; needs a stop block (task
+                // context) — pure value cones (e.g. string Eq) nope
+                let Some(sb) = stop_bb else {
+                    return nope("string concat outside task context");
+                };
+                match self.emit_foreign(
+                    f,
+                    STRING_CONCAT_FUNC,
+                    args,
+                    &[],
+                    64,
+                    sb,
+                )? {
+                    Some(v) => Ok(v),
+                    None => nope("string concat returned no value"),
+                }
+            }
+            _ => nope("expression not string-lowerable"),
+        }
+    }
+
     fn emit_foreign(
         &mut self,
         f: &mut Frame<'ctx>,
@@ -4030,6 +4195,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // Real tag makes the decode rebuild Arg::Real
                 let v = self.expr(f, a)?;
                 spec_args.push(FArgSpec::Real);
+                vals.push((v, 64));
+                continue;
+            }
+            if self.expr_is_str(f, a) {
+                // i64 string id, one marshaled word; the spec's StrDyn
+                // tag makes the decode resolve it to Arg::Str
+                let v = self.str_expr(f, a, Some(stop_bb))?;
+                spec_args.push(FArgSpec::StrDyn);
                 vals.push((v, 64));
                 continue;
             }

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -274,6 +274,30 @@ fn nope<T>(why: impl Into<String>) -> Result<T, Ineligible> {
     Err(Ineligible(why.into()))
 }
 
+/// Variant name for ineligibility notes: the catch-alls must say WHICH
+/// expression kind they refused, or the sweep's why= column lumps every
+/// unlowered variant into one unactionable bucket.
+fn expr_kind(e: &Expr) -> &'static str {
+    match e {
+        Expr::Const { .. } => "Const",
+        Expr::Def(..) => "Def",
+        Expr::Port(..) => "Port",
+        Expr::Param(..) => "Param",
+        Expr::MethCall { .. } => "MethCall",
+        Expr::MethValue { .. } => "MethValue",
+        Expr::TaskValue { .. } => "TaskValue",
+        Expr::ForeignCall { .. } => "ForeignCall",
+        Expr::Str(..) => "Str",
+        Expr::Clock { .. } => "Clock",
+        Expr::Real(..) => "Real",
+        Expr::Reset { .. } => "Reset",
+        Expr::Gate { .. } => "Gate",
+        Expr::Prim { .. } => "Prim",
+        Expr::If { .. } => "If",
+        Expr::Case { .. } => "Case",
+    }
+}
+
 fn words_for(w: u32) -> u32 {
     w.div_ceil(64)
 }
@@ -1738,7 +1762,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     nope("zero-width expression")
                 }
             }
-            _ => nope("expression kind not compilable"),
+            _ => nope(format!(
+                "expression kind not compilable: {}",
+                expr_kind(e)
+            )),
         }
     }
 
@@ -2065,7 +2092,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             Expr::ForeignCall { width, func, args } => {
                 self.bdpi_value_call(f, (*width).max(1), *func, args)
             }
-            _ => nope("expression kind not compilable"),
+            _ => nope(format!(
+                "expression kind not compilable: {}",
+                expr_kind(e)
+            )),
         }
     }
 

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -102,11 +102,14 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
     let mut argv = Vec::with_capacity(arg_widths.len());
     let mut off = 0usize;
     for &w in &arg_widths {
-        let words = ((w as usize) + 63) / 64;
-        let limbs =
-            std::slice::from_raw_parts(args.add(off), words.max(1)).to_vec();
-        // TRUE width: a zero-width prim arg must reach the prim as the
-        // interp's width-0 Value (from_limbs64 masks the over-read word)
+        // physical layout is w.max(1) words per argument on BOTH sides
+        // of the ABI — a zero-width argument still occupies one (zero)
+        // word (review finding: reading words.max(1) while advancing by
+        // the logical count walked past the allocation)
+        let words = ((w.max(1) as usize) + 63) / 64;
+        let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
+        // TRUE logical width: a zero-width prim arg must reach the prim
+        // as the interp's width-0 Value (from_limbs64 masks the word)
         argv.push(Value::from_limbs64(w, limbs));
         off += words;
     }
@@ -2546,11 +2549,15 @@ impl Interp {
                 }
                 match kind {
                     trs_ir::PortKind::MethodArg => {
-                        port_consts.insert(pn, (w.max(1), 0));
+                        // LOGICAL width, zero included: the interp's
+                        // fallback masks from_u64(0, _) to the empty
+                        // vector, so a zero-width port must not become
+                        // a width-1 value (review finding)
+                        port_consts.insert(pn, (w, 0));
                     }
                     trs_ir::PortKind::MethodEnable => {}
                     _ => {
-                        port_consts.insert(pn, (w.max(1), 1));
+                        port_consts.insert(pn, (w, if w == 0 { 0 } else { 1 }));
                     }
                 }
             }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2437,7 +2437,7 @@ impl Interp {
                     }
                     Some(ArenaKind::Fifo { width, size, guard }) => {
                         let words = width.max(1).div_ceil(64);
-                        let base = alloc(&mut nslots, 6 + size * words);
+                        let base = alloc(&mut nslots, 7 + size * words);
                         fifo_slot.insert(name, (base, width, size, guard));
                         attach.push((ci, base));
                     }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2517,12 +2517,21 @@ impl Interp {
             // sysTwoLevelReal2); unfolded means Ineligible -> interp.
             let mut port_consts: HashMap<StrId, (u32, u64)> = HashMap::new();
             let mut real_consts: HashMap<StrId, u64> = HashMap::new();
+            let mut wide_consts: HashMap<StrId, (u32, Vec<u32>)> = HashMap::new();
             for (&pn, pv) in params {
                 if pv.width >= 1 && pv.width <= 64 {
                     port_consts.insert(pn, (pv.width, pv.as_u64()));
                 } else if let Some(r) = pv.as_real() {
                     // real params ride as f64 bits (task-arg carrier)
                     real_consts.insert(pn, r.to_bits());
+                } else if pv.width > 64 && pv.width < u32::MAX - 1 {
+                    // wide instantiation values as LE 32-bit limbs
+                    let mut limbs = Vec::new();
+                    for &l in pv.limbs64() {
+                        limbs.push(l as u32);
+                        limbs.push((l >> 32) as u32);
+                    }
+                    wide_consts.insert(pn, (pv.width, limbs));
                 }
             }
             for (&pn, &(w, kind)) in &self.mods[module].ports {
@@ -2564,6 +2573,7 @@ impl Interp {
                     real_consts,
                     gates: gates.clone(),
                     str_consts: str_params.clone(),
+                    wide_consts,
                     region: (region_start, 0),
                 },
             );
@@ -2657,6 +2667,13 @@ impl Interp {
                     e.str_consts.iter().map(|(&k, &v)| (k, v)).collect();
                 m14.sort_unstable();
                 m14.hash(&mut h);
+                let mut m15: Vec<_> = e
+                    .wide_consts
+                    .iter()
+                    .map(|(&k, (w, l))| (k, *w, l.clone()))
+                    .collect();
+                m15.sort_unstable();
+                m15.hash(&mut h);
                 // the sig must cover every input the exec lowering
                 // reads (handoff rule): regfile regions included
                 let mut m10: Vec<_> = e

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -105,7 +105,9 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         let words = ((w as usize) + 63) / 64;
         let limbs =
             std::slice::from_raw_parts(args.add(off), words.max(1)).to_vec();
-        argv.push(Value::from_limbs64(w.max(1), limbs));
+        // TRUE width: a zero-width prim arg must reach the prim as the
+        // interp's width-0 Value (from_limbs64 masks the over-read word)
+        argv.push(Value::from_limbs64(w, limbs));
         off += words;
     }
     crate::prim::FROM_COMPILED.with(|c| c.set(token));
@@ -412,7 +414,10 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
                 let w = width;
                 let words = ((w.max(1) as usize) + 63) / 64;
                 let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
-                argv.push(Arg::Val(Value::from_limbs64(w.max(1), limbs), signed));
+                // the TRUE width, zero included: the formatter must see
+                // the interp's width-0 Value for zero-width args, not a
+                // width-1 impostor (from_limbs64 masks the buffer word)
+                argv.push(Arg::Val(Value::from_limbs64(w, limbs), signed));
                 off += words;
             }
         }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -971,16 +971,23 @@ fn aot_emit(
         .map_err(|e| EmitFail::Infra(format!("meta object: {e}")))?;
         let mf = tmp.join("meta.o");
         std::fs::write(&mf, meta).map_err(|e| EmitFail::Infra(e.to_string()))?;
+        // temp+rename: a crash mid-cc must never leave a truncated
+        // .so at the final path (it would dlopen-fail or worse on the
+        // next run before the gates can judge it)
+        let so_tmp = so.with_extension("so.tmp");
         let st = std::process::Command::new(cc_tool())
             .args(["-shared", "-o"])
-            .arg(so)
+            .arg(&so_tmp)
             .args([&f, &mf])
             .status()
             .map_err(|e| EmitFail::Infra(format!("cc: {e}")))?;
         std::fs::remove_dir_all(&tmp).ok();
         if !st.success() {
+            std::fs::remove_file(&so_tmp).ok();
             return Err(EmitFail::Infra("cc -shared failed".into()));
         }
+        std::fs::rename(&so_tmp, so)
+            .map_err(|e| EmitFail::Infra(format!("rename .so: {e}")))?;
         if std::env::var_os("TRS_JIT_TIME").is_some() {
             eprintln!("trs aot: emit + link {:?}", t0.elapsed());
         }
@@ -1102,16 +1109,21 @@ fn aot_emit(
     let mf = tmp.join("meta.o");
     std::fs::write(&mf, meta).map_err(|e| EmitFail::Infra(e.to_string()))?;
     files.push(mf);
+    // temp+rename, same discipline as the single-object emit
+    let so_tmp = so.with_extension("so.tmp");
     let st = std::process::Command::new("cc")
         .args(["-shared", "-o"])
-        .arg(so)
+        .arg(&so_tmp)
         .args(&files)
         .status()
         .map_err(|e| EmitFail::Infra(format!("cc: {e}")))?;
     std::fs::remove_dir_all(&tmp).ok();
     if !st.success() {
+        std::fs::remove_file(&so_tmp).ok();
         return Err(EmitFail::Infra("cc -shared failed".into()));
     }
+    std::fs::rename(&so_tmp, so)
+        .map_err(|e| EmitFail::Infra(format!("rename .so: {e}")))?;
     if std::env::var_os("TRS_JIT_TIME").is_some() {
         eprintln!("trs aot: emit + link {:?}", t0.elapsed());
     }
@@ -1346,6 +1358,7 @@ impl Interp {
         inst_envs: &HashMap<usize, InstEnv>,
         nodes: &[Vec<(bool, usize)>],
         specs: &[RuleSpec],
+        has_early: bool,
         stats: bool,
     ) -> trs_codegen::lower::EdgeSsaPlan {
         let specs_lite: Vec<(usize, usize)> =
@@ -2085,6 +2098,17 @@ impl Interp {
             .iter()
             .flat_map(|sp| sp.inhibit_slots.iter().copied())
             .collect();
+        // interp-side consumers: with any early (clock-crossing) rule,
+        // the PG_FINAL pass reads compiled CF slots (inhibitors via
+        // latched_or_arena) and eager/WF defs via eval's arena
+        // fallthrough — keep them all (early designs are rare; the
+        // cost is per-edge scalar stores)
+        if has_early {
+            for e in inst_envs.values() {
+                export_slots.extend(e.cfwf_slot.values().copied());
+                export_slots.extend(e.eager_slot.values().map(|&(b, _)| b));
+            }
+        }
         for &o in &outlined_execs {
             export_slots.insert(specs[o].wf_slot);
             let (inst, ridx) = specs_lite[o];
@@ -2121,6 +2145,10 @@ impl Interp {
     /// fully interpreted.  Called once from prime().
     pub(crate) fn jit_plan(&mut self, rcomps: &[RComp]) -> Option<JitPlans> {
         let request = std::mem::take(&mut self.jit_request);
+        // early (clock-crossing) rules run interpreted in the PG_FINAL
+        // pass and read compiled CF/eager slots — edge-SSA store
+        // elision must keep those stores (see edge_ssa_plan)
+        let has_early = rcomps.iter().any(|rc| !rc.early.is_empty());
         // direct-BDPI registries (task #22): baked-mode call emission
         // reads these; set-once, idempotent
         let _ = trs_codegen::lower::STDIO_CB.set(jit_stdio_cb as usize);
@@ -2837,7 +2865,7 @@ impl Interp {
                     v
                 })
                 .collect();
-            let _ = self.edge_ssa_plan(&inst_envs, &nodes, &specs, true);
+            let _ = self.edge_ssa_plan(&inst_envs, &nodes, &specs, has_early, true);
         }
         // sharing census (TRS_JIT_SHARE_STATS=1): how many defs are
         // consumed by 2+ rules of the same module — the cross-rule
@@ -2972,9 +3000,30 @@ impl Interp {
         // ---- exec dedup classes: one compiled body per class ----
         let mut classes: Vec<(usize, Vec<usize>)> = Vec::new();
         {
-            let mut key_to_class: HashMap<(u64, usize), usize> = HashMap::new();
+            let mut key_to_class: HashMap<(u64, usize, Vec<(bool, u32)>), usize> =
+                HashMap::new();
             for (o, sp) in specs.iter().enumerate() {
-                let key = (inst_sig[&sp.inst], sp.rule_idx);
+                // the compiled body bakes always_fire and inhibitor slot
+                // LOADS; own-region slots are region-relative in codegen
+                // (twins share safely), foreign-instance slots are
+                // absolute (twins must not share) — the key mirrors that
+                let ie = &inst_envs[&sp.inst];
+                let own: std::collections::HashSet<u32> =
+                    ie.cfwf_slot.values().copied().collect();
+                let r0 = ie.region.0;
+                let mut inh: Vec<(bool, u32)> = sp
+                    .inhibit_slots
+                    .iter()
+                    .map(|&sl| {
+                        if own.contains(&sl) {
+                            (true, sl - r0)
+                        } else {
+                            (false, sl)
+                        }
+                    })
+                    .collect();
+                inh.sort_unstable();
+                let key = (inst_sig[&sp.inst], sp.rule_idx, inh);
                 let c = *key_to_class.entry(key).or_insert_with(|| {
                     classes.push((o, Vec::new()));
                     classes.len() - 1
@@ -3000,6 +3049,13 @@ impl Interp {
                             SchedNode::Sched(r) => (r, true),
                             SchedNode::Exec(r) => (r, false),
                         };
+                        // early rules run in THIS comp's PG_FINAL pass
+                        // interpreted — emitting them here would double-
+                        // run a rule that another comp scheduled (and
+                        // gave an ordinal to) normally
+                        if rc.early.contains(&(en.inst, r)) {
+                            continue;
+                        }
                         // interface-method nodes have no ordinal:
                         // they are no-ops in the edge walk (interp
                         // parity — nothing to latch or execute)
@@ -3235,7 +3291,9 @@ impl Interp {
                         })
                         .collect();
                     let mut plan =
-                        self.edge_ssa_plan(&inst_envs, &nodes, &specs, false);
+                        self.edge_ssa_plan(
+                            &inst_envs, &nodes, &specs, has_early, false,
+                        );
                     plan.wire_clears =
                         self.wire_tick_coverage(&inst_envs, rcomps).0;
                     plan

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -420,6 +420,13 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
                 argv.push(Arg::Val(Value::from_limbs64(w, limbs), signed));
                 off += words;
             }
+            FArgSpec::Real => {
+                // one word of f64 bits -> the interp's Arg::Real, so
+                // %f/%e/%g formatting is byte-identical
+                let word = *args.add(off);
+                argv.push(Arg::Real(f64::from_bits(word)));
+                off += 1;
+            }
         }
     }
     let fname = interp.s(func).to_string();
@@ -2467,9 +2474,13 @@ impl Interp {
             // "unbound" bakes a wrong constant (sysWideModArgPortTest,
             // sysTwoLevelReal2); unfolded means Ineligible -> interp.
             let mut port_consts: HashMap<StrId, (u32, u64)> = HashMap::new();
+            let mut real_consts: HashMap<StrId, u64> = HashMap::new();
             for (&pn, pv) in params {
                 if pv.width >= 1 && pv.width <= 64 {
                     port_consts.insert(pn, (pv.width, pv.as_u64()));
+                } else if let Some(r) = pv.as_real() {
+                    // real params ride as f64 bits (task-arg carrier)
+                    real_consts.insert(pn, r.to_bits());
                 }
             }
             for (&pn, &(w, kind)) in &self.mods[module].ports {
@@ -2508,6 +2519,7 @@ impl Interp {
                     eager_slot,
                     memo_slot,
                     port_consts,
+                    real_consts,
                     region: (region_start, 0),
                 },
             );
@@ -2583,6 +2595,10 @@ impl Interp {
                     e.port_consts.iter().map(|(&k, &(w, v))| (k, w, v)).collect();
                 m11.sort_unstable();
                 m11.hash(&mut h);
+                let mut m12: Vec<_> =
+                    e.real_consts.iter().map(|(&k, &v)| (k, v)).collect();
+                m12.sort_unstable();
+                m12.hash(&mut h);
                 // the sig must cover every input the exec lowering
                 // reads (handoff rule): regfile regions included
                 let mut m10: Vec<_> = e

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -440,7 +440,33 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
                 argv.push(Arg::Real(f64::from_bits(word)));
                 off += 1;
             }
+            FArgSpec::StrDyn => {
+                // one word of string id (static or runtime-interned)
+                // -> the interp's Arg::Str
+                let word = *args.add(off);
+                argv.push(Arg::Str(interp.s(word as u32).to_string()));
+                off += 1;
+            }
         }
+    }
+    if func == trs_codegen::lower::STRING_CONCAT_FUNC {
+        // compiled PrimOp::StringConcat: concatenate the resolved
+        // texts and intern per evaluation, the interp's exact behavior
+        // (func is a sentinel, not a string id — resolve nothing)
+        let mut text = String::new();
+        for a in &argv {
+            if let Arg::Str(s) = a {
+                text.push_str(s);
+            }
+        }
+        let id = interp.intern_dyn(text);
+        *out = id as u64;
+        if let Some(t0) = _t0 {
+            prof::add(&prof::FOREIGN_NS, t0);
+            prof::FOREIGN_CALLS
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        return 0;
     }
     let fname = interp.s(func).to_string();
     let loc = interp.loc_of(inst);
@@ -2537,6 +2563,7 @@ impl Interp {
                     port_consts,
                     real_consts,
                     gates: gates.clone(),
+                    str_consts: str_params.clone(),
                     region: (region_start, 0),
                 },
             );
@@ -2626,6 +2653,10 @@ impl Interp {
                     .collect();
                 m13.sort_unstable();
                 m13.hash(&mut h);
+                let mut m14: Vec<_> =
+                    e.str_consts.iter().map(|(&k, &v)| (k, v)).collect();
+                m14.sort_unstable();
+                m14.hash(&mut h);
                 // the sig must cover every input the exec lowering
                 // reads (handoff rule): regfile regions included
                 let mut m10: Vec<_> = e

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -111,7 +111,15 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         off += words;
     }
     crate::prim::FROM_COMPILED.with(|c| c.set(token));
-    if is_action {
+    if method == trs_codegen::lower::GATE_OUT_METHOD {
+        // compiled Expr::Gate on a prim child: not a method — answer
+        // gate_out(), the interp's exact read
+        let g = match &interp.insts[inst].kind {
+            InstKind::Prim(p) => p.gate_out() as u64,
+            _ => 1,
+        };
+        *out = g;
+    } else if is_action {
         interp.call_action(inst, method, &argv);
     } else {
         let v = interp.call_value(inst, method, &argv, ret_width);
@@ -125,7 +133,12 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
     if let Some(t0) = _t0 {
         prof::add(&prof::PRIM_NS, t0);
         prof::PRIM_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let meth = interp.s(method).to_string();
+        // the gate sentinel is no string id — interp.s() would index OOB
+        let meth = if method == trs_codegen::lower::GATE_OUT_METHOD {
+            "$gate_out".to_string()
+        } else {
+            interp.s(method).to_string()
+        };
         prof::PRIM_HIST
             .lock()
             .unwrap()
@@ -2139,12 +2152,12 @@ impl Interp {
         let mut rules: Vec<RuleInfo> = Vec::new();
         let mut rule_ord: HashMap<(usize, StrId), usize> = HashMap::new();
         for rc in rcomps {
-            if !rc.early.is_empty() {
-                if trace {
-                    eprintln!("trs jit: off (early rules)");
-                }
-                return None;
-            }
+            // clock-crossing "early" rules never enter the compiled
+            // edge walk: the general loop's after-edge pass (PG_FINAL)
+            // runs them interpreted over the same arena-backed state,
+            // exactly like a cold exec cell — so they are SKIPPED here
+            // (kept out of rule_ord and the node stream), not refused.
+            // The central fast loop already bails on early comps.
             // eager defs owned by entries already walked in THIS comp,
             // per instance: later rules of the same instance may load
             // their slots instead of re-expanding the cone
@@ -2152,6 +2165,9 @@ impl Interp {
             for en in &rc.entries {
                 for &node in &en.nodes {
                     let SchedNode::Sched(r) = node else { continue };
+                    if rc.early.contains(&(en.inst, r)) {
+                        continue; // after-edge pass runs it interpreted
+                    }
                     if rule_ord.contains_key(&(en.inst, r)) {
                         continue;
                     }
@@ -2520,6 +2536,7 @@ impl Interp {
                     memo_slot,
                     port_consts,
                     real_consts,
+                    gates: gates.clone(),
                     region: (region_start, 0),
                 },
             );
@@ -2599,6 +2616,16 @@ impl Interp {
                     e.real_consts.iter().map(|(&k, &v)| (k, v)).collect();
                 m12.sort_unstable();
                 m12.hash(&mut h);
+                // gate wiring pins the sig: owner slots are ABSOLUTE in
+                // deduped bodies, so instances gated differently (other
+                // owner, other expr) must never share exec code
+                let mut m13: Vec<_> = e
+                    .gates
+                    .iter()
+                    .map(|(&k, (o, g))| (k, *o, format!("{g:?}")))
+                    .collect();
+                m13.sort_unstable();
+                m13.hash(&mut h);
                 // the sig must cover every input the exec lowering
                 // reads (handoff rule): regfile regions included
                 let mut m10: Vec<_> = e
@@ -2630,6 +2657,9 @@ impl Interp {
                     let SchedNode::Exec(r) = node else { continue };
                     if !self.mods[module].rules.contains_key(&r) {
                         continue; // method exec node
+                    }
+                    if rc.early.contains(&(en.inst, r)) {
+                        continue; // after-edge pass runs it interpreted
                     }
                     if !rule_ord.contains_key(&(en.inst, r)) {
                         if trace {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -1176,9 +1176,25 @@ impl Interp {
                     // EN_* is latched 1 for the rest of the pass when the
                     // method executes (urgency inhibitors read it); an
                     // uncalled method's EN reads 0
-                    Some(&(w, ir::PortKind::MethodEnable)) => self
-                        .latched(inst, *name)
-                        .unwrap_or_else(|| Value::from_u64(w, 0)),
+                    Some(&(w, ir::PortKind::MethodEnable)) => {
+                        if let Some(v) = self.latched(inst, *name) {
+                            return v;
+                        }
+                        // compiled call sites store EN only in the
+                        // arena; interpreted cones (PG_FINAL early
+                        // rules, cold bodies) must read it there
+                        if !self.jit_arena_ptr.is_null() {
+                            if let Some(&slot) =
+                                self.jit_en_slots.get(&(inst, *name))
+                            {
+                                let word = unsafe {
+                                    *self.jit_arena_ptr.add(slot as usize)
+                                };
+                                return Value::from_u64(w, word);
+                            }
+                        }
+                        Value::from_u64(w, 0)
+                    }
                     Some(&(w, ir::PortKind::MethodArg)) => Value::from_u64(w, 0),
                     Some(&(w, _)) => Value::from_u64(w, 1),
                     None => Value::from_u64(1, 1),
@@ -4027,6 +4043,24 @@ impl Interp {
                     Some(j) => match &j.comp_nodes[rci] {
                         Some(nodes) => {
                             let ap = j.arena_ptr();
+                            // latch space clears per edge UNCONDITIONALLY
+                            // and for BOTH dispatch arms (fused and node
+                            // walk): warming fallback bodies latch state as
+                            // they run, and the PG_FINAL early-rule pass
+                            // latches CF/WF — a surviving latch would shadow
+                            // both the arena fall-through and recomputation
+                            // on the NEXT timeslice (latched() wins in
+                            // eval), freezing an early rule's first fire
+                            // decision forever.  Review round 2 found the
+                            // first fix covered only the node-walk arm while
+                            // AOT runs fuse from the first slice.
+                            for i in 0..self.insts.len() {
+                                if let InstKind::User { latched, .. } =
+                                    &mut self.insts[i].kind
+                                {
+                                    latched.clear();
+                                }
+                            }
                             // fused fast path (task #17): the whole
                             // edge as one compiled call — the schedule
                             // promoted from data to code.  The node
@@ -4049,25 +4083,6 @@ impl Interp {
                             } else {
                             // ConfigReg reads compare written_at to now
                             unsafe { *ap.add(j.now_slot as usize) = t };
-                            let warming = j.lazy.any_cold();
-                            // latch space clears per edge UNCONDITIONALLY,
-                            // exactly like the interpreted path: warming
-                            // fallback bodies latch state as they run, and
-                            // the PG_FINAL early-rule pass latches CF/WF —
-                            // a surviving latch would shadow both the arena
-                            // fall-through and recomputation on the NEXT
-                            // timeslice (latched() wins in eval), freezing
-                            // an early rule's first fire decision forever
-                            // (review finding: fully-compiled/AOT mode
-                            // never cleared)
-                            for i in 0..self.insts.len() {
-                                if let InstKind::User { latched, .. } =
-                                    &mut self.insts[i].kind
-                                {
-                                    latched.clear();
-                                }
-                            }
-                            let _ = warming;
                             // the C++ schedule zeroes every enable at the
                             // top of the pass; compiled call sites set them
                             for &s in &j.en_slots {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -658,7 +658,7 @@ impl Interp {
     }
 
     /// Intern a runtime-created string (StringConcat) into the arena.
-    fn intern_dyn(&mut self, text: String) -> StrId {
+    pub(crate) fn intern_dyn(&mut self, text: String) -> StrId {
         self.dyn_strs.push(text);
         (self.d.strings.len() + self.dyn_strs.len() - 1) as StrId
     }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -1046,6 +1046,29 @@ impl Interp {
         }
     }
 
+    /// A latched def, or its arena-slot value when the def is kept
+    /// current by compiled scheds (fire signals / schedule-position
+    /// defs).  Inhibitor lookups must see compiled rules' CFs.
+    fn latched_or_arena(&self, inst: usize, name: StrId) -> Option<Value> {
+        if let Some(v) = self.latched(inst, name) {
+            return Some(v);
+        }
+        if !self.jit_arena_ptr.is_null() {
+            if let Some(&(base, w)) = self.jit_eager_slots.get(&(inst, name)) {
+                let words = ((w.max(1) as usize) + 63) / 64;
+                let limbs = unsafe {
+                    std::slice::from_raw_parts(
+                        self.jit_arena_ptr.add(base as usize),
+                        words,
+                    )
+                }
+                .to_vec();
+                return Some(Value::from_limbs64(w.max(1), limbs));
+            }
+        }
+        None
+    }
+
     /// Evaluate an expression in an instance context.  Body-local defs and
     /// per-cycle latched defs win over recomputation; in memo contexts,
     /// on-demand def values are cached.
@@ -2919,11 +2942,16 @@ impl Interp {
         let mut ctx = Ctx { memo: true, ..Default::default() };
 
         let mut cf = self.eval(inst, &mut ctx, &Expr::Def(r.can_fire));
-        // intra-module ME inhibitors (earlier disjoint rules' CFs)
+        // intra-module ME inhibitors (earlier disjoint rules' CFs).
+        // A compiled rule's CF lives in its arena slot, not in latched
+        // (the native scheds keep it current) — an early rule inhibited
+        // by a compiled rule must read the slot when no interpreter
+        // latch exists (review finding: latched-only lookup missed
+        // every compiled inhibitor)
         for other in &r.me_inhibits {
             let other_ri = self.mods[module].rules[other];
             let other_cf = self.d.modules[mir].rules[other_ri].can_fire;
-            if let Some(v) = self.latched(inst, other_cf) {
+            if let Some(v) = self.latched_or_arena(inst, other_cf) {
                 if v.as_bool() {
                     cf = Value::zero(1);
                 }
@@ -2931,7 +2959,7 @@ impl Interp {
         }
         // cross-module inhibitors targeting this rule
         for (other_inst, other_cf) in cross_inh {
-            if let Some(v) = self.latched(*other_inst, *other_cf) {
+            if let Some(v) = self.latched_or_arena(*other_inst, *other_cf) {
                 if v.as_bool() {
                     cf = Value::zero(1);
                 }
@@ -4022,19 +4050,24 @@ impl Interp {
                             // ConfigReg reads compare written_at to now
                             unsafe { *ap.add(j.now_slot as usize) = t };
                             let warming = j.lazy.any_cold();
-                            if warming {
-                                // interpreted fallback bodies latch state
-                                // as they run; clear per edge or stale
-                                // latched defs would shadow the arena
-                                // fall-through (latched() wins in eval)
-                                for i in 0..self.insts.len() {
-                                    if let InstKind::User { latched, .. } =
-                                        &mut self.insts[i].kind
-                                    {
-                                        latched.clear();
-                                    }
+                            // latch space clears per edge UNCONDITIONALLY,
+                            // exactly like the interpreted path: warming
+                            // fallback bodies latch state as they run, and
+                            // the PG_FINAL early-rule pass latches CF/WF —
+                            // a surviving latch would shadow both the arena
+                            // fall-through and recomputation on the NEXT
+                            // timeslice (latched() wins in eval), freezing
+                            // an early rule's first fire decision forever
+                            // (review finding: fully-compiled/AOT mode
+                            // never cleared)
+                            for i in 0..self.insts.len() {
+                                if let InstKind::User { latched, .. } =
+                                    &mut self.insts[i].kind
+                                {
+                                    latched.clear();
                                 }
                             }
+                            let _ = warming;
                             // the C++ schedule zeroes every enable at the
                             // top of the pass; compiled call sites set them
                             for &s in &j.en_slots {

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -2124,9 +2124,11 @@ impl Prim for RWire {
         true // wire clear placement differs by engine (see trait doc)
     }
     fn sym_read(&mut self, key: &str, _now: u64) -> Option<Value> {
+        // slot-aware reads: after arena_attach the boxed fields are
+        // frozen at attach time; compiled wset writes only the slots
         match key {
-            "" | "value" => Some(self.value.clone()),
-            "isValid" => Some(Value::from_u64(1, self.valid as u64)),
+            "" | "value" => Some(self.get_value()),
+            "isValid" => Some(Value::from_u64(1, self.get_valid() as u64)),
             _ => None,
         }
     }
@@ -2912,6 +2914,11 @@ impl Prim for Fifo {
                     self.saved_elems = self.elems;
                 }
                 self.elems = 0;
+                // the reference's METH_clear resets BOTH cursors
+                // (bs_prim_mod_fifo.h: fst = 0; elems = 0) — a stale fst
+                // desynchronizes data addressing vs the reference after
+                // deq-then-clear (sym reads, unguarded first)
+                self.fst = 0;
                 self.mirror_header();
             }
             m => panic!("FIFO: unknown action method {m:?}"),
@@ -2931,6 +2938,7 @@ impl Prim for Fifo {
                 self.saved_elems = self.elems;
             }
             self.elems = 0;
+            self.fst = 0; // rst_tick_clk calls METH_clear: fst resets too
             self.suppress = true;
             self.mirror_header();
         }

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -2556,30 +2556,34 @@ impl Fifo {
     /// Mirror the header (elems/saved/fst/instants) into the arena.
     fn mirror_header(&self) {
         let Some(slot) = self.slot else { return };
-        let h = unsafe { std::slice::from_raw_parts_mut(slot, 6) };
+        let h = unsafe { std::slice::from_raw_parts_mut(slot, 7) };
         h[0] = self.elems as u64;
         h[1] = self.saved_elems as u64;
         h[2] = self.fst as u64;
         h[3] = self.enq_at;
         h[4] = self.deq_at;
         h[5] = self.clear_at;
+        h[6] = self.suppress as u64;
     }
     /// Arena-authoritative refresh: compiled INLINE enq/deq update the
     /// slots directly; boxed ops re-read them first.
     fn refresh(&mut self) {
         let Some(slot) = self.slot else { return };
         let w = self.arena_words();
-        let h = unsafe { std::slice::from_raw_parts(slot, 6 + self.size * w) };
+        let h = unsafe { std::slice::from_raw_parts(slot, 7 + self.size * w) };
         self.elems = h[0] as usize;
         self.saved_elems = h[1] as usize;
         self.fst = h[2] as usize;
         self.enq_at = h[3];
         self.deq_at = h[4];
         self.clear_at = h[5];
+        // h[6] (suppress) is a one-way mirror: the boxed field is
+        // authoritative, compiled fast paths only read it to bounce
+        // suppressed ops to the boxed prim
         let width = self.width.max(1);
         for i in 0..self.size {
             self.data[i] =
-                Value::from_limbs64(width, h[6 + i * w..6 + (i + 1) * w].to_vec());
+                Value::from_limbs64(width, h[7 + i * w..7 + (i + 1) * w].to_vec());
         }
     }
 
@@ -2588,7 +2592,7 @@ impl Fifo {
         let Some(slot) = self.slot else { return };
         let w = self.arena_words();
         let dst =
-            unsafe { std::slice::from_raw_parts_mut(slot.add(6 + idx * w), w) };
+            unsafe { std::slice::from_raw_parts_mut(slot.add(7 + idx * w), w) };
         for (i, d) in dst.iter_mut().enumerate() {
             *d = self.data[idx].limbs64().get(i).copied().unwrap_or(0);
         }
@@ -2947,6 +2951,11 @@ impl Prim for Fifo {
         self.in_reset = asserted;
         if !asserted {
             self.suppress = false;
+            // suppress alone: a blanket mirror_header here would push
+            // boxed fields over arena state the compiled ops own
+            if let Some(slot) = self.slot {
+                unsafe { *slot.add(6) = 0 };
+            }
         }
     }
 

--- a/src/trs/crates/trs-interp/src/value.rs
+++ b/src/trs/crates/trs-interp/src/value.rs
@@ -250,6 +250,9 @@ impl Value {
 
     pub fn lshr(&self, sh: u64, w: u32) -> Value {
         let mut r = Value::zero(w);
+        if sh >= self.width as u64 {
+            return r; // also guards i + sh overflow for huge sh
+        }
         for i in 0..w {
             let src = i as u64 + sh;
             if src < self.width as u64 && self.bit(src as u32) {
@@ -262,6 +265,15 @@ impl Value {
     pub fn ashr(&self, sh: u64, w: u32) -> Value {
         let s = self.sign();
         let mut r = Value::zero(w);
+        if sh >= self.width as u64 {
+            // pure sign fill; also guards i + sh overflow for huge sh
+            if s {
+                for i in 0..w {
+                    r.limbs[(i as usize) / 64] |= 1 << (i % 64);
+                }
+            }
+            return r;
+        }
         for i in 0..w {
             let src = i as u64 + sh;
             let b = if src < self.width as u64 { self.bit(src as u32) } else { s };

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -216,7 +216,13 @@ fn main() -> ExitCode {
                      exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" ${{1+\"$@\"}}\n"
                 )
             };
-            if let Err(e) = std::fs::write(&base, script) {
+            // temp+rename: a crash mid-write must never leave a
+            // truncated-but-executable wrapper (a script missing its
+            // exec line runs and exits 0 doing nothing)
+            let base_tmp = format!("{base}.tmp");
+            if let Err(e) = std::fs::write(&base_tmp, script)
+                .and_then(|()| std::fs::rename(&base_tmp, &base))
+            {
                 eprintln!("trs link: {base}: {e}");
                 return ExitCode::FAILURE;
             }

--- a/src/trs/tools/diffsweep.py
+++ b/src/trs/tools/diffsweep.py
@@ -262,9 +262,28 @@ def one_test(job):
         return (rel, top, "TIMEOUT", f"limit {limit:.0f}s (ref {ref_secs:.2f}s)")
     if inp.returncode != 0 and "panicked" in inp.stderr:
         return (rel, top, "INTERP_PANIC", panic_reason(inp.stderr))
-    if "error" in inp.stderr.lower() and inp.returncode != 0:
+    # infra-failure heuristic: only when the reference did NOT fail the
+    # same way — a design that legitimately exits nonzero (e.g. $fatal)
+    # while printing "Error" must reach the output diff, not hide in an
+    # infra bucket
+    if ("error" in inp.stderr.lower() and inp.returncode != 0
+            and inp.returncode != ref.returncode):
         return (rel, top, "DECODE_FAIL", first_error(inp.stderr))
 
+    # stderr is a sim output channel too ($fdisplay to stderr): diff it
+    # like stdout, with trs' own infra notes (all "trs"-prefixed lines)
+    # filtered out of the trs side first
+    trs_notes = [l for l in inp.stderr.splitlines(True) if l.startswith("trs")]
+    inp_err = "".join(
+        l for l in inp.stderr.splitlines(True) if not l.startswith("trs"))
+    if engine_note == " engine=aot" and any(
+            "compiling in-process instead" in l for l in trs_notes):
+        # the wrapper had --code but the artifact refused at load: the
+        # run was NOT aot — never credit aot timings to a fallback
+        engine_note = " engine=interp why=stale_artifact_load_fallback"
+    if ref.stdout == inp.stdout and ref.stderr != inp_err:
+        return (rel, top, "DIFF",
+                "stderr: " + diff_summary(ref.stderr, inp_err))
     if ref.stdout == inp.stdout:
         if ref.returncode != inp.returncode:
             return (rel, top, "DIFF",
@@ -358,9 +377,15 @@ def main():
         # workers re-import this module (spawn/forkserver); hand the
         # override down via the environment
         os.environ["DIFFSWEEP_TRS"] = TRS
+    # bind the globals too: fork-start pools never re-import, so the
+    # env-only handoff silently no-ops the flags there
     if args.timeout_floor is not None:
+        global TIMEOUT_FLOOR
+        TIMEOUT_FLOOR = args.timeout_floor
         os.environ["DIFFSWEEP_TIMEOUT_FLOOR"] = str(args.timeout_floor)
     if args.timeout_factor is not None:
+        global TIMEOUT_FACTOR
+        TIMEOUT_FACTOR = args.timeout_factor
         os.environ["DIFFSWEEP_TIMEOUT_FACTOR"] = str(args.timeout_factor)
     if args.aot:
         global AOT
@@ -395,11 +420,13 @@ def main():
             if status == "PASS" and note.startswith("t "):
                 total = 0.0
                 for kv in note[2:].split():
-                    _, _, v = kv.partition("=")
+                    k, _, v = kv.partition("=")
+                    if k not in ("ref_build", "ref_run", "trs_link", "trs_run"):
+                        continue  # engine=/why= (even numeric-looking)
                     try:
                         total += float(v)
                     except ValueError:
-                        pass  # non-timing columns (engine=, why=)
+                        pass
                 cost[(rel, top)] = total
         def jobkey(j):
             rel = os.path.relpath(j[0], REPO)


### PR DESCRIPTION
Stacked on #124. Executes the closure plan end to end, then burns the remaining named fallbacks down to zero: **every design that runs without waveforms now runs compiled**. Census: **87.8% → 98.9% compiled** (974/995 passing designs); the only interp fallbacks left are the 21 VCD-by-design cases (accepted: fast artifact = speed, waveforms only via dump format). Sealed by frozen-binary full `--aot` sweeps at **0 DIFF** after every commit group.

## Rungs
| Rung | Commit | What |
|---|---|---|
| 0 | `528187dd` | Catch-alls name the refused `Expr` variant (telemetry only) |
| 1 | `61f51ec5` | AV/foreign task results survive Cond joins — per-frame undet-initialized allocas mirroring the interp's body-wide `ctx.locals`; missing `expr_width` arms. dft64's 135–172× interp penalty erased |
| 2 | `7dfe6d6e` | Zero-width values as the empty bit-vector; callback specs carry true width 0 (formatter parity). sysBRAM0Test's 35× erased. REV 9 |
| 3 | `f7b02de1` | Reals as i64 f64-bits + `FArgSpec::Real` → the interp's `Arg::Real`, `%f` byte-identical. REV 10 |
| 4 | `c417bc3e` | MCD: static bound gates lower in the owner frame; prim `gate_out()` via trampoline sentinel; early rules run interpreted in the PG_FINAL pass over shared arena state. REV 11 |
| 5 | `c256d9e2`, `799f0bfd` | Strings as i64 ids (`StrDyn` specs, id-compare Eq, concat via per-evaluation intern callback) — **sysFloatTest 20.0s → 0.39s**; wide instantiation values; `MethValue` → `value_call`. REV 12 |

## Review rounds
`c0f0ed7a` (external ChatGPT review: 5 blockers + 3 fixed, REV 13) and `4c6cd45f` (five-lens adversarial review of the whole tree: 20 confirmed fixes, REV 14) — details in the two comments below.

## Burn-down to the floor
| Commit | What |
|---|---|
| `291b70bc` | splitports quartet: compiled `MethValue` on user-child AV methods — per-edge arg latches (`select(cond, v, 0)`), uncaptured args fold to the interp's 0-at-schedule-position read |
| `76f385a3` | The last four non-VCD singletons: Action calls to ActionValue methods (result discarded, body runs — interp parity); `always_enabled` bodies gated on the sibling `RDY_<m>` value method after EN lands (the C++ `check_rdy` contract); BDPI calls with dynamic CString args via the boxed trampoline; `emit_foreign`'s stop block made optional so string concat compiles in pure value cones. REV 15 |
| `00b4464e` | Dynamic clock gates compile — unblocked by the real root cause: the long-standing mcd_Rand "gate latch semantics" DIFF was actually the compiled FIFO fast path ignoring reset **suppress** (an enq inside a reset window survived the clear the reference drops). The FIFO arena header grows a 7th word mirroring suppress; suppressed enq/deq bounce to the boxed slow path. Gates then chase live cones (`Expr::Gate` prim reads + `Expr::Port` owner links). Latent-bug fix for ANY compiled design with cross-domain FIFO traffic during reset. REV 16 |

## Remaining fallback
21 VCD-by-design (accepted floor). Non-PASS rows are all upstream-class; the ConflictFree*Large ref-**build** timeouts seen intermittently are container-environment (bsc build time, byte-identical when run solo).

## Validation
Every commit group: unit tests, regress ladder 6/6, vcd ladder 10/10, class witnesses byte-identical, then a frozen-binary full `--aot` sweep — final seal at `00b4464e`: **995 PASS / 0 DIFF / 974 aot**, perf fence clean. mcd_Rand byte-identical over its full run with everything compiled. **Known gaps for reviewers**: the interactive battery (33 tests, needs `TRS_CAPI_LIB`) has not run on this stack; the perf fence is not rebaselined (noisy 4-core container).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_