### PR TITLE
trs: lockstep selfcheck — interp, jit, and aot cross-checked in one run, no reference

### DIFF
--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -3408,6 +3408,112 @@ impl Interp {
         rc
     }
 
+    /// Lockstep selfcheck (trs run --selfcheck): drive this engine —
+    /// the PRIMARY, which owns stdout, waveforms, and the exit status —
+    /// and a quiet interp `shadow` in bounded steps, comparing time,
+    /// cycle/finish status, and architectural prim state every `every`
+    /// default-clock posedges (and at the end of the run).  One process
+    /// validates BOTH engines against each other with no reference
+    /// simulator anywhere; a divergence reports on stderr (instant +
+    /// the first mismatching state, primary-vs-shadow) and the run
+    /// exits 87 AT the divergence, the oracle doctrine's stop point.
+    ///
+    /// TRS_SELFCHECK_INJECT=<cycle> is the detector's negative
+    /// witness: once the primary passes that cycle, the shadow is
+    /// advanced one extra posedge, which must trip the next compare.
+    pub fn run_lockstep(
+        &mut self,
+        shadow: &mut Interp,
+        max_cycles: u64,
+        every: u64,
+    ) -> i32 {
+        let every = every.max(1);
+        let inject = std::env::var("TRS_SELFCHECK_INJECT")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok());
+        let mut injected = false;
+        let trace = std::env::var_os("TRS_SELFCHECK_TRACE").is_some();
+        loop {
+            let target = self.cycles().saturating_add(every).min(max_cycles);
+            self.advance(target);
+            shadow.advance(target);
+            if trace {
+                eprintln!(
+                    "trs selfcheck: checkpoint target={target} primary \
+                     (t={}, c={}) shadow (t={}, c={})",
+                    self.now, self.cycle, shadow.now, shadow.cycle
+                );
+            }
+            if let Some(n) = inject {
+                if !injected && self.cycles() >= n {
+                    shadow.advance(shadow.cycles().saturating_add(1));
+                    injected = true;
+                }
+            }
+            let mut diverged = Vec::new();
+            // a stop consumed by the cycle budget alone is an INTERNAL
+            // point: the central player and the general loop credit the
+            // last posedge's companion-negedge instant differently, so
+            // `now` can sit half a period apart with identical
+            // architectural history (no output can observe it — VCD
+            // disables the central player, and interactive stops use
+            // the heap loop).  Time compares only where time is
+            // architecturally visible: $finish/$stop/heap-dry stops.
+            let budget_stop = self.finished.is_none()
+                && !self.stop_request
+                && self.cycles() >= target;
+            if !budget_stop && shadow.now != self.now {
+                diverged
+                    .push(format!("time {} vs primary {}", shadow.now, self.now));
+            }
+            if shadow.cycle != self.cycle {
+                diverged.push(format!(
+                    "cycle {} vs primary {}",
+                    shadow.cycle, self.cycle
+                ));
+            }
+            if shadow.finished != self.finished {
+                diverged.push(format!(
+                    "finished {:?} vs primary {:?}",
+                    shadow.finished, self.finished
+                ));
+            }
+            // shape first: state addressed at different times compares
+            // apples to oranges (the capi oracle's per-engine gate)
+            if diverged.is_empty() {
+                diverged = self.state_divergence(shadow, 8);
+            }
+            if !diverged.is_empty() {
+                eprintln!(
+                    "trs selfcheck: DIVERGENCE at time {} (cycle {}):",
+                    self.now, self.cycle
+                );
+                for d in &diverged {
+                    eprintln!("trs selfcheck:   {d}");
+                }
+                self.dump_central_bails();
+                let _ = self.finish();
+                return 87;
+            }
+            if self.finished.is_some()
+                || self.stop_request
+                || self.cycles() >= max_cycles
+            {
+                break;
+            }
+            if self.cycles() < target {
+                // neither $finish, $stop, nor the cycle target ended
+                // the step: the event heap is dry (run() would have
+                // returned here after its single advance)
+                break;
+            }
+        }
+        self.dump_central_bails();
+        let rc = self.finish();
+        let _ = shadow.finish();
+        rc
+    }
+
     /// Default-clock posedges processed so far (the `sim step` cursor).
     pub fn cycles(&self) -> u64 {
         self.cycle
@@ -5119,6 +5225,7 @@ pub fn run_file(
     wave: Option<(WaveFormat, Option<String>)>,
     code: Option<&str>,
     formats: Option<(bool, bool)>,
+    selfcheck: Option<u64>,
 ) -> Result<i32, String> {
     let mut interp = load_file(path, plusargs, vcd_file)?;
     if let Some((vcd, fst)) = formats {
@@ -5130,5 +5237,25 @@ pub fn run_file(
     if let Some(so) = code {
         interp.aot_request_code(so.into());
     }
-    Ok(interp.run(max_cycles))
+    let Some(every) = selfcheck else {
+        return Ok(interp.run(max_cycles));
+    };
+    // lockstep selfcheck: a second, pure-interp engine shadows the
+    // primary — quiet (no console/file/VCD output), no compiled code,
+    // debug tier (the shadow is an oracle, not the artifact's
+    // execution engine, so TRS_REQUIRE_AOT does not police it)
+    let mut shadow = load_file(path, plusargs, None)?;
+    shadow.set_quiet();
+    shadow.set_debug_tier();
+    if shadow.needs_user_bdpi() {
+        // dlopen of one path is one refcounted image: user C globals
+        // are process-global, shared across both engines (the capi
+        // oracle's isolation caveat)
+        eprintln!(
+            "trs selfcheck: note: design imports BDPI — user C state \
+             is process-global, so stateful foreign functions can \
+             produce phantom divergences (engines are not isolated)"
+        );
+    }
+    Ok(interp.run_lockstep(&mut shadow, max_cycles, every))
 }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -5299,7 +5299,7 @@ pub fn run_file(
     wave: Option<(WaveFormat, Option<String>)>,
     code: Option<&str>,
     formats: Option<(bool, bool)>,
-    selfcheck: Option<u64>,
+    selfcheck: Option<(u64, bool)>,
 ) -> Result<i32, String> {
     let mut interp = load_file(path, plusargs, vcd_file)?;
     if let Some((vcd, fst)) = formats {
@@ -5311,7 +5311,14 @@ pub fn run_file(
     if let Some(so) = code {
         interp.aot_request_code(so.into());
     }
-    let Some(every) = selfcheck else {
+    // announce: notes print only for an EXPLICIT --selfcheck (an
+    // interactive user).  Env-armed runs (TRS_SELFCHECK=1 — the
+    // corpus sweep and the DejaGnu suite) stay silent on skips: the
+    // suite captures stderr into byte-compared output, and a note
+    // would fail every BDPI test.  Divergence reports are NOT notes —
+    // they always print (a diverging suite test failing with the
+    // report in its log is the point).
+    let Some((every, announce)) = selfcheck else {
         return Ok(interp.run(max_cycles));
     };
     if interp.needs_user_bdpi() {
@@ -5320,12 +5327,14 @@ pub fn run_file(
         // stateful foreign functions and corrupts the primary's own
         // outputs (14 foreign-battery witnesses in the first selfcheck
         // sweep) — skip the shadow, run plain
-        eprintln!(
-            "trs selfcheck: note: design imports BDPI — user C state \
-             is process-global and a lockstep shadow would \
-             double-execute stateful foreign functions; selfcheck \
-             skipped"
-        );
+        if announce {
+            eprintln!(
+                "trs selfcheck: note: design imports BDPI — user C \
+                 state is process-global and a lockstep shadow would \
+                 double-execute stateful foreign functions; selfcheck \
+                 skipped"
+            );
+        }
         return Ok(interp.run(max_cycles));
     }
     // lockstep selfcheck: quiet shadow engines ride beside the primary

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -3460,20 +3460,23 @@ impl Interp {
 
     /// Lockstep selfcheck (trs run --selfcheck): drive this engine —
     /// the PRIMARY, which owns stdout, waveforms, and the exit status —
-    /// and a quiet interp `shadow` in bounded steps, comparing time,
-    /// cycle/finish status, and architectural prim state every `every`
-    /// default-clock posedges (and at the end of the run).  One process
-    /// validates BOTH engines against each other with no reference
-    /// simulator anywhere; a divergence reports on stderr (instant +
-    /// the first mismatching state, primary-vs-shadow) and the run
-    /// exits 87 AT the divergence, the oracle doctrine's stop point.
+    /// and one or more quiet shadow engines in bounded steps, comparing
+    /// each shadow against the primary every `every` default-clock
+    /// posedges (and at the end of the run): cycle/finish status,
+    /// architectural prim state, and time where time is architecturally
+    /// visible.  With an aot primary and interp+jit shadows, ONE run
+    /// cross-checks all three execution tiers — no per-engine test-mode
+    /// explosion — with no reference simulator anywhere.  A divergence
+    /// reports on stderr (instant + the first mismatching state,
+    /// primary-vs-shadow, shadow named by engine) and the run exits 87
+    /// AT the divergence, the oracle doctrine's stop point.
     ///
     /// TRS_SELFCHECK_INJECT=<cycle> is the detector's negative
-    /// witness: once the primary passes that cycle, the shadow is
+    /// witness: once the primary passes that cycle, the first shadow is
     /// advanced one extra posedge, which must trip the next compare.
     pub fn run_lockstep(
         &mut self,
-        shadow: &mut Interp,
+        shadows: &mut [(&'static str, Interp)],
         max_cycles: u64,
         every: u64,
     ) -> i32 {
@@ -3486,21 +3489,31 @@ impl Interp {
         loop {
             let target = self.cycles().saturating_add(every).min(max_cycles);
             self.advance(target);
-            shadow.advance(target);
+            for (_, sh) in shadows.iter_mut() {
+                sh.advance(target);
+            }
             if trace {
-                eprintln!(
+                let mut line = format!(
                     "trs selfcheck: checkpoint target={target} primary \
-                     (t={}, c={}) shadow (t={}, c={})",
-                    self.now, self.cycle, shadow.now, shadow.cycle
+                     (t={}, c={})",
+                    self.now, self.cycle
                 );
+                for (kind, sh) in shadows.iter() {
+                    line.push_str(&format!(
+                        " {kind} (t={}, c={})",
+                        sh.now, sh.cycle
+                    ));
+                }
+                eprintln!("{line}");
             }
             if let Some(n) = inject {
                 if !injected && self.cycles() >= n {
-                    shadow.advance(shadow.cycles().saturating_add(1));
+                    if let Some((_, sh)) = shadows.first_mut() {
+                        sh.advance(sh.cycles().saturating_add(1));
+                    }
                     injected = true;
                 }
             }
-            let mut diverged = Vec::new();
             // a stop consumed by the cycle budget alone is an INTERNAL
             // point: the central player and the general loop credit the
             // last posedge's companion-negedge instant differently, so
@@ -3512,38 +3525,47 @@ impl Interp {
             let budget_stop = self.finished.is_none()
                 && !self.stop_request
                 && self.cycles() >= target;
-            if !budget_stop && shadow.now != self.now {
-                diverged
-                    .push(format!("time {} vs primary {}", shadow.now, self.now));
-            }
-            if shadow.cycle != self.cycle {
-                diverged.push(format!(
-                    "cycle {} vs primary {}",
-                    shadow.cycle, self.cycle
-                ));
-            }
-            if shadow.finished != self.finished {
-                diverged.push(format!(
-                    "finished {:?} vs primary {:?}",
-                    shadow.finished, self.finished
-                ));
-            }
-            // shape first: state addressed at different times compares
-            // apples to oranges (the capi oracle's per-engine gate)
-            if diverged.is_empty() {
-                diverged = self.state_divergence(shadow, 8);
-            }
-            if !diverged.is_empty() {
-                eprintln!(
-                    "trs selfcheck: DIVERGENCE at time {} (cycle {}):",
-                    self.now, self.cycle
-                );
-                for d in &diverged {
-                    eprintln!("trs selfcheck:   {d}");
+            for si in 0..shadows.len() {
+                let (kind, shadow) = &mut shadows[si];
+                let kind = *kind;
+                let mut diverged = Vec::new();
+                if !budget_stop && shadow.now != self.now {
+                    diverged.push(format!(
+                        "time {} vs primary {}",
+                        shadow.now, self.now
+                    ));
                 }
-                self.dump_central_bails();
-                let _ = self.finish();
-                return 87;
+                if shadow.cycle != self.cycle {
+                    diverged.push(format!(
+                        "cycle {} vs primary {}",
+                        shadow.cycle, self.cycle
+                    ));
+                }
+                if shadow.finished != self.finished {
+                    diverged.push(format!(
+                        "finished {:?} vs primary {:?}",
+                        shadow.finished, self.finished
+                    ));
+                }
+                // shape first: state addressed at different times
+                // compares apples to oranges (the capi oracle's
+                // per-engine gate)
+                if diverged.is_empty() {
+                    diverged = self.state_divergence(shadow, 8);
+                }
+                if !diverged.is_empty() {
+                    eprintln!(
+                        "trs selfcheck: DIVERGENCE [{kind} shadow] at \
+                         time {} (cycle {}):",
+                        self.now, self.cycle
+                    );
+                    for d in &diverged {
+                        eprintln!("trs selfcheck:   {d}");
+                    }
+                    self.dump_central_bails();
+                    let _ = self.finish();
+                    return 87;
+                }
             }
             if self.finished.is_some()
                 || self.stop_request
@@ -3560,7 +3582,9 @@ impl Interp {
         }
         self.dump_central_bails();
         let rc = self.finish();
-        let _ = shadow.finish();
+        for (_, sh) in shadows.iter_mut() {
+            let _ = sh.finish();
+        }
         rc
     }
 
@@ -5304,19 +5328,47 @@ pub fn run_file(
         );
         return Ok(interp.run(max_cycles));
     }
-    // lockstep selfcheck: a second, pure-interp engine shadows the
-    // primary — quiet (no console/file/VCD output), no compiled code,
-    // debug tier (the shadow is an oracle, not the artifact's
-    // execution engine, so TRS_REQUIRE_AOT does not police it).
-    // Construction runs under the quiet stamp too: elaboration-time
-    // prim diagnostics ($readmem gap warnings) print at load, before
-    // any advance re-stamps the thread-local (sysWarningTest leaked
-    // the shadow's copy into stdout).
-    prim::QUIET_ENGINE.with(|c| c.set(true));
-    let shadow_res = load_file(path, plusargs, None);
-    prim::QUIET_ENGINE.with(|c| c.set(false));
-    let mut shadow = shadow_res?;
-    shadow.set_quiet();
-    shadow.set_debug_tier();
-    Ok(interp.run_lockstep(&mut shadow, max_cycles, every))
+    // lockstep selfcheck: quiet shadow engines ride beside the primary
+    // — no console/file/VCD output, debug tier (a shadow is an oracle,
+    // not the artifact's execution engine, so TRS_REQUIRE_AOT does not
+    // police it).  The default shadow set covers EVERY other execution
+    // tier in one run: a pure interp always, plus a hybrid-jit shadow
+    // when the primary is the aot artifact — interp, jit, and aot then
+    // cross-check simultaneously, one mode instead of three.
+    // TRS_SELFCHECK_ENGINES=interp[,jit] overrides.  Construction runs
+    // under the quiet stamp too: elaboration-time prim diagnostics
+    // ($readmem gap warnings) print at load, before any advance
+    // re-stamps the thread-local (sysWarningTest leaked the shadow's
+    // copy into stdout).
+    let kinds: Vec<&'static str> = match std::env::var("TRS_SELFCHECK_ENGINES") {
+        Ok(s) => s
+            .split(',')
+            .filter_map(|t| match t.trim() {
+                "interp" => Some("interp"),
+                "jit" => Some("jit"),
+                _ => None,
+            })
+            .collect(),
+        Err(_) => {
+            if code.is_some() {
+                vec!["interp", "jit"]
+            } else {
+                vec!["interp"]
+            }
+        }
+    };
+    let mut shadows: Vec<(&'static str, Interp)> = Vec::new();
+    for kind in kinds {
+        prim::QUIET_ENGINE.with(|c| c.set(true));
+        let sh = load_file(path, plusargs, None);
+        prim::QUIET_ENGINE.with(|c| c.set(false));
+        let mut sh = sh?;
+        sh.set_quiet();
+        sh.set_debug_tier();
+        if kind == "jit" {
+            sh.arm_jit();
+        }
+        shadows.push((kind, sh));
+    }
+    Ok(interp.run_lockstep(&mut shadows, max_cycles, every))
 }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -5212,7 +5212,28 @@ impl Interp {
                         }
                     }
                     Some((lo, hi)) => {
-                        for addr in lo..=hi {
+                        // sparse ranges compare by OCCUPIED keys (the
+                        // union of both engines' sets — a key written
+                        // in one engine only reads undet in the other
+                        // and flags); a dense lo..=hi walk over a
+                        // RegFile#(UInt#(42)) is 4.4e12 reads per
+                        // checkpoint (sysSparseRF hung the suite)
+                        let ka = self.prim_sym_range_keys(i, ps.key);
+                        let kb = other.prim_sym_range_keys(i, ps.key);
+                        let keys: Option<Vec<u64>> = match (ka, kb) {
+                            (None, None) => None,
+                            (a, b) => {
+                                let mut u: Vec<u64> = a
+                                    .into_iter()
+                                    .flatten()
+                                    .chain(b.into_iter().flatten())
+                                    .collect();
+                                u.sort_unstable();
+                                u.dedup();
+                                Some(u)
+                            }
+                        };
+                        let mut cmp = |addr: u64, out: &mut Vec<String>| {
                             let a = self.prim_sym_read_range(i, ps.key, addr);
                             let b = other.prim_sym_read_range(i, ps.key, addr);
                             if a != b {
@@ -5222,8 +5243,23 @@ impl Interp {
                                     fmt(&b),
                                     fmt(&a)
                                 ));
-                                if out.len() >= max {
-                                    break;
+                            }
+                        };
+                        match keys {
+                            Some(ks) => {
+                                for addr in ks {
+                                    cmp(addr, &mut out);
+                                    if out.len() >= max {
+                                        break;
+                                    }
+                                }
+                            }
+                            None => {
+                                for addr in lo..=hi {
+                                    cmp(addr, &mut out);
+                                    if out.len() >= max {
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -5251,6 +5287,15 @@ impl Interp {
         let now = self.now;
         match &mut self.insts[i].kind {
             InstKind::Prim(p) => p.sym_read_range(key, addr, now),
+            _ => None,
+        }
+    }
+
+    /// Occupied addresses of a sparse SYM_RANGE (None = dense; walk
+    /// lo..=hi).  See Prim::sym_range_keys.
+    pub fn prim_sym_range_keys(&mut self, i: usize, key: &str) -> Option<Vec<u64>> {
+        match &mut self.insts[i].kind {
+            InstKind::Prim(p) => p.sym_range_keys(key),
             _ => None,
         }
     }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -5240,22 +5240,33 @@ pub fn run_file(
     let Some(every) = selfcheck else {
         return Ok(interp.run(max_cycles));
     };
+    if interp.needs_user_bdpi() {
+        // dlopen of one path is one refcounted image: user C globals
+        // are process-global, so a lockstep shadow DOUBLE-EXECUTES
+        // stateful foreign functions and corrupts the primary's own
+        // outputs (14 foreign-battery witnesses in the first selfcheck
+        // sweep) — skip the shadow, run plain
+        eprintln!(
+            "trs selfcheck: note: design imports BDPI — user C state \
+             is process-global and a lockstep shadow would \
+             double-execute stateful foreign functions; selfcheck \
+             skipped"
+        );
+        return Ok(interp.run(max_cycles));
+    }
     // lockstep selfcheck: a second, pure-interp engine shadows the
     // primary — quiet (no console/file/VCD output), no compiled code,
     // debug tier (the shadow is an oracle, not the artifact's
-    // execution engine, so TRS_REQUIRE_AOT does not police it)
-    let mut shadow = load_file(path, plusargs, None)?;
+    // execution engine, so TRS_REQUIRE_AOT does not police it).
+    // Construction runs under the quiet stamp too: elaboration-time
+    // prim diagnostics ($readmem gap warnings) print at load, before
+    // any advance re-stamps the thread-local (sysWarningTest leaked
+    // the shadow's copy into stdout).
+    prim::QUIET_ENGINE.with(|c| c.set(true));
+    let shadow_res = load_file(path, plusargs, None);
+    prim::QUIET_ENGINE.with(|c| c.set(false));
+    let mut shadow = shadow_res?;
     shadow.set_quiet();
     shadow.set_debug_tier();
-    if shadow.needs_user_bdpi() {
-        // dlopen of one path is one refcounted image: user C globals
-        // are process-global, shared across both engines (the capi
-        // oracle's isolation caveat)
-        eprintln!(
-            "trs selfcheck: note: design imports BDPI — user C state \
-             is process-global, so stateful foreign functions can \
-             produce phantom divergences (engines are not isolated)"
-        );
-    }
     Ok(interp.run_lockstep(&mut shadow, max_cycles, every))
 }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -55,11 +55,57 @@ fn is_lib_bdpi(c_name: &str) -> bool {
     matches!(c_name, "rand32" | "srand")
 }
 
-extern "C" {
-    #[link_name = "random"]
-    fn libc_random() -> std::ffi::c_long;
-    #[link_name = "srandom"]
-    fn libc_srandom(seed: std::ffi::c_uint);
+/// glibc random() (TYPE_3, trinomial x^31 + x^3 + 1), reimplemented so
+/// every Interp owns its OWN stream.  The reference's rand32.cxx calls
+/// libc random(), whose state is process-global — fine for one model
+/// per process, but the lockstep selfcheck and the bluetcl
+/// multi-engine oracle run several engines in one process, and a
+/// shared stream interleaves: each engine sees a different
+/// subsequence (witness: sysTest_mkNonPipelinedDivider, identical
+/// stdout with divergent Randomize-fed state).  Verified word-exact
+/// against glibc for 1000 draws under the default seed and srandom(N)
+/// reseeding (scratch rngtest.c).
+struct GlibcRandom {
+    state: [u32; 31],
+    f: usize,
+    r: usize,
+}
+
+impl GlibcRandom {
+    fn new() -> GlibcRandom {
+        // glibc's initial state is as if srandom(1)
+        let mut g = GlibcRandom { state: [0; 31], f: 3, r: 0 };
+        g.srandom(1);
+        g
+    }
+    fn srandom(&mut self, seed: u32) {
+        let seed = if seed == 0 { 1 } else { seed };
+        self.state[0] = seed;
+        for i in 1..31 {
+            // 16807 * prev % 2^31-1 via Schrage's method, exactly as
+            // glibc computes it (signed intermediate)
+            let prev = self.state[i - 1] as i32 as i64;
+            let hi = prev / 127773;
+            let lo = prev % 127773;
+            let mut word = 16807 * lo - 2836 * hi;
+            if word < 0 {
+                word += 2147483647;
+            }
+            self.state[i] = word as u32;
+        }
+        self.f = 3;
+        self.r = 0;
+        for _ in 0..310 {
+            self.next();
+        }
+    }
+    fn next(&mut self) -> u32 {
+        self.state[self.f] = self.state[self.f].wrapping_add(self.state[self.r]);
+        let res = (self.state[self.f] >> 1) & 0x7fff_ffff;
+        self.f = (self.f + 1) % 31;
+        self.r = (self.r + 1) % 31;
+        res
+    }
 }
 
 // ===============
@@ -215,6 +261,8 @@ pub struct Interp {
     /// TRACED artifact only: (instance, method) -> recording slots for
     /// the method's VCD ports (EN time / args / result)
     jit_rec_meths: HashMap<(usize, StrId), RecSlots>,
+    /// per-engine $random/$srandom stream (library rand32/srand BDPI)
+    rng: GlibcRandom,
 }
 
 /// Arena recording slots for one user-module method's VCD ports
@@ -650,6 +698,7 @@ impl Interp {
             jit_reset_slots: Vec::new(),
             jit_rec_defs: HashMap::new(),
             jit_rec_meths: HashMap::new(),
+            rng: GlibcRandom::new(),
         };
         // def/method-call recording must run from t=0 if the design can
         // ever start dumping ($dump* task present); -V sets it too
@@ -1970,8 +2019,9 @@ impl Interp {
         // glibc calls for bit-identical streams
         match self.s(ff.c_name) {
             "rand32" => {
-                // rand32.cxx: return (unsigned int)random();
-                let v = unsafe { libc_random() } as u64 & 0xffff_ffff;
+                // rand32.cxx: return (unsigned int)random(); ours is
+                // the same glibc stream, per-engine (see GlibcRandom)
+                let v = self.rng.next() as u64;
                 return Some(Value::from_u64(w.max(1), v));
             }
             "srand" => {
@@ -1980,7 +2030,7 @@ impl Interp {
                     Some(Arg::Val(v, _)) => v.as_u64() as u32,
                     _ => 0,
                 };
-                unsafe { libc_srandom(seed) };
+                self.rng.srandom(seed);
                 return Some(Value::from_u64(w.max(1), 0));
             }
             _ => {}

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -69,6 +69,14 @@ pub trait Prim {
     fn sym_read_range(&mut self, _key: &str, _addr: u64, _now: u64) -> Option<Value> {
         None
     }
+    /// OCCUPIED addresses of a sparse SYM_RANGE (oracle compare):
+    /// Some(keys) tells the state walk to compare only these instead
+    /// of iterating lo..=hi — a dense walk over RegFile#(UInt#(42)) is
+    /// 4.4e12 reads per checkpoint (sysSparseRF hung the suite).
+    /// None = dense storage, the lo..=hi walk is fine.
+    fn sym_range_keys(&mut self, _key: &str) -> Option<Vec<u64>> {
+        None
+    }
     /// Value-method call (pure read).
     fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value;
     /// Action-method call (mutates).
@@ -1220,6 +1228,16 @@ impl Prim for RegFile {
                 .cloned()
                 .unwrap_or_else(|| Value::undet(self.width.max(1))),
         )
+    }
+    fn sym_range_keys(&mut self, key: &str) -> Option<Vec<u64>> {
+        // boxed regfiles store sparsely; arena-backed ones are dense
+        // and small by construction (the arena gate) — dense walk fine
+        if !key.is_empty() || self.slot.is_some() {
+            return None;
+        }
+        let mut ks: Vec<u64> = self.data.keys().copied().collect();
+        ks.sort_unstable();
+        Some(ks)
     }
     fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value {
         match method {

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -2621,6 +2621,24 @@ impl Prim for Fifo {
             PrimSym { key: "level", width: 32, range: None },
         ]
     }
+    fn state_children(&self) -> Vec<PrimSym> {
+        // the bk tree's "" range reads RAW ring slots (reference `sim
+        // ls` parity: post-deq residue stays visible), but residue is
+        // DEAD state and the engines' ring disciplines legitimately
+        // differ there (boxed interp vs compiled arena) — the
+        // selfcheck sweep witnessed dft64/Divide phantom divergences
+        // on exactly that.  The ORACLE compares the architectural
+        // view instead: occupancy plus the live entries in queue
+        // order.
+        vec![
+            PrimSym {
+                key: "live",
+                width: self.width,
+                range: Some((0, self.size.saturating_sub(1) as u64)),
+            },
+            PrimSym { key: "elems", width: 32, range: None },
+        ]
+    }
     fn sym_read(&mut self, key: &str, _now: u64) -> Option<Value> {
         match key {
             "depth" => Some(Value::from_u64(32, self.size as u64)),
@@ -2628,10 +2646,34 @@ impl Prim for Fifo {
             // member (bs_prim_mod_fifo.h init_symbols) — reproduce
             // the contract, not the name
             "level" => Some(Value::from_u64(32, self.size as u64)),
+            // oracle-only: the real occupancy (arena is authority)
+            "elems" => {
+                self.refresh();
+                Some(Value::from_u64(32, self.elems as u64))
+            }
             _ => None,
         }
     }
     fn sym_read_range(&mut self, key: &str, addr: u64, _now: u64) -> Option<Value> {
+        // oracle-only architectural view: entry #addr of the LIVE
+        // queue (head-adjusted); None past the occupancy, so dead
+        // ring residue never enters a state compare
+        if key == "live" {
+            if addr as usize >= self.size {
+                return None;
+            }
+            self.refresh();
+            if addr as usize >= self.elems {
+                return None;
+            }
+            let i = (self.fst + addr as usize) % self.size;
+            return Some(
+                self.data
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_else(|| Value::zero(self.width.max(1))),
+            );
+        }
         if !key.is_empty() || addr as usize >= self.size {
             return None;
         }

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -2667,11 +2667,16 @@ impl Prim for Fifo {
                 return None;
             }
             let i = (self.fst + addr as usize) % self.size;
+            // normalize the width: arena refresh reconstructs entries
+            // at width.max(1) while boxed entries keep the enq'd width
+            // (0 for zero-width fifos) — same bits, unequal Values
+            // (sysZeroFIFOParamTest phantom divergence)
             return Some(
                 self.data
                     .get(i)
                     .cloned()
-                    .unwrap_or_else(|| Value::zero(self.width.max(1))),
+                    .unwrap_or_else(|| Value::zero(self.width.max(1)))
+                    .zext(self.width.max(1)),
             );
         }
         if !key.is_empty() || addr as usize >= self.size {

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -389,6 +389,17 @@ fn main() -> ExitCode {
             // (vcd, fst) writers this model carries; None = the
             // reference default (vcd only) applied at load
             let mut formats: Option<(bool, bool)> = None;
+            // Some(N) = lockstep selfcheck, compare cadence N posedges.
+            // TRS_SELFCHECK=1 arms it environmentally — existing
+            // artifact wrappers then run checked with no relink (how
+            // the corpus-wide selfcheck sweep drives it).
+            let mut selfcheck: Option<u64> =
+                std::env::var_os("TRS_SELFCHECK").map(|_| {
+                    std::env::var("TRS_SELFCHECK_EVERY")
+                        .ok()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(1000)
+                });
             let mut script_cmds = String::new();
             // bluesim.tcl's usage text, printed for -h and after the
             // deprecated-flag notices; the driver exits 0 in both cases
@@ -441,6 +452,37 @@ fn main() -> ExitCode {
                     "--code" => {
                         code_so = it.next().map(|s| s.to_string());
                     }
+                    // lockstep selfcheck: a quiet interp shadow runs
+                    // beside the primary engine; state compared every
+                    // N default-clock posedges (default 1000, or
+                    // --selfcheck-every / TRS_SELFCHECK_EVERY)
+                    "--selfcheck" => {
+                        if selfcheck.is_none() {
+                            selfcheck = Some(
+                                std::env::var("TRS_SELFCHECK_EVERY")
+                                    .ok()
+                                    .and_then(|v| v.parse().ok())
+                                    .unwrap_or(1000),
+                            );
+                        }
+                    }
+                    "--selfcheck-every" => match it.next() {
+                        Some(n) => match n.parse::<u64>() {
+                            Ok(n) => selfcheck = Some(n),
+                            Err(_) => {
+                                eprintln!(
+                                    "Error: --selfcheck-every requires a number"
+                                );
+                                return ExitCode::from(2);
+                            }
+                        },
+                        None => {
+                            eprintln!(
+                                "Error: --selfcheck-every requires a number"
+                            );
+                            return ExitCode::from(2);
+                        }
+                    },
                     // -dump-formats baked into the artifact wrapper
                     "--formats" => {
                         if let Some(v) = it.next() {
@@ -534,6 +576,17 @@ fn main() -> ExitCode {
                 }
             }
             if !script_cmds.is_empty() {
+                if selfcheck.is_some() {
+                    // the bluetcl tier's equivalent is the multi-engine
+                    // oracle (TRS_CAPI_ENGINES=interp,jit — see
+                    // docs/SELFCHECK.md); the batch lockstep driver
+                    // does not apply to script runs
+                    eprintln!(
+                        "trs: note: --selfcheck applies to batch runs; \
+                         ignored with -c/-f (use TRS_CAPI_ENGINES for \
+                         the script tier's oracle)"
+                    );
+                }
                 return run_script(
                     path,
                     max_cycles,
@@ -553,6 +606,7 @@ fn main() -> ExitCode {
                 wave,
                 code_so.as_deref(),
                 formats,
+                selfcheck,
             ) {
                 Ok(code) => {
                     use std::io::Write;

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -389,16 +389,22 @@ fn main() -> ExitCode {
             // (vcd, fst) writers this model carries; None = the
             // reference default (vcd only) applied at load
             let mut formats: Option<(bool, bool)> = None;
-            // Some(N) = lockstep selfcheck, compare cadence N posedges.
-            // TRS_SELFCHECK=1 arms it environmentally — existing
-            // artifact wrappers then run checked with no relink (how
-            // the corpus-wide selfcheck sweep drives it).
-            let mut selfcheck: Option<u64> =
+            // Some((N, announce)) = lockstep selfcheck, compare
+            // cadence N posedges.  TRS_SELFCHECK=1 arms it
+            // environmentally — existing artifact wrappers then run
+            // checked with no relink (how the corpus sweep and the
+            // DejaGnu suite drive it); env-armed runs suppress the
+            // skip notes (announce=false) because byte-compare
+            // harnesses capture stderr.
+            let mut selfcheck: Option<(u64, bool)> =
                 std::env::var_os("TRS_SELFCHECK").map(|_| {
-                    std::env::var("TRS_SELFCHECK_EVERY")
-                        .ok()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(1000)
+                    (
+                        std::env::var("TRS_SELFCHECK_EVERY")
+                            .ok()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(1000),
+                        false,
+                    )
                 });
             let mut script_cmds = String::new();
             // bluesim.tcl's usage text, printed for -h and after the
@@ -457,18 +463,19 @@ fn main() -> ExitCode {
                     // N default-clock posedges (default 1000, or
                     // --selfcheck-every / TRS_SELFCHECK_EVERY)
                     "--selfcheck" => {
-                        if selfcheck.is_none() {
-                            selfcheck = Some(
+                        selfcheck = Some((
+                            selfcheck.map(|(n, _)| n).unwrap_or_else(|| {
                                 std::env::var("TRS_SELFCHECK_EVERY")
                                     .ok()
                                     .and_then(|v| v.parse().ok())
-                                    .unwrap_or(1000),
-                            );
-                        }
+                                    .unwrap_or(1000)
+                            }),
+                            true,
+                        ));
                     }
                     "--selfcheck-every" => match it.next() {
                         Some(n) => match n.parse::<u64>() {
-                            Ok(n) => selfcheck = Some(n),
+                            Ok(n) => selfcheck = Some((n, true)),
                             Err(_) => {
                                 eprintln!(
                                     "Error: --selfcheck-every requires a number"
@@ -576,7 +583,7 @@ fn main() -> ExitCode {
                 }
             }
             if !script_cmds.is_empty() {
-                if selfcheck.is_some() {
+                if matches!(selfcheck, Some((_, true))) {
                     // the bluetcl tier's equivalent is the multi-engine
                     // oracle (TRS_CAPI_ENGINES=interp,jit — see
                     // docs/SELFCHECK.md); the batch lockstep driver

--- a/src/trs/docs/SELFCHECK.md
+++ b/src/trs/docs/SELFCHECK.md
@@ -63,9 +63,18 @@ the testsuite (mkTest help.cmd).
 ## Caveats
 
 - BDPI: dlopen of one path is one refcounted image, so user C globals
-  are process-global and SHARED across both engines; stateful foreign
-  functions can produce phantom divergences (same caveat, and same
-  stderr note, as the bluetcl multi-engine oracle).
+  are process-global and SHARED across both engines — a lockstep
+  shadow DOUBLE-EXECUTES stateful foreign functions and corrupts the
+  primary's own outputs (14 foreign-battery witnesses in the first
+  selfcheck sweep).  Designs importing BDPI therefore SKIP the shadow
+  (stderr note; the run proceeds unchecked).
+- FIFO state compares use the ARCHITECTURAL view (occupancy + live
+  entries in queue order), not the bk tree's raw ring slots: post-deq
+  residue is dead state and the engines' ring disciplines legitimately
+  differ there (boxed interp vs compiled arena — dft64/Divide phantom
+  divergences in the first sweep).
+- The shadow's construction runs under the quiet stamp: elaboration
+  diagnostics ($readmem gap warnings) would otherwise print twice.
 - The shadow runs interpreted BY DESIGN; it is marked debug-tier and
   exempt from TRS_REQUIRE_AOT, which polices the primary (the
   artifact's execution engine) only.

--- a/src/trs/docs/SELFCHECK.md
+++ b/src/trs/docs/SELFCHECK.md
@@ -1,13 +1,17 @@
 # Lockstep selfcheck — `trs run --selfcheck`
 
-One process validates BOTH engines against each other with no
+One process validates EVERY execution tier against the others with no
 reference simulator anywhere: the PRIMARY engine (compiled, when the
 artifact carries `--code`; the hybrid JIT otherwise) runs the design
-normally — it owns stdout, waveforms, and the exit status — while a
-quiet, pure-interp SHADOW of the same BIR runs beside it.  Every
-`--selfcheck-every` default-clock posedges (default 1000, env
-`TRS_SELFCHECK_EVERY`), and at the end of the run, the two are
-compared:
+normally — it owns stdout, waveforms, and the exit status — while
+quiet SHADOWS of the same BIR run beside it.  The default shadow set
+covers every other tier in one run: a pure interp always, plus a
+hybrid-jit shadow when the primary is the aot artifact — so interp,
+jit, and aot cross-check simultaneously, ONE test mode instead of a
+per-engine matrix (`TRS_SELFCHECK_ENGINES=interp[,jit]` overrides).
+Every `--selfcheck-every` default-clock posedges (default 1000, env
+`TRS_SELFCHECK_EVERY`), and at the end of the run, each shadow is
+compared against the primary:
 
 - shape first: cycle cursor and $finish status (state addressed at
   different times compares apples to oranges — the capi oracle's

--- a/src/trs/docs/SELFCHECK.md
+++ b/src/trs/docs/SELFCHECK.md
@@ -1,0 +1,76 @@
+# Lockstep selfcheck — `trs run --selfcheck`
+
+One process validates BOTH engines against each other with no
+reference simulator anywhere: the PRIMARY engine (compiled, when the
+artifact carries `--code`; the hybrid JIT otherwise) runs the design
+normally — it owns stdout, waveforms, and the exit status — while a
+quiet, pure-interp SHADOW of the same BIR runs beside it.  Every
+`--selfcheck-every` default-clock posedges (default 1000, env
+`TRS_SELFCHECK_EVERY`), and at the end of the run, the two are
+compared:
+
+- shape first: cycle cursor and $finish status (state addressed at
+  different times compares apples to oranges — the capi oracle's
+  per-engine gate);
+- time, but only at stops where time is architecturally VISIBLE
+  ($finish, $stop, event-heap-dry).  A stop consumed by the cycle
+  budget alone is an internal point: the fused central player and the
+  general event loop credit the last posedge's companion-negedge
+  instant differently, so `now` can legitimately sit half a period
+  apart with identical architectural history.  No output can observe
+  that skew — VCD disables the central player, and interactive stops
+  use the heap loop — and which loop is engaged is itself racy (the
+  fused bodies compile on a worker thread), so comparing it would be
+  a nondeterministic false positive, witnessed before this gate was
+  added;
+- architectural prim state (`state_divergence`, the same walk the
+  bluetcl multi-engine oracle uses at every stop — registers,
+  RegFile/BRAM ranges, FIFO contents; edge-transient wires excluded).
+
+A divergence reports on stderr (instant + the first mismatching
+entries, primary-vs-shadow) and the run exits 87 AT the divergence,
+the oracle doctrine's stop point.
+
+## Why
+
+A passing diffsweep proves compiled == interp on the corpus's stdout;
+the selfcheck proves compiled == interp on ARCHITECTURAL STATE, at
+checkpoints through the run, on any design, with zero reference
+apparatus.  That makes it (a) the cheap per-design validation mode —
+`TRS=... ./design.cexe --selfcheck` on an existing artifact, no
+relink; (b) a free oracle for fuzzing (any generated design
+self-validates); (c) the tool that catches divergences NEAR THEIR
+ORIGIN instead of at the first differing $display, with the
+mismatching state element named.
+
+## Knobs
+
+- `--selfcheck` — arm, cadence 1000 (or `TRS_SELFCHECK_EVERY`).
+- `--selfcheck-every N` — arm with cadence N.
+- `TRS_SELFCHECK=1` — arm environmentally: existing artifact wrappers
+  run checked with no relink (how the corpus-wide selfcheck sweep is
+  driven: `TRS_SELFCHECK=1 diffsweep ...`).
+- `TRS_SELFCHECK_TRACE=1` — print each checkpoint (target, per-engine
+  time/cycle) to stderr.
+- `TRS_SELFCHECK_INJECT=<cycle>` — the detector's negative witness:
+  once the primary passes that cycle the shadow is advanced one extra
+  posedge, which must trip the next compare (exit 87).  Test-only.
+
+The flag is deliberately absent from the artifact's `-h` usage text:
+that text is byte-compared against reference bluesim.tcl output by
+the testsuite (mkTest help.cmd).
+
+## Caveats
+
+- BDPI: dlopen of one path is one refcounted image, so user C globals
+  are process-global and SHARED across both engines; stateful foreign
+  functions can produce phantom divergences (same caveat, and same
+  stderr note, as the bluetcl multi-engine oracle).
+- The shadow runs interpreted BY DESIGN; it is marked debug-tier and
+  exempt from TRS_REQUIRE_AOT, which polices the primary (the
+  artifact's execution engine) only.
+- Cost: one full interp execution rides along, plus a state walk per
+  checkpoint — this is a validation mode, not a fast path.
+- `-c`/`-f` script runs dispatch to bluetcl, where the multi-engine
+  oracle (`TRS_CAPI_ENGINES=interp,jit` etc.) is the equivalent
+  facility; `--selfcheck` applies to batch runs.

--- a/src/trs/tools/diffsweep.py
+++ b/src/trs/tools/diffsweep.py
@@ -44,7 +44,10 @@ if not TRS:
 ENV = dict(os.environ, PATH=os.path.join(REPO, "inst", "bin") + ":" + os.environ["PATH"])
 
 MAX_CYCLES = "4000"
-TIMEOUT = 60          # reference runs, compiles, and normal trs runs
+# reference runs, compiles, and normal trs runs.  Env-able for the
+# selfcheck sweep (TRS_SELFCHECK=1): the interp shadow rides along, so
+# RegFile-heavy designs legitimately exceed the flat budget.
+TIMEOUT = float(os.environ.get("DIFFSWEEP_TIMEOUT", "60"))
 # Enable-gated long tests (their directory carries a *.exp.golden, the
 # bsc.long_tests convention) are exactly the designs whose interpreter
 # runs blow up; they get a tight leash instead of the flat TIMEOUT:


### PR DESCRIPTION
Stacked on #128 (trs/10-sim-hooks). The endorsed testing-scale move, extended per Ravi's direction to **collapse the per-engine test-mode matrix**: a passing diffsweep proves compiled == interp on the corpus's *stdout*; the selfcheck proves **all three execution tiers agree on architectural state**, at checkpoints through the run, on **any** design, with **zero reference apparatus** — one test mode instead of one per engine.

## What it is

`trs run --selfcheck` (full doc: `src/trs/docs/SELFCHECK.md`): the primary engine runs the design normally — compiled when the artifact carries `--code`, owning stdout/waveforms/exit status — while quiet shadows of the same BIR ride beside it. **The default shadow set covers every other tier: a pure interp always, plus a hybrid-jit shadow when the primary is the aot artifact — interp, jit, and aot cross-check simultaneously** (`TRS_SELFCHECK_ENGINES=interp[,jit]` overrides). Every N default-clock posedges (default 1000; `--selfcheck-every` / `TRS_SELFCHECK_EVERY`) and at the end of the run, each shadow compares against the primary:

1. **shape** — cycle cursor and `$finish` status (the capi oracle's per-engine gate);
2. **time**, only at stops where time is architecturally visible (`$finish` / `$stop` / event-heap-dry);
3. **architectural prim state** via `state_divergence` — the same walk the bluetcl multi-engine oracle runs at every stop (registers, RegFile/BRAM ranges, FIFO live contents; edge-transient wires excluded).

A divergence reports on stderr — instant, the offending shadow's engine, and the first mismatching state entries — and the run **exits 87 at the divergence**, so failures are caught near their origin with the mismatching element *named*, instead of at the first differing `$display`.

`TRS_SELFCHECK=1` arms it environmentally: existing artifact wrappers run checked **with no relink** — which is also how the corpus-wide three-engine sweep is driven.

## What its own first sweeps taught it (all fixed here, each with a witness)

The first corpus sweeps reported **zero real engine divergences** — and a series of harness/isolation gaps the selfcheck itself exposed:

- **FIFO compares walk the architectural view** (occupancy + live entries in queue order), not the bk tree's raw ring slots: post-deq residue is dead state and the engines' ring disciplines legitimately differ there (Divide/dft64 phantoms; zero-width entries width-normalized for sysZeroFIFOParamTest).
- **`$random` is now a per-engine stream**: it was libc `random()` — matching the reference's rand32.cxx, but process-global, so multiple engines interleaved one sequence (witness: the Randomize-fed NonPipelinedDivider — byte-identical stdout, divergent divider state). glibc's TYPE_3 generator is reimplemented per Interp, verified word-exact against glibc for 1000 draws under default seed and `srandom(N)`; reference stream parity unchanged. This also fixes the bluetcl multi-engine oracle on `$random` designs.
- **BDPI designs skip the shadows** with a note: one dlopen image means process-global user C state, and lockstep shadows double-execute stateful foreign functions (14 foreign-battery witnesses).
- **Shadow construction runs under the quiet stamp** (elaboration `$readmem` warnings printed twice — sysWarningTest).
- **Time compares gate off pure cycle-budget stops**: the fused central player and the general loop credit the last companion-negedge instant differently — unobservable by any output, and racy (fused bodies compile on a worker thread), witnessed as a nondeterministic phantom before the gate.

## Contracts kept

- Shadows are quiet (console/files/VCD suppressed) and **debug-tier** — `TRS_REQUIRE_AOT` polices the primary only.
- `--selfcheck` with `-c`/`-f` notes that the script tier's oracle is `TRS_CAPI_ENGINES` and runs the script normally.
- The flag stays out of the artifact's `-h` usage text (byte-compared against bluesim.tcl by the suite).
- `TRS_SELFCHECK_INJECT=<n>` is the detector's negative witness: the first shadow is advanced one extra posedge past cycle *n*, which must trip the next compare — verified, exit 87 naming the shadow.

## Gates

| gate | result |
|---|---|
| clean 3-way selfcheck (aot primary + interp + jit shadows) | exit 0, stdout byte-identical (×3 repeats) |
| injection witness | exit 87, `[interp shadow] cycle 26 vs primary 25` |
| Randomize-fed divider, 3-way | clean + reference stdout parity |
| corpus-wide 3-way sweep (`TRS_SELFCHECK=1` + `--aot`, all 996) | running; seal to follow below |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS