### PR TITLE
trs: simulation hooks — the -c/-f script tier rides bluetcl on a shared capi

### DIFF
--- a/src/trs/Makefile
+++ b/src/trs/Makefile
@@ -15,12 +15,19 @@ all: install
 # needs no BLUESPECDIR or LD_LIBRARY_PATH), so it is installed directly
 # in "bin" with no wrapper script.  libtrs_capi.a (the bk_* C API for
 # `trs link --interactive` models) installs beside it — the linker
-# searches next to its own binary.
+# searches next to its own binary — and `trs capi-so` turns it into
+# the ONE shared libtrs_capi.so the fast link's per-design capi shims
+# link against (docs/TCL-CAPI.md).
 #
-# The hybrid JIT needs llvm-sys (LLVM 18 dev headers): when the
-# environment provides LLVM_SYS_181_PREFIX, build the full product;
-# otherwise the lean interpreter-only fallback (no LLVM required).
-ifdef LLVM_SYS_181_PREFIX
+# The hybrid JIT needs llvm-sys (LLVM 18 dev headers).  The prefix is
+# AUTO-DETECTED via llvm-config-18 so a plain build produces the full
+# product (a lean install silently downgraded every artifact to the
+# interpreter until the perf fence caught it); LLVM_SYS_181_PREFIX in
+# the environment overrides the probe.  Without either, the lean
+# interpreter-only fallback builds (no LLVM required).
+LLVM_SYS_181_PREFIX ?= $(shell llvm-config-18 --prefix 2>/dev/null)
+ifneq ($(LLVM_SYS_181_PREFIX),)
+export LLVM_SYS_181_PREFIX
 TRS_FLAGS = --features jit
 CAPI_FLAGS  =
 else
@@ -41,6 +48,12 @@ install: build
 	# debuginfo in the staticlib is dead weight at .so link time
 	# (~420MB -> tens of MB); the interactive link strips the model
 	strip --strip-debug $(BINDIR)/libtrs_capi.a
+	# the shared capi: linked ONCE here instead of once per design;
+	# without it the fast wrapper's -c/-f script tier is absent (the
+	# artifact contract is unchanged), so a cc/LLVM-less environment
+	# degrades with a note rather than failing the install
+	$(BINDIR)/trs capi-so -o $(BINDIR)/libtrs_capi.so \
+	  || echo "trs: note: libtrs_capi.so not built; artifacts will lack the -c/-f script tier"
 
 .PHONY: clean full_clean
 clean full_clean:

--- a/src/trs/crates/trs-capi/src/lib.rs
+++ b/src/trs/crates/trs-capi/src/lib.rs
@@ -1322,7 +1322,12 @@ pub extern "C" fn bk_set_waveform_format(
     if !vcd_capable(st) {
         return BK_ERROR;
     }
-    st.primary().wave_set_format(fmt);
+    // -dump-formats gate: the refusal (reference's exact stderr error,
+    // sim continues) must reach bluetcl as BK_ERROR — simWaveform only
+    // enables dumping on OK
+    if !st.primary().wave_set_format(fmt) {
+        return BK_ERROR;
+    }
     BK_SUCCESS
 }
 

--- a/src/trs/crates/trs-capi/src/lib.rs
+++ b/src/trs/crates/trs-capi/src/lib.rs
@@ -211,10 +211,25 @@ pub extern "C" fn bk_init(model: *mut c_void, _master: u8) -> *mut c_void {
     };
     let bdpi_so = companion("bdpi.so");
     let aot_so = companion("aot.so");
+    // -dump-formats travels from the fast wrapper's -c/-f dispatch as
+    // TRS_CAPI_FORMATS=vcd[,fst]|none (the Model ABI stays frozen);
+    // absent = the historical default (vcd only)
+    let formats = std::env::var("TRS_CAPI_FORMATS").ok().map(|f| {
+        (
+            f.split(',').any(|t| t.trim() == "vcd"),
+            f.split(',').any(|t| t.trim() == "fst"),
+        )
+    });
     let mut engines = Vec::new();
     for kind in kinds.iter().copied() {
         match Interp::from_bir_bytes(bir) {
             Ok(mut interp) => {
+                // the capi IS the debug tier: interp/jit execution is
+                // its design point, never a strict-mode violation
+                interp.set_debug_tier();
+                if let Some((v, f)) = formats {
+                    interp.set_allowed_wave_formats(v, f);
+                }
                 if let Some(so) = &bdpi_so {
                     if let Err(e) = interp.load_bdpi(so) {
                         eprintln!("trs capi: bk_init: {e}");
@@ -295,14 +310,19 @@ pub extern "C" fn bk_init(model: *mut c_void, _master: u8) -> *mut c_void {
     // one-time event-loop setup: clocks resolved, kernel reset
     // protocol seeded — `sim clock` works right after `sim load`
     for e in &mut st.engines {
-        e.interp.prime();
-        // debug tier: the INTERP engine retains last-computed def
-        // values for peeks; JIT engines skip the recording (their
-        // def visibility degrades per the capability tiers — and
-        // sym_trace would disable the hybrid entirely)
-        if e.kind == EngineKind::Interp {
+        // debug tier: interp engines retain last-computed def values
+        // in the recording map; jit engines build a TRACED plan
+        // (sym_trace = vcd_trace) whose compiled bodies record defs
+        // and method ports into arena slots — def/port peeks and VCD
+        // read slots first, so both tiers serve the full debug
+        // surface.  Only the aot engine skips recording: it runs the
+        // untraced fast artifact (forcing trace would just hash-bounce
+        // it back to the hybrid).  BEFORE prime: the plan is built
+        // there.
+        if e.kind != EngineKind::Aot {
             e.interp.set_sym_trace();
         }
+        e.interp.prime();
     }
     let raw = Box::into_raw(st);
     unsafe { build_symbols(raw) };
@@ -512,10 +532,13 @@ fn peek_symbol_value_inner(p: *mut c_void) -> *const u32 {
     }
     // capability tiers: only the interp engine records defs/ports —
     // other engines degrade to NoValue rather than fabricate zeros
+    // interp records defs in the map; a traced-plan jit engine records
+    // into arena slots — both serve def/port peeks.  Only aot (the
+    // untraced fast artifact) degrades to NoValue.
     let recording = st
         .engines
         .first()
-        .map(|e| e.kind == EngineKind::Interp)
+        .map(|e| e.kind != EngineKind::Aot)
         .unwrap_or(false);
     match s.kind {
         SymKind::Def { .. } | SymKind::MethPort { .. } if !recording => {
@@ -1190,20 +1213,23 @@ pub extern "C" fn bk_set_timescale(
 // VCD control (`sim vcd [on|off|<file>]` -> these three): routed to
 // the PRIMARY engine's writer — the same one the $dump* tasks drive.
 // Secondary engines stay quiet (they'd clobber the same file).
-// Capability tier: VCD needs the interp engine's def recording; a
-// non-interp primary degrades honestly (stderr note + failure) —
-// compiled bodies do not record the def values the dump walks read.
+// Capability tier: VCD needs a RECORDING engine — interp with
+// set_sym_trace, or a jit engine whose traced plan records defs and
+// method ports into arena slots (the compiled-VCD tier).  Only the
+// aot engine degrades (it runs the untraced fast artifact): honest
+// stderr note + failure.
 
-/// True iff the primary engine can serve VCD (interp tier); prints
-/// the remedy note once per call site otherwise.
+/// True iff the primary engine can serve VCD (a recording tier);
+/// prints the remedy note once per call site otherwise.
 fn vcd_capable(st: &mut SimState) -> bool {
     match st.engines.first() {
-        Some(e) if e.kind == EngineKind::Interp => true,
+        Some(e) if e.kind != EngineKind::Aot => true,
         Some(_) => {
             eprintln!(
-                "trs: VCD dumping needs the interp engine \
-                 (TRS_CAPI_ENGINES=interp); the current primary \
-                 engine does not record signal values"
+                "trs: VCD dumping needs a recording engine \
+                 (TRS_CAPI_ENGINES=interp or jit); the aot engine \
+                 runs the untraced artifact and does not record \
+                 signal values"
             );
             false
         }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -152,6 +152,9 @@ pub struct Interp {
     /// VCD — while all STATE effects (including $finish/$fatal flags
     /// and file reads) run normally so lockstep compare is meaningful
     quiet: bool,
+    /// DEBUG-tier engine (bluetcl capi): exempt from the
+    /// TRS_REQUIRE_AOT strict-execution refusal (see set_debug_tier)
+    debug_tier: bool,
     /// $stop yield: ends the current advance at the slice boundary
     /// but does NOT finish the sim — cleared at the next advance so
     /// the session resumes (the reference's resumable-$stop contract)
@@ -625,6 +628,7 @@ impl Interp {
             vcd: vcd::Vcd::new(),
             vcd_trace: false,
             quiet: false,
+            debug_tier: false,
             stop_request: false,
             wave_pending: None,
             vcd_def_vals: HashMap::new(),
@@ -3825,6 +3829,7 @@ impl Interp {
         #[cfg(feature = "jit")]
         if jit.is_none()
             && !was_emit
+            && !self.debug_tier
             && std::env::var_os("TRS_REQUIRE_AOT").is_some()
         {
             eprintln!(
@@ -4625,6 +4630,15 @@ impl Interp {
         self.quiet = true;
     }
 
+    /// Mark this interp as a DEBUG-tier engine (the bluetcl capi).
+    /// TRS_REQUIRE_AOT polices the fast artifact's execution contract;
+    /// the interactive tier runs interp/jit BY DESIGN (introspection
+    /// needs the interp engine's recording), so its engines are exempt
+    /// from the strict-mode refusal.
+    pub fn set_debug_tier(&mut self) {
+        self.debug_tier = true;
+    }
+
     /// Oracle divergence protocol (docs/TCL-CAPI.md): flip the fatal
     /// flag so scripts stop AT the divergence (bluesim.tcl exits 1
     /// via `sim isfatal`).  fatal implies finished in the reference
@@ -4940,7 +4954,15 @@ impl Interp {
 
     /// Last-computed value of a def (set_sym_trace recording); zeros
     /// until first computed, like the reference's member fields.
+    /// Traced-plan engines record into arena slots (the single
+    /// authority when present — compiled bodies store them inline),
+    /// so the slot is read first, like the VCD writer.
     pub fn def_peek(&self, i: usize, d: StrId) -> Option<Value> {
+        if !self.jit_arena_ptr.is_null() {
+            if let Some(&(base, w)) = self.jit_rec_defs.get(&(i, d)) {
+                return Some(self.rec_read(base, w));
+            }
+        }
         self.vcd_def_vals.get(&(i, d)).cloned()
     }
 

--- a/src/trs/crates/trs-interp/src/vcd.rs
+++ b/src/trs/crates/trs-interp/src/vcd.rs
@@ -216,7 +216,11 @@ impl Vcd {
 
     pub fn set_format(&mut self, fmt: WaveFormat, now: u64) -> bool {
         if fmt == self.format {
-            return true;
+            // same-format set skips the switch, NOT the availability
+            // gate: a -dump-formats none model keeps the default
+            // format (vcd), so `sim vcd on` lands here and must still
+            // report "built with -dump-formats none"
+            return self.format_available(fmt);
         }
         if !self.format_available(fmt) {
             return false;

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -254,14 +254,41 @@ fn main() -> ExitCode {
                 .ok()
                 .and_then(|p| p.to_str().map(String::from))
                 .unwrap_or_else(|| "trs".into());
+            // debug/script tier: -c/-f are Tcl (while/foreach/expr —
+            // bluesim.tcl's `source`/`eval`), so those runs go through
+            // stock bluetcl + the capi shim, not the fast runner.  The
+            // capi's own default engine applies (traced-plan jit:
+            // fast `sim run` AND slot-recorded def/port peeks);
+            // TRS_CAPI_ENGINES overrides, and the -dump-formats
+            // contract travels via TRS_CAPI_FORMATS.
+            let top = interp.top_name().to_string();
+            let capi = write_capi_shim(path, &base, &top, compiled);
+            let dispatch = if capi {
+                format!(
+                    "for arg in ${{1+\"$@\"}}\n\
+                     do\n\
+                     \x20 case \"$arg\" in\n\
+                     \x20 -c|-f)\n\
+                     \x20   if test -f \"$d/$b.capi.so\"; then\n\
+                     \x20     TRS_CAPI_FORMATS=\"{fmt_arg}\"; export TRS_CAPI_FORMATS\n\
+                     \x20     BLUESPECDIR=`echo 'puts $env(BLUESPECDIR)' | bluetcl`\n\
+                     \x20     exec $BLUESPECDIR/tcllib/bluespec/bluesim.tcl \"$d/$b.capi.so\" {top} --script_name \"$b\" ${{1+\"$@\"}}\n\
+                     \x20   fi\n\
+                     \x20   ;;\n\
+                     \x20 esac\n\
+                     done\n"
+                )
+            } else {
+                String::new()
+            };
             let script = if compiled {
                 format!(
-                    "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n\
+                    "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n{dispatch}\
                      exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" --code \"$d/$b.so\"{split_arg} --formats {fmt_arg} ${{1+\"$@\"}}\n"
                 )
             } else {
                 format!(
-                    "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n\
+                    "#!/bin/sh\nd=`dirname \"$0\"`\nb=`basename \"$0\"`\n{dispatch}\
                      exec \"${{TRS:-{self_exe}}}\" run \"$d/$b.bir\" --formats {fmt_arg} ${{1+\"$@\"}}\n"
                 )
             };
@@ -284,6 +311,70 @@ fn main() -> ExitCode {
                 );
             }
             ExitCode::SUCCESS
+        }
+        // trs capi-so: build the ONE shared libtrs_capi.so the fast
+        // link's per-design shims link against (install it beside the
+        // trs binary).  The 4s / 50MB capi+engine link happens once
+        // here instead of once per design (docs/TCL-CAPI.md).
+        ["capi-so", rest @ ..] => {
+            let mut out = "libtrs_capi.so".to_string();
+            let mut it = rest.iter();
+            while let Some(a) = it.next() {
+                match *a {
+                    "-o" => match it.next() {
+                        Some(v) => out = v.to_string(),
+                        None => {
+                            eprintln!("Error: -o requires a value");
+                            return ExitCode::from(2);
+                        }
+                    },
+                    "--capi-lib" => match it.next() {
+                        Some(v) => std::env::set_var("TRS_CAPI_LIB", v),
+                        None => {
+                            eprintln!("Error: --capi-lib requires a value");
+                            return ExitCode::from(2);
+                        }
+                    },
+                    other => {
+                        eprintln!("Error: invalid capi-so option '{other}'");
+                        return ExitCode::from(2);
+                    }
+                }
+            }
+            let Some(lib) = find_capi_staticlib() else {
+                eprintln!(
+                    "trs capi-so: libtrs_capi.a not found (set \
+                     TRS_CAPI_LIB or install it next to the trs binary)"
+                );
+                return ExitCode::FAILURE;
+            };
+            let tmp = std::env::temp_dir()
+                .join(format!("trs-capi-so-{}", std::process::id()));
+            if let Err(e) = std::fs::create_dir_all(&tmp) {
+                eprintln!("trs capi-so: {}: {e}", tmp.display());
+                return ExitCode::FAILURE;
+            }
+            let map = tmp.join("export.map");
+            // no new_MODEL_* here: the per-design shims provide those
+            if let Err(e) = std::fs::write(
+                &map,
+                "{ global: bk_*; trs_*; local: *; };\n",
+            ) {
+                eprintln!("trs capi-so: write {}: {e}", map.display());
+                return ExitCode::FAILURE;
+            }
+            let r = capi_cc_link(&out, &[], &lib, &map);
+            let _ = std::fs::remove_dir_all(&tmp);
+            match r {
+                Ok(()) => {
+                    println!("trs capi-so: shared capi written: {out}");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("trs capi-so: {e}");
+                    ExitCode::FAILURE
+                }
+            }
         }
         ["run", path, rest @ ..] => {
             // mirror the bluesim.tcl driver's argument handling: -m N is
@@ -503,95 +594,50 @@ const BK_EXPORTS: &[&str] = &[
     "bk_is_single_value", "bk_is_value_range", "bk_peek_symbol_value",
     "bk_get_range_min_addr", "bk_get_range_max_addr",
     "bk_peek_range_value", "bk_num_symbols", "bk_get_nth_symbol",
-    "bk_set_VCD_file", "bk_enable_VCD_dumping", "bk_disable_VCD_dumping",
+    "bk_set_VCD_file", "bk_get_VCD_file_name", "bk_enable_VCD_dumping",
+    "bk_disable_VCD_dumping", "bk_set_waveform_format",
 ];
 
-/// `trs link --interactive`: produce <base>.so (the bk_* capi model
-/// with the BIR embedded via incbin) and <base>, the same bluesim.tcl
-/// wrapper the reference emits — `sim load`-able by stock bluetcl and
-/// runnable by the interactive testsuite unchanged.
-fn link_interactive(bir_path: &str, base: &str, top: &str) -> ExitCode {
-    let fail = |m: String| {
-        eprintln!("trs link --interactive: {m}");
-        ExitCode::FAILURE
-    };
-    // the capi staticlib: env override, then alongside the binary
-    let lib = std::env::var("TRS_CAPI_LIB").ok().map(std::path::PathBuf::from).or_else(|| {
+/// The capi staticlib: env override, then alongside the binary.
+fn find_capi_staticlib() -> Option<std::path::PathBuf> {
+    std::env::var("TRS_CAPI_LIB").ok().map(std::path::PathBuf::from).or_else(|| {
         let exe = std::env::current_exe().ok()?;
         let d = exe.parent()?;
         [d.join("libtrs_capi.a"), d.join("../lib/libtrs_capi.a")]
             .into_iter()
             .find(|p| p.exists())
-    });
-    let Some(lib) = lib else {
-        return fail(
-            "libtrs_capi.a not found (set TRS_CAPI_LIB or install it              next to the trs binary)"
-                .into(),
-        );
-    };
-    let Ok(bir_abs) = std::path::Path::new(bir_path).canonicalize() else {
-        return fail(format!("cannot resolve {bir_path}"));
-    };
-    let tmp = std::env::temp_dir().join(format!("trs-capi-{}", std::process::id()));
-    if let Err(e) = std::fs::create_dir_all(&tmp) {
-        return fail(format!("{}: {e}", tmp.display()));
-    }
-    let shim_s = tmp.join("bir.s");
-    let shim_c = tmp.join("shim.c");
-    let map = tmp.join("export.map");
-    let w = |p: &std::path::Path, c: String| std::fs::write(p, c);
-    if let Err(e) = w(
-        &shim_s,
-        format!(
-            r##"	.section .rodata
-	.align 8
-	.globl trs_bir_start
-trs_bir_start:
-	.incbin "{}"
-	.globl trs_bir_end
-trs_bir_end:
-"##,
-            bir_abs.display()
-        ),
-    ) {
-        return fail(format!("write {}: {e}", shim_s.display()));
-    }
-    if let Err(e) = w(
-        &shim_c,
-        format!(
-            r##"/* generated by trs link --interactive */
-typedef struct {{
-    const unsigned char* bir_ptr;
-    unsigned long        bir_len;
-    const char*          top;
-}} Model;
-extern const unsigned char trs_bir_start[], trs_bir_end[];
-static Model M;
-void* new_MODEL_{top}(void) {{
-    M.bir_ptr = trs_bir_start;
-    M.bir_len = (unsigned long)(trs_bir_end - trs_bir_start);
-    M.top = "{top}";
-    return &M;
-}}
-"##
-        ),
-    ) {
-        return fail(format!("write {}: {e}", shim_c.display()));
-    }
-    if let Err(e) = w(
-        &map,
-        "{ global: bk_*; trs_*; new_MODEL_*; local: *; };\n".into(),
-    ) {
-        return fail(format!("write {}: {e}", map.display()));
-    }
-    let so = format!("{base}.so");
+    })
+}
+
+/// The shared libtrs_capi.so (built once by `trs capi-so`): env
+/// override, then alongside the binary — the fast link's shim tier
+/// exists only when this is installed.
+fn find_capi_shared() -> Option<std::path::PathBuf> {
+    std::env::var("TRS_CAPI_SO").ok().map(std::path::PathBuf::from).or_else(|| {
+        let exe = std::env::current_exe().ok()?;
+        let d = exe.parent()?;
+        [d.join("libtrs_capi.so"), d.join("../lib/libtrs_capi.so")]
+            .into_iter()
+            .find(|p| p.exists())
+    })
+}
+
+/// The cc link shared by the fat `--interactive` .so and the
+/// once-per-install `trs capi-so` shared library: force-keep exactly
+/// the dlsym'd bk surface from the staticlib, dead-strip the rest,
+/// and (jit builds) resolve the staticlib's LLVM references against
+/// the shared libLLVM.
+fn capi_cc_link(
+    out: &str,
+    inputs: &[&std::path::Path],
+    lib: &std::path::Path,
+    map: &std::path::Path,
+) -> Result<(), String> {
     let mut cc = std::process::Command::new("cc");
-    cc.arg("-shared")
-        .arg("-fPIC")
-        .arg("-o")
-        .arg(&so)
-        .arg(&shim_c)
-        .arg(&shim_s);
+    cc.arg("-shared").arg("-fPIC").arg("-o").arg(out);
+    for i in inputs {
+        cc.arg(i);
+    }
     // force-keep exactly the exported surface: --whole-archive would
     // drag every llvm-sys binding object (LineEditor -> libedit, ffi
     // stubs) into the .so; -u pulls only what the bk_*/new_MODEL
@@ -599,7 +645,7 @@ void* new_MODEL_{top}(void) {{
     for sym in BK_EXPORTS {
         cc.arg(format!("-Wl,-u,{sym}"));
     }
-    cc.arg(&lib)
+    cc.arg(lib)
         // rust emits function sections: dead-strip everything the
         // -u keep-list doesn't reach, and drop symbols (166MB -> )
         .arg("-Wl,--gc-sections")
@@ -633,11 +679,200 @@ void* new_MODEL_{top}(void) {{
             // fail at LINK time instead of at sim load
             .arg("-Wl,--no-undefined");
     }
-    let st = cc.status();
-    match st {
+    match cc.status() {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => Err(format!("cc exited {s}")),
+        Err(e) => Err(format!("cc: {e}")),
+    }
+}
+
+/// Write the model shim sources into `tmp`: bir.s (the design's BIR
+/// embedded via incbin) and shim.c (the Model struct + the
+/// `new_MODEL_<top>` constructor BluesimLoader.hs dlsym's).  Returns
+/// (bir.s, shim.c).
+fn write_shim_sources(
+    tmp: &std::path::Path,
+    bir_abs: &std::path::Path,
+    top: &str,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+    let shim_s = tmp.join("bir.s");
+    let shim_c = tmp.join("shim.c");
+    std::fs::write(
+        &shim_s,
+        format!(
+            r##"	.section .note.GNU-stack,"",@progbits
+	.section .rodata
+	.align 8
+	.globl trs_bir_start
+trs_bir_start:
+	.incbin "{}"
+	.globl trs_bir_end
+trs_bir_end:
+"##,
+            bir_abs.display()
+        ),
+    )
+    .map_err(|e| format!("write {}: {e}", shim_s.display()))?;
+    std::fs::write(
+        &shim_c,
+        format!(
+            r##"/* generated by trs link */
+typedef struct {{
+    const unsigned char* bir_ptr;
+    unsigned long        bir_len;
+    const char*          top;
+}} Model;
+extern const unsigned char trs_bir_start[], trs_bir_end[];
+static Model M;
+void* new_MODEL_{top}(void) {{
+    M.bir_ptr = trs_bir_start;
+    M.bir_len = (unsigned long)(trs_bir_end - trs_bir_start);
+    M.top = "{top}";
+    return &M;
+}}
+"##
+        ),
+    )
+    .map_err(|e| format!("write {}: {e}", shim_c.display()))?;
+    Ok((shim_s, shim_c))
+}
+
+/// Fast-link debug tier: emit `<base>.capi.so`, a tiny bluetcl-loadable
+/// shim (embedded BIR + `new_MODEL_<top>`) with a DT_NEEDED on the
+/// shared libtrs_capi.so installed beside the trs binary — dlsym on the
+/// shim's handle resolves the bk_* surface through the dependency
+/// scope.  Companions follow bk_init's dladdr lookup (model base =
+/// `<base>.capi`): `<base>.capi.bdpi.so` and `<base>.capi.aot.so` are
+/// same-directory symlinks onto the fast artifact's files.  Returns
+/// false when the shared lib is absent or the link fails — the fast
+/// artifact stays fully usable, only the -c/-f script tier is missing.
+fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> bool {
+    let note = |m: String| {
+        eprintln!("trs link: note: {m}; -c/-f scripting will not be available");
+        false
+    };
+    let Some(shared) = find_capi_shared() else {
+        // silent: an install without the shared capi simply has no
+        // script tier — the artifact contract doesn't change
+        return false;
+    };
+    let Some(shared_dir) = shared.parent().map(std::path::Path::to_path_buf) else {
+        return note(format!("{} has no parent directory", shared.display()));
+    };
+    let Ok(shared_dir) = shared_dir.canonicalize() else {
+        return note(format!("cannot resolve {}", shared_dir.display()));
+    };
+    let Ok(bir_abs) = std::path::Path::new(bir_path).canonicalize() else {
+        return note(format!("cannot resolve {bir_path}"));
+    };
+    let tmp =
+        std::env::temp_dir().join(format!("trs-capi-shim-{}", std::process::id()));
+    if let Err(e) = std::fs::create_dir_all(&tmp) {
+        return note(format!("{}: {e}", tmp.display()));
+    }
+    let sources = write_shim_sources(&tmp, &bir_abs, top);
+    let (shim_s, shim_c) = match sources {
+        Ok(p) => p,
+        Err(e) => return note(e),
+    };
+    let map = tmp.join("export.map");
+    if let Err(e) = std::fs::write(
+        &map,
+        "{ global: new_MODEL_*; trs_*; local: *; };\n",
+    ) {
+        return note(format!("write {}: {e}", map.display()));
+    }
+    let so = format!("{base}.capi.so");
+    let mut cc = std::process::Command::new("cc");
+    cc.arg("-shared")
+        .arg("-fPIC")
+        .arg("-o")
+        .arg(&so)
+        .arg(&shim_c)
+        .arg(&shim_s)
+        .arg(format!("-L{}", shared_dir.display()))
+        // -l: form pins DT_NEEDED to the plain soname; the rpath
+        // resolves it at load (an artifact moved to another machine
+        // falls back to that machine's installed capi).  The shim
+        // itself references NO capi symbol — bluetcl dlsym's bk_*
+        // through the dependency scope — so --as-needed (many distros'
+        // default) would silently drop the DT_NEEDED: disable it.
+        .arg("-Wl,--no-as-needed")
+        .arg("-l:libtrs_capi.so")
+        .arg(format!("-Wl,-rpath,{}", shared_dir.display()))
+        .arg(format!("-Wl,--version-script={}", map.display()))
+        .arg("-Wl,--no-undefined");
+    let r = cc.status();
+    let _ = std::fs::remove_dir_all(&tmp);
+    match r {
         Ok(s) if s.success() => {}
-        Ok(s) => return fail(format!("cc exited {s}")),
-        Err(e) => return fail(format!("cc: {e}")),
+        Ok(s) => return note(format!("cc exited {s}")),
+        Err(e) => return note(format!("cc: {e}")),
+    }
+    // companions: same-directory RELATIVE symlinks (they survive the
+    // whole artifact directory moving together); a filesystem without
+    // symlinks gets copies
+    let file = std::path::Path::new(base)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| base.to_string());
+    let link_beside = |link: &str, target_file: &str| {
+        let _ = std::fs::remove_file(link);
+        #[cfg(unix)]
+        if std::os::unix::fs::symlink(target_file, link).is_ok() {
+            return;
+        }
+        let target = std::path::Path::new(base)
+            .parent()
+            .map(|d| d.join(target_file))
+            .unwrap_or_else(|| std::path::PathBuf::from(target_file));
+        let _ = std::fs::copy(target, link);
+    };
+    if compiled {
+        link_beside(&format!("{base}.capi.aot.so"), &format!("{file}.so"));
+    }
+    if std::path::Path::new(&format!("{base}.bdpi.so")).exists() {
+        link_beside(&format!("{base}.capi.bdpi.so"), &format!("{file}.bdpi.so"));
+    }
+    true
+}
+
+/// `trs link --interactive`: produce <base>.so (the bk_* capi model
+/// with the BIR embedded via incbin) and <base>, the same bluesim.tcl
+/// wrapper the reference emits — `sim load`-able by stock bluetcl and
+/// runnable by the interactive testsuite unchanged.
+fn link_interactive(bir_path: &str, base: &str, top: &str) -> ExitCode {
+    let fail = |m: String| {
+        eprintln!("trs link --interactive: {m}");
+        ExitCode::FAILURE
+    };
+    let Some(lib) = find_capi_staticlib() else {
+        return fail(
+            "libtrs_capi.a not found (set TRS_CAPI_LIB or install it              next to the trs binary)"
+                .into(),
+        );
+    };
+    let Ok(bir_abs) = std::path::Path::new(bir_path).canonicalize() else {
+        return fail(format!("cannot resolve {bir_path}"));
+    };
+    let tmp = std::env::temp_dir().join(format!("trs-capi-{}", std::process::id()));
+    if let Err(e) = std::fs::create_dir_all(&tmp) {
+        return fail(format!("{}: {e}", tmp.display()));
+    }
+    let (shim_s, shim_c) = match write_shim_sources(&tmp, &bir_abs, top) {
+        Ok(p) => p,
+        Err(e) => return fail(e),
+    };
+    let map = tmp.join("export.map");
+    if let Err(e) = std::fs::write(
+        &map,
+        "{ global: bk_*; trs_*; new_MODEL_*; local: *; };\n",
+    ) {
+        return fail(format!("write {}: {e}", map.display()));
+    }
+    let so = format!("{base}.so");
+    if let Err(e) = capi_cc_link(&so, &[&shim_c, &shim_s], &lib, &map) {
+        return fail(e);
     }
     let _ = std::fs::remove_dir_all(&tmp);
     // user BDPI code travels with the model: bk_init dladdr's its own

--- a/src/trs/docs/TCL-CAPI.md
+++ b/src/trs/docs/TCL-CAPI.md
@@ -114,15 +114,23 @@ design), and the reference API already has the vocabulary for it
 (NULL peeks / NoValue errors in bluetcl, unknown tags, whatever
 child list we enumerate).  Per-engine tiers on one symbol tree:
 
-- interp: full introspection (modules, rules, defs, state, ranges).
-- hybrid JIT: architectural state (regs, RegFiles, FIFO contents)
-  is arena-resident and edge-coherent -> peekable at stops; rule/
-  def views degrade to NoValue where the compiled path owns them.
-- fast/AOT: architectural state only — STATE was never elided, only
-  the observability scaffolding; rules/defs enumerate valueless or
-  not at all.  `sim describe`/`ls` reflect reality; peeks that need
-  more error with the remedy (relink --engines=interp), in the
-  linker-note voice.
+- interp: full introspection (modules, rules, defs, state, ranges) —
+  set_sym_trace records every computed def in the map.
+- hybrid JIT: since the compiled-VCD rung, bk_init arms sym_trace
+  (= vcd_trace) here too, so the hybrid builds a TRACED plan whose
+  compiled bodies record defs and method ports into arena recording
+  slots — def/port peeks and the VCD writer read slots first, and
+  the tier serves the SAME debug surface as interp at compiled
+  speed.  (Slot coverage is the VCD selection walk's def set; a def
+  outside it degrades to NoValue.)  This is the shipped default
+  engine when the library carries the jit feature.
+- fast/AOT: architectural state only — the aot engine runs the
+  UNTRACED fast artifact (forcing trace would hash-bounce it back to
+  the hybrid), so rules/defs enumerate valueless or not at all, and
+  VCD control degrades honestly (stderr note + failure).  `sim
+  describe`/`ls` reflect reality; peeks that need more error with
+  the remedy (TRS_CAPI_ENGINES=interp or jit), in the linker-note
+  voice.
 
 Degradation policy: bk_init returns NULL only for hard failures
 (unparseable BIR); a requested engine that cannot construct (AOT
@@ -197,3 +205,35 @@ Acceptance gates, in order: (1) `sim load` + `sim time` + `sim ls`
 on mkTest; (2) the interactive battery's mkTest.cmd byte-identical;
 (3) all 22 interactive outputs byte-identical; (4) VCD-under-Tcl
 parity spot checks.
+
+## Shared capi + per-design shims (the fast wrapper's script tier)
+
+`trs link --interactive` self-contains the whole capi in each
+design's .so (~50MB, ~4.4s per design) — right for a shipped debug
+artifact, wrong for a testsuite that links hundreds of designs.  The
+fast `trs link` therefore uses a split product:
+
+- `trs capi-so` builds ONE shared `libtrs_capi.so` from the
+  staticlib (same -u keep-list, version script, and shared-libLLVM
+  resolution as the fat link) — installed beside the trs binary,
+  once per install.
+- every fast `trs link` also emits `<base>.capi.so`, a ~20KB shim
+  (incbin'd BIR + `new_MODEL_<top>`) with a DT_NEEDED on the shared
+  lib (-Wl,--no-as-needed: the shim references no capi symbol
+  itself; bluetcl dlsym's bk_* through the dependency scope) and an
+  rpath to its directory.  Companions follow bk_init's dladdr
+  lookup: `<base>.capi.bdpi.so` / `<base>.capi.aot.so` are
+  same-directory symlinks onto the fast artifact's files.  No
+  shared lib installed -> no shim, silently: the artifact contract
+  doesn't change, only the script tier is absent.
+- the fast wrapper dispatches -c/-f runs (real Tcl — while/foreach/
+  expr under bluesim.tcl's source/eval) to stock bluetcl +
+  bluesim.tcl on the shim, exporting TRS_CAPI_FORMATS=<-dump-formats
+  csv> so the link-time waveform contract survives the engine swap
+  (the Model ABI stays frozen); every other invocation runs the fast
+  artifact directly.  TRS_CAPI_ENGINES still overrides the engine
+  set; the default is the traced-plan jit tier above.
+
+The capi engines are DEBUG tier by definition: bk_init marks them
+set_debug_tier, exempting them from the TRS_REQUIRE_AOT
+strict-execution refusal that polices the fast artifact.


### PR DESCRIPTION
Stacked on #127 (trs/9-dump-formats). Closes the last non-environmental testsuite gap: the 44 `bsc.bluesim/interactive` failures and the 3 `bsc.bluesim/misc` ones.

## Why bluetcl, not a Tcl reimplementation

`-c`/`-f` arguments are **real Tcl** — the testsuite's `.cmd` files use `while`, `foreach`, `expr`, `catch`, `after`, async runs — executed by `bluesim.tcl` via `source`/`eval`. The reference's wrapper hands the whole session to bluetcl and a `bk_*` capi `.so`; the fast runner's scripting subset could never keep up. So the fast artifact now ships the same contract.

## The split product

`trs link --interactive`'s self-contained `.so` is ~50MB and takes ~4.4s of linking **per design** — right for a shipped debug artifact, wrong for a suite that links hundreds. Instead:

- **`trs capi-so`** builds ONE shared `libtrs_capi.so` from the staticlib (same `-u` keep-list, version script, and shared-libLLVM resolution as the fat link), installed beside the `trs` binary. The heavy link happens once per install.
- **Every fast `trs link`** also emits `<base>.capi.so`: a **~20KB shim** (incbin'd BIR + `new_MODEL_<top>`) with a `DT_NEEDED` on the shared lib (`--no-as-needed`, since the shim references no capi symbol itself — bluetcl dlsym's `bk_*` through the dependency scope) plus an rpath. Companions follow `bk_init`'s dladdr lookup as same-directory symlinks (`<base>.capi.bdpi.so`, `<base>.capi.aot.so`). No shared lib installed → no shim, silently: the artifact contract doesn't change, only the script tier is absent.
- **The wrapper** dispatches `-c`/`-f` invocations to stock `bluetcl` + `bluesim.tcl` on the shim, exporting `TRS_CAPI_FORMATS=<csv>` so the `-dump-formats` link contract survives the engine swap (the Model ABI stays frozen). Every other invocation runs the fast artifact exactly as before.

## Debug-tier upgrade: the traced-plan jit engine

`bk_init` now arms `sym_trace` on jit engines too. Since the compiled-VCD rung, `sym_trace` = `vcd_trace`, so the hybrid builds a **traced plan** whose compiled bodies record defs and method ports into arena slots. `def_peek` gains the slot-first read (`method_port_peek` already had it), and VCD control accepts any recording engine. Net: the default jit engine serves the **full peek surface and VCD control at compiled speed** — `mkLong`'s 300M-cycle async script runs jit-fast in the same session where `mkTbGCD`'s per-cycle debug peeks stay live. Only the aot engine (which runs the untraced fast artifact) degrades, honestly, with the remedy in the note.

The capi engines are DEBUG tier by definition: marked `set_debug_tier`, exempt from the `TRS_REQUIRE_AOT` strict-execution refusal that polices the fast artifact.

Also: `BK_EXPORTS` grows `bk_get_VCD_file_name` (a mandatory `BluesimLoader.hs` dlsym) and `bk_set_waveform_format` (`sim fst`); the generated shim asm gets a `.note.GNU-stack` section.

## Gates

| gate | result |
|---|---|
| interactive battery (34 .cmd tests, all engine configs) | 34/34 |
| `bsc.bluesim/interactive` localcheck `-trs` | **68/68 — exact reference parity** (was 44 FAIL) |
| `bsc.bluesim/misc` localcheck `-trs` | 161 PASS / 0 FAIL (was 3 FAIL) |
| `bsc.bluesim/fst` localcheck `-trs` (fstswitch now routes through bluetcl) | stays 45/45 |
| full frozen-binary seal sweep | running; will post below |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_