### PR TITLE
trs: obey -dump-formats — waveform writers are a link-time contract

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1964,8 +1964,19 @@ trsLink errh flags toplevel user_cfiles user_ofiles = do
     -- same amortization as the C++ backend's g++ link, at a fraction
     -- of the cost.  Any failure (trs not on PATH, built without the
     -- jit feature, infra error) falls back to the interpreter wrapper.
+    -- like the C++ backend, trs dumps waveforms only in VCD and FST
+    let bad_fmts2 = filter (`notElem` ["vcd", "fst"]) (dumpFormats flags)
+    when (not (null bad_fmts2)) $
+        bsError errh
+            [(cmdPosition,
+              EGeneric ("Bluesim does not support waveform dump format `" ++
+                        f ++ "' (supported: vcd, fst)"))
+            | f <- bad_fmts2]
+    let dumpFmtsArg = case dumpFormats flags of
+                        [] -> "none"
+                        fs -> intercalate "," fs
     let linkCmd = "\"${TRS:-trs}\" link \"" ++ outFile ++ ".bir\" -o \""
-                  ++ outFile ++ "\""
+                  ++ outFile ++ "\" --dump-formats " ++ dumpFmtsArg
     rc <- system linkCmd
     case rc of
       ExitSuccess -> do

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -3746,16 +3746,20 @@ impl Interp {
         // set_state (mirroring bluesim.tcl's `sim <fmt> on|<file>`)
         if let Some((fmt, file)) = self.wave_pending.take() {
             let now = self.now;
-            self.vcd.set_format(fmt, now);
-            match file {
-                Some(f) => {
-                    if self.vcd.set_file(&f).is_ok() {
-                        self.vcd.set_state(true);
+            // -dump-formats gate FIRST: a refused request must not
+            // even create the file (the reference errors on stderr
+            // and the simulation runs on, dump-less)
+            if self.vcd.format_available(fmt) && self.vcd.set_format(fmt, now) {
+                match file {
+                    Some(f) => {
+                        if self.vcd.set_file(&f).is_ok() {
+                            self.vcd.set_state(true);
+                        }
                     }
+                    None => self.vcd.set_state(true),
                 }
-                None => self.vcd.set_state(true),
+                self.vcd_trace = true;
             }
-            self.vcd_trace = true;
         }
 
         // seed the event heap (see Stepper::heap for the ordering)
@@ -4667,16 +4671,29 @@ impl Interp {
     /// bk_set_waveform_format's engine half (the capi validates the
     /// string): a same-format set is a no-op, otherwise any dump in
     /// progress ends and the file closes.
-    pub fn wave_set_format(&mut self, fmt: WaveFormat) {
+    pub fn wave_set_format(&mut self, fmt: WaveFormat) -> bool {
         let now = self.now;
-        self.vcd.set_format(fmt, now);
+        if !self.vcd.set_format(fmt, now) {
+            return false;
+        }
         // FST recording needs the same def/method traces as VCD
         self.vcd_trace = true;
+        true
     }
 
     /// bk_get_waveform_format.
     pub fn wave_format(&self) -> WaveFormat {
         self.vcd.format()
+    }
+
+    /// -dump-formats plumbing: which waveform writers this model
+    /// carries.  `none` also turns recording off entirely — the model
+    /// is the untraced fast artifact and can never start dumping.
+    pub fn set_allowed_wave_formats(&mut self, vcd: bool, fst: bool) {
+        self.vcd.set_allowed(vcd, fst);
+        if !vcd && !fst {
+            self.vcd_trace = false;
+        }
     }
 
     /// Batch driver (+bscvcd / +bscfst): stage a waveform request
@@ -5079,8 +5096,12 @@ pub fn run_file(
     vcd_file: Option<&str>,
     wave: Option<(WaveFormat, Option<String>)>,
     code: Option<&str>,
+    formats: Option<(bool, bool)>,
 ) -> Result<i32, String> {
     let mut interp = load_file(path, plusargs, vcd_file)?;
+    if let Some((vcd, fst)) = formats {
+        interp.set_allowed_wave_formats(vcd, fst);
+    }
     if let Some((f, file)) = wave {
         interp.wave_request(f, file);
     }

--- a/src/trs/crates/trs-interp/src/vcd.rs
+++ b/src/trs/crates/trs-interp/src/vcd.rs
@@ -62,6 +62,12 @@ pub struct Vcd {
     /// -dump-formats gates which writers are COMPILED INTO a C++
     /// model — an interpreter has no codegen to elide)
     format: WaveFormat,
+    /// -dump-formats: which writers this model claims to carry.  The
+    /// reference default is vcd-only; format selection and dump
+    /// enabling report the reference's exact errors when the model
+    /// was not built with the requested format.
+    allowed_vcd: bool,
+    allowed_fst: bool,
     filename: Option<String>,
     pub state: VcdState,
     pub enabled: bool,
@@ -91,6 +97,8 @@ impl Vcd {
         Vcd {
             sink: None,
             format: WaveFormat::Vcd,
+            allowed_vcd: true,
+            allowed_fst: false,
             filename: None,
             state: VcdState::Off,
             enabled: false,
@@ -165,9 +173,53 @@ impl Vcd {
     /// closed; re-enabling writes a file in the new format.  Format
     /// availability is the CALLER's check (capi): the interp engine
     /// carries both writers.
-    pub fn set_format(&mut self, fmt: WaveFormat, now: u64) {
+    /// -dump-formats: record which writers the model carries; also
+    /// selects the default format (vcd_set_allowed_formats semantics —
+    /// vcd wins when both are present).
+    pub fn set_allowed(&mut self, vcd: bool, fst: bool) {
+        self.allowed_vcd = vcd;
+        self.allowed_fst = fst;
+        if vcd {
+            self.format = WaveFormat::Vcd;
+        } else if fst {
+            self.format = WaveFormat::Fst;
+        }
+    }
+
+    /// vcd_format_available: true iff the model carries `fmt`,
+    /// reporting the reference's exact stderr error when it does not
+    /// (the simulation continues either way).
+    pub fn format_available(&self, fmt: WaveFormat) -> bool {
+        if !self.allowed_vcd && !self.allowed_fst {
+            eprintln!(
+                "Error: this model was built with -dump-formats none; \
+                 no waveform dumping is available"
+            );
+            return false;
+        }
+        let ok = match fmt {
+            WaveFormat::Vcd => self.allowed_vcd,
+            WaveFormat::Fst => self.allowed_fst,
+        };
+        if !ok {
+            let (name, flag) = match fmt {
+                WaveFormat::Fst => ("FST", "fst"),
+                WaveFormat::Vcd => ("VCD", "vcd"),
+            };
+            eprintln!(
+                "Error: this model was not built with {name} support \
+                 (rebuild with -dump-formats {flag})"
+            );
+        }
+        ok
+    }
+
+    pub fn set_format(&mut self, fmt: WaveFormat, now: u64) -> bool {
         if fmt == self.format {
-            return;
+            return true;
+        }
+        if !self.format_available(fmt) {
+            return false;
         }
         self.enabled = false;
         self.go_xs = false;
@@ -187,6 +239,7 @@ impl Vcd {
         self.filename = None;
         self.state = VcdState::Off;
         self.format = fmt;
+        true
     }
 
     pub fn set_file(&mut self, name: &str) -> Result<(), ()> {
@@ -219,6 +272,11 @@ impl Vcd {
     }
 
     pub fn set_state(&mut self, on: bool) {
+        // $dumpon/$dumpvars on a model without the current format:
+        // loud error, stay off, open no file
+        if on && !self.format_available(self.format) {
+            return;
+        }
         if on && self.sink.is_none() {
             let _ = self.set_file(self.default_file_name());
         }

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -52,11 +52,30 @@ fn main() -> ExitCode {
         ["link", path, rest @ ..] => {
             let mut out: Option<String> = None;
             let mut interactive = false;
+            // -dump-formats plumbing from bsc: which waveform writers
+            // the artifact carries (reference default: vcd only)
+            let mut fmt_arg = "vcd".to_string();
             let mut it = rest.iter();
             while let Some(a) = it.next() {
                 match *a {
                     "-o" => out = it.next().map(|s| s.to_string()),
                     "--interactive" => interactive = true,
+                    "--dump-formats" => {
+                        let Some(v) = it.next() else {
+                            eprintln!("Error: --dump-formats requires a value");
+                            return ExitCode::from(2);
+                        };
+                        for tok in v.split(',').filter(|t| !t.is_empty()) {
+                            if !matches!(tok, "none" | "vcd" | "fst") {
+                                eprintln!(
+                                    "trs link: unsupported dump format \
+                                     `{tok}' (supported: vcd, fst, none)"
+                                );
+                                return ExitCode::FAILURE;
+                            }
+                        }
+                        fmt_arg = v.to_string();
+                    }
                     // hermeticity: every output-affecting knob is a
                     // flag (bsc passes these through; build systems
                     // key actions on argv, not env).  The env vars
@@ -106,6 +125,11 @@ fn main() -> ExitCode {
                     return ExitCode::FAILURE;
                 }
             };
+            let fmt_vcd = fmt_arg.split(',').any(|t| t == "vcd");
+            let fmt_fst = fmt_arg.split(',').any(|t| t == "fst");
+            // `none` turns recording off: the artifact is the pure
+            // untraced fast model (and the trace salt follows)
+            interp.set_allowed_wave_formats(fmt_vcd, fmt_fst);
             if interactive {
                 // DEBUG/interactive product: a bluetcl-loadable model
                 // .so (docs/TCL-CAPI.md) + the reference's bluesim.tcl
@@ -233,12 +257,12 @@ fn main() -> ExitCode {
             let script = if compiled {
                 format!(
                     "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n\
-                     exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" --code \"$d/$b.so\"{split_arg} ${{1+\"$@\"}}\n"
+                     exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" --code \"$d/$b.so\"{split_arg} --formats {fmt_arg} ${{1+\"$@\"}}\n"
                 )
             } else {
                 format!(
                     "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n\
-                     exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" ${{1+\"$@\"}}\n"
+                     exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" --formats {fmt_arg} ${{1+\"$@\"}}\n"
                 )
             };
             // temp+rename: a crash mid-write must never leave a
@@ -271,6 +295,9 @@ fn main() -> ExitCode {
                 None;
             let mut vcd_file: Option<String> = None;
             let mut code_so: Option<String> = None;
+            // (vcd, fst) writers this model carries; None = the
+            // reference default (vcd only) applied at load
+            let mut formats: Option<(bool, bool)> = None;
             let mut script_cmds = String::new();
             // bluesim.tcl's usage text, printed for -h and after the
             // deprecated-flag notices; the driver exits 0 in both cases
@@ -322,6 +349,15 @@ fn main() -> ExitCode {
                     }
                     "--code" => {
                         code_so = it.next().map(|s| s.to_string());
+                    }
+                    // -dump-formats baked into the artifact wrapper
+                    "--formats" => {
+                        if let Some(v) = it.next() {
+                            formats = Some((
+                                v.split(',').any(|t| t == "vcd"),
+                                v.split(',').any(|t| t == "fst"),
+                            ));
+                        }
                     }
                     // artifacts pin their split threshold (arena layout)
                     "--split" => {
@@ -414,6 +450,7 @@ fn main() -> ExitCode {
                     vcd_file.as_deref(),
                     wave.clone(),
                     code_so.as_deref(),
+                    formats,
                     &script_cmds,
                 );
             }
@@ -424,6 +461,7 @@ fn main() -> ExitCode {
                 vcd_file.as_deref(),
                 wave,
                 code_so.as_deref(),
+                formats,
             ) {
                 Ok(code) => {
                     use std::io::Write;
@@ -652,6 +690,7 @@ fn run_script(
     vcd: Option<&str>,
     wave: Option<(trs_interp::WaveFormat, Option<String>)>,
     code: Option<&str>,
+    formats: Option<(bool, bool)>,
     script: &str,
 ) -> ExitCode {
     let mut interp = match trs_interp::load_file(path, plusargs, vcd) {
@@ -661,6 +700,9 @@ fn run_script(
             return ExitCode::FAILURE;
         }
     };
+    if let Some((v, f)) = formats {
+        interp.set_allowed_wave_formats(v, f);
+    }
     if let Some((f, file)) = wave {
         interp.wave_request(f, file);
     }
@@ -730,6 +772,37 @@ fn run_script(
                 .collect::<Vec<_>>()
                 .join(" "),
             ["sim", "config", "interactive"] => String::new(),
+            // bluetcl's `sim vcd` / `sim fst`: select the format
+            // (refused with the reference's error when the model was
+            // not built with it), then on|off|<file>|query
+            ["sim", f @ ("vcd" | "fst")] => {
+                // query: current dump file name (empty list when none)
+                let _ = f;
+                interp.vcd_file_name().to_string()
+            }
+            ["sim", f @ ("vcd" | "fst"), arg] => {
+                let fmt = if *f == "fst" {
+                    trs_interp::WaveFormat::Fst
+                } else {
+                    trs_interp::WaveFormat::Vcd
+                };
+                match *arg {
+                    "off" => interp.vcd_disable(),
+                    "on" => {
+                        if interp.wave_set_format(fmt) {
+                            let _ = interp.vcd_enable();
+                        }
+                    }
+                    file => {
+                        if interp.wave_set_format(fmt)
+                            && interp.vcd_set_file(Some(file)).is_ok()
+                        {
+                            let _ = interp.vcd_enable();
+                        }
+                    }
+                }
+                String::new()
+            }
             _ => {
                 eprintln!(
                     "trs: unsupported -c/-f command {cmd:?} \

--- a/testsuite/bsc.bluesim/fst/fst.exp
+++ b/testsuite/bsc.bluesim/fst/fst.exp
@@ -170,10 +170,13 @@ if { $ctest == 1 } {
     find_regexp sysFstVcdOnly.vcd {\$var reg 8 \S+ counter \$end}
 
     # the per-signal dump code is generated, but the FST writer is
-    # not referenced (it is only linked in when fst is selected)
-    string_occurs mkFstDumpCore.cxx "vcd_write_val"
-    string_does_not_occur model_sysFstVcdOnly.cxx "vcd_register_fst"
-    string_occurs model_sysFstDump.cxx "vcd_register_fst"
+    # not referenced (it is only linked in when fst is selected) —
+    # C++-backend artifacts only
+    if { [cxx_codegen_tests] } {
+        string_occurs mkFstDumpCore.cxx "vcd_write_val"
+        string_does_not_occur model_sysFstVcdOnly.cxx "vcd_register_fst"
+        string_occurs model_sysFstDump.cxx "vcd_register_fst"
+    }
 
     sim_output sysFstVcdOnly {+bscfst}
     string_occurs sysFstVcdOnly.out "Error: this model was not built with FST support (rebuild with -dump-formats fst)"
@@ -188,10 +191,13 @@ if { $ctest == 1 } {
     # the per-signal dump code really is dropped: relinking with
     # none must regenerate the module (not reuse the object built
     # with vcd,fst above) without the dump machinery (the clock
-    # definitions, which the kernel owns, are not gated)
-    string_does_not_occur mkFstDumpCore.cxx "vcd_write_val"
-    string_does_not_occur mkFstDumpCore.cxx "vcd_defs"
-    string_occurs model_sysFstNone.cxx "no waveform dumping is available"
+    # definitions, which the kernel owns, are not gated) —
+    # C++-backend artifacts only
+    if { [cxx_codegen_tests] } {
+        string_does_not_occur mkFstDumpCore.cxx "vcd_write_val"
+        string_does_not_occur mkFstDumpCore.cxx "vcd_defs"
+        string_occurs model_sysFstNone.cxx "no waveform dumping is available"
+    }
 
     sim_output sysFstNone {+bscfst}
     string_occurs sysFstNone.out "Error: this model was built with -dump-formats none; no waveform dumping is available"


### PR DESCRIPTION
Stacked on #126. Closes the 18-test `bsc.bluesim/fst` gap: the reference treats `-dump-formats` as a **build-time contract** — requesting a format the model wasn't built with reports the exact kernel error on stderr, the simulation continues, and no file is created; a `none` model carries no dumping at all. trs previously honored every dump request on every artifact.

## What changed
- **bsc -trs** validates the formats like `simLink` (vcd/fst only; fsdb fails the link) and passes them to `trs link --dump-formats`; the wrapper bakes `--formats <set>` so runs know what the artifact carries (absent = the reference default, vcd only).
- **The Vcd engine holds the allowed set**: format selection and dump enabling gate on it with the reference's exact messages ("Error: this model was not built with VCD support (rebuild with -dump-formats vcd)" / FST analog / the `none` message). The whole batch request (`-V`/`+bscvcd`/`+bscfst`) gates **before** any file is created.
- **`none` forces recording off** — the artifact is the pure untraced fast model (per the opt-in tracing doctrine of #126), and the trace-salted artifact identity follows automatically.
- The `-c`/`-f` script subset learns bluetcl's `sim vcd|fst [on|off|<file>]` and the query form — what the mid-simulation format-switch test drives; `Vcd::set_format` already ends the current dump cleanly and the switch test passes.
- `fst.exp`'s C++-artifact greps gained the existing `cxx_codegen_tests` guard (they inspect generated `.cxx`, which only the C++ backend produces).

## Validation
Official harness, `SIM_BACKEND_FLAG=-trs`: **bsc.bluesim/fst 45 PASS / 0 FAIL** (was 18 FAIL) — fst-only, vcd-only (default), both-formats, and `none` models; refusal messages verbatim; `$dump*`-task FST routing; the format-switch script. `bsc.bluesim/vcd` 32/32; `bsc.bluesim/misc` unchanged (its 3 failures are the interactive sim-step class, next slice's scope); vcd ladder spots byte-identical; unit tests green. Full frozen-binary diffsweep seal running; result will be posted here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_