### PR TITLE
trs: three-simulator benchmark — Bluesim vs Verilator vs trs, plus `BSV_TASKS_DELAY

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,3 +94,31 @@ jobs:
           path: |
             bench-results.json
             bench-table.txt
+      # The durable archive is MatX-inc/bsc-benchmarks (results/ —
+      # queryable history, not expiring artifacts).  Needs the
+      # BENCH_ARCHIVE_TOKEN secret (contents:write on that repo);
+      # without it the artifact above is the fallback.
+      - name: Archive to bsc-benchmarks
+        if: ${{ env.BENCH_ARCHIVE_TOKEN != '' }}
+        env:
+          BENCH_ARCHIVE_TOKEN: ${{ secrets.BENCH_ARCHIVE_TOKEN }}
+        run: |
+          git clone --depth 1 \
+            "https://x-access-token:${BENCH_ARCHIVE_TOKEN}@github.com/MatX-inc/bsc-benchmarks.git" archive
+          STAMP=$(date -u +%Y-%m-%d)
+          SHA=$(git rev-parse --short=9 HEAD)
+          OUT="archive/results/${STAMP}-${SHA}-gha.json"
+          python3 - "$OUT" "$SHA" <<'PY'
+          import json, sys, platform, subprocess
+          out, sha = sys.argv[1:3]
+          data = json.load(open("bench-results.json"))
+          meta = dict(label="indicative", bsc_sha=sha, host="github-actions",
+                      machine=platform.machine(),
+                      verilator=subprocess.run(["verilator", "--version"],
+                        capture_output=True, text=True).stdout.strip())
+          json.dump(dict(meta=meta, results=data), open(out, "w"), indent=1)
+          PY
+          cd archive
+          git -c user.name="bsc-bench-ci" -c user.email="bench-ci@users.noreply.github.com" \
+            add results && git -c user.name="bsc-bench-ci" -c user.email="bench-ci@users.noreply.github.com" \
+            commit -m "results: ${STAMP} ${SHA} (gha, indicative)" && git push

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,96 @@
+name: Simulator Benchmark
+
+# Three-simulator benchmark (Bluesim vs Verilator vs trs) over the
+# in-repo pool — src/trs/tools/bench.py, methodology in
+# src/trs/docs/BENCH.md.
+#
+# Shared-runner numbers are INDICATIVE and only meaningful as
+# RELATIVE deltas within one run (same machine, same moment);
+# authoritative absolute numbers come from the calibrated machine.
+# The external macro pool (Flute, CHERI-Toooba, JpegEncoder,
+# blue-rdma, Fife+FreeRTOS) arrives with the separate benchmark repo
+# (corpus pins + workload images + results archive — the Toooba
+# model); this workflow covers the in-repo designs.
+#
+# Linux only (per Ravi): macOS runners are excluded.
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "substring filter on design names (empty = all)"
+        required: false
+        default: ""
+      runs:
+        description: "runs per measurement (median reported)"
+        required: false
+        default: "3"
+  schedule:
+    # nightly, off-peak for the runner pool
+    - cron: "17 9 * * *"
+
+jobs:
+  bench:
+    name: "Bench: ubuntu-latest"
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo .github/workflows/install_dependencies_ubuntu.sh
+          sudo apt-get install -y verilator llvm-18-dev libpolly-18-dev libelf-dev
+      - name: Install GHC
+        uses: haskell/ghcup-setup@v1
+        with:
+          ghc: 9.6.7
+          cabal: recommended
+      - name: Install Haskell dependencies
+        shell: bash
+        run: |
+          cabal update
+          cabal v1-install cborg old-time regex-compat split strict-concurrency syb
+      # Warm from the regular CI builds' ccache (same key prefix), so
+      # the bsc build here is mostly cache replay
+      - name: CCache cache files
+        uses: actions/cache@v5
+        with:
+          path: ${{ GITHUB.WORKSPACE }}/ccache
+          key: build-ubuntu-latest-ghc-9.6.7-ccache-bench-${{ github.sha }}
+          restore-keys: |
+            build-ubuntu-latest-ghc-9.6.7-ccache-
+      - name: Build bsc + trs
+        env:
+          CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/ccache
+        run: |
+          ccache --zero-stats --max-size 250M
+          export PATH=/usr/lib/ccache:$PATH
+          CORES=$(nproc)
+          make -j ${CORES} GHCJOBS=2 GHCRTSFLAGS='+RTS -M5G -A128m -RTS' install-src
+      - name: Run benchmark
+        run: |
+          export BSC="$PWD/inst/bin/bsc"
+          export TRS="$PWD/inst/bin/trs"
+          export LC_ALL=en_US.UTF-8
+          python3 src/trs/tools/bench.py \
+            --filter "${{ github.event.inputs.filter || '' }}" \
+            --runs "${{ github.event.inputs.runs || '3' }}" \
+            --out bench-results.json | tee bench-table.txt
+      - name: Summary
+        run: |
+          {
+            echo "## Simulator benchmark (shared runner — relative deltas only)"
+            echo '```'
+            cat bench-table.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-${{ github.sha }}
+          path: |
+            bench-results.json
+            bench-table.txt

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -96,6 +96,7 @@ instance PPrint VProgram where
     pPrint d p (VProgram ms _dpis cs) =
         ppComment cs $+$
         assignment_delay_macro $+$
+        zero_delay_macro $+$
         reset_level_macro $+$
         vsepEmptyLine (map (pPrint d 0) ms) $+$
         text ""
@@ -105,6 +106,16 @@ instance PPrint VProgram where
           text "`ifdef BSV_ASSIGNMENT_DELAY" $+$
           text "`else" $+$
           text "  `define BSV_ASSIGNMENT_DELAY" $+$
+          text "`endif" $+$
+          text ""
+        -- the 0-tick synchronization delay in system-task blocks
+        -- (historically a hardcoded "#0" to pacify VCS and NC);
+        -- overridable so delay-free consumers (Verilator without
+        -- --timing) can define it empty
+        zero_delay_macro =
+          text "`ifdef BSV_ZERO_DELAY" $+$
+          text "`else" $+$
+          text "  `define BSV_ZERO_DELAY #0" $+$
           text "`endif" $+$
           text ""
         reset_level_macro =
@@ -586,7 +597,7 @@ instance PPrint VStmt where
         pPrint d p (VAssert ev es) = ppAssert d p ev es
 
 
-        pPrint d p  VZeroDelay     = text "#0;"
+        pPrint d p  VZeroDelay     = text "`BSV_ZERO_DELAY;"
 
 instance NFData VStmt where
     rnf (VAt ev stmt) = rnf2 ev stmt

--- a/src/comp/Verilog.hs
+++ b/src/comp/Verilog.hs
@@ -96,7 +96,7 @@ instance PPrint VProgram where
     pPrint d p (VProgram ms _dpis cs) =
         ppComment cs $+$
         assignment_delay_macro $+$
-        zero_delay_macro $+$
+        tasks_delay_macro $+$
         reset_level_macro $+$
         vsepEmptyLine (map (pPrint d 0) ms) $+$
         text ""
@@ -112,10 +112,10 @@ instance PPrint VProgram where
         -- (historically a hardcoded "#0" to pacify VCS and NC);
         -- overridable so delay-free consumers (Verilator without
         -- --timing) can define it empty
-        zero_delay_macro =
-          text "`ifdef BSV_ZERO_DELAY" $+$
+        tasks_delay_macro =
+          text "`ifdef BSV_TASKS_DELAY" $+$
           text "`else" $+$
-          text "  `define BSV_ZERO_DELAY #0" $+$
+          text "  `define BSV_TASKS_DELAY #0" $+$
           text "`endif" $+$
           text ""
         reset_level_macro =
@@ -597,7 +597,7 @@ instance PPrint VStmt where
         pPrint d p (VAssert ev es) = ppAssert d p ev es
 
 
-        pPrint d p  VZeroDelay     = text "`BSV_ZERO_DELAY;"
+        pPrint d p  VZeroDelay     = text "`BSV_TASKS_DELAY;"
 
 instance NFData VStmt where
     rnf (VAt ev stmt) = rnf2 ev stmt

--- a/src/trs/docs/BENCH.md
+++ b/src/trs/docs/BENCH.md
@@ -14,13 +14,22 @@
 ## Fairness ground rules
 
 - Every leg runs SINGLE-THREADED.
+- Every leg's generated code compiles `-O3`: Bluesim ships `c++ -O3`;
+  Verilator's packaged `verilated.mk` defaults `OPT_FAST`/`OPT_GLOBAL`
+  to `-Os`, which measured 34% slower on the dispatch floor (mkLong),
+  so the harness raises both to `-O3`; trs AOT uses its own shipped
+  LLVM pipeline.  Build seconds are reported, so the compile cost of
+  `-O3` stays visible.
 - Verilator runs with NO timing flags (per Ravi: `--timing` has known
   issues, and `--no-timing` would silently ignore stray delays).
-  Instead: `BSV_ASSIGNMENT_DELAY` is \`define'd away, bsc's literal
-  `#0;` system-task ordering guards are stripped (inert under the C++
-  driver — the negedge instant is a plain eval long after posedge
-  NBAs settle), and a generic C++ driver toggles CLK/RST_N on the bsc
-  top, so all three legs simulate the same closed testbench module.
+  Instead: bsc emits its delays behind `BSV_ASSIGNMENT_DELAY` and
+  `BSV_TASKS_DELAY` (the 0-tick system-task ordering guard), both
+  \`define'd empty on this leg — the guard is inert under the C++
+  driver anyway (the negedge instant is a plain eval long after
+  posedge NBAs settle) — and a generic C++ driver toggles CLK/RST_N
+  on the bsc top, so all three legs simulate the same closed
+  testbench module.  A literal-`#0;` strip survives only as a
+  fallback for benchmarking bsc revisions that predate the macro.
   Anything else timing-shaped errors loudly for explicit handling.
 - Designs terminate themselves (`$finish`): identical workload per
   leg, no `-m` games.

--- a/src/trs/docs/BENCH.md
+++ b/src/trs/docs/BENCH.md
@@ -69,8 +69,35 @@
   not `Empty`, so it needs a small closed BSV TB wrapper (drive
   LwcIfc with in-BSV vectors, self-check, `$finish`) before it can
   enter the pool.  Staged as follow-up.
-- BlueCheck / CHERI variants / further candidates: web survey in
-  progress; add here as they qualify.
+- Survey results (2026-08-20, full ranked table in the session notes) —
+  the starter set beyond the two cores, all cloned and all with
+  SELF-TERMINATING in-repo Bluesim testbenches:
+  - **JpegEncoder** (WangXuan95/BSV_Tutorial_cn, GPL-3.0):
+    `mkTbJpegEncoderMulti` reads 12 in-repo 1816x1008 .pgm images via
+    $fopen — a multi-million-cycle DSP run (2-D DCT, quantizer,
+    Huffman; dense wide fixed-point) with ZERO external deps.  The
+    non-CPU compute character the cores don't cover.
+  - **blue-rdma** (datenlord, GPL-2.0): RoCEv2 engine — 256-bit+
+    datapaths, header parse/deparse, CRC, FIFO meshes; ~30
+    independent self-terminating Bluesim tops
+    (`Makefile.test TESTFILE=.. TOPMODULE=..`), run length dialed via
+    MAX_CMP_CNT.  Its CI pins stock B-Lang bsc — proven open-bsc flow.
+  - **Fife running FreeRTOS** (rsnikhil/Learn_Bluespec_and_RISCV_Design,
+    MIT): 5-stage RV32 running the in-repo RTOSDemo.memhex32 —
+    millions of cycles of REAL SOFTWARE with no RISC-V toolchain;
+    paired b_*/v_* Bluesim/Verilator targets and DPI C devices
+    (exercises -use-dpi).  One-line `cycle_limit` edit bounds the run.
+    The most modern-bsc-idiomatic code in the pool (active 2026).
+  - **bluecheck** (CTSRD-CHERI/bluecheck — note: `mn416/blue-check`
+    does not exist): QuickCheck-style rule churn, dial-a-length;
+    correctness/scheduler stressor rather than throughput.
+  - Also surveyed and shelved with reasons: MAERI (accelerator
+    alternate), MIT 6.375 audio (FIR/FFT, license unclear), RVBS
+    (elaboration stressor), tinsel + airblue + riscy-OOO + SHAKTI +
+    quartz (all high-effort: dead TB infra, external toolchains, or
+    buck2), OpenSMART/Accel_AES/chromite (stale or no TB).  No
+    surveyed repo ships prebuilt Dhrystone/CoreMark images — Fife's
+    FreeRTOS and the JPEG encoder are the long real-workload runs.
 
 ## Running
 

--- a/src/trs/docs/BENCH.md
+++ b/src/trs/docs/BENCH.md
@@ -1,0 +1,81 @@
+# Three-simulator benchmark — Bluesim vs Verilator vs trs
+
+`tools/bench.py`. Two axes per design:
+
+- **build**: bsc frontend (elaboration) + backend-specific build —
+  Bluesim's C++ codegen + g++, Verilator's `--cc --build`, trs's
+  `.bir` export + `trs link`.  The testsuite corpus is already an
+  excellent COMPILE benchmark (conflict_free_large: 417s Bluesim
+  build vs ~18s trs link at last measure); runtime needs the designs
+  below.
+- **run**: wall time to natural `$finish` (median of `--runs`), peak
+  RSS, and cycles/s where the design's cycle count is known.
+
+## Fairness ground rules
+
+- Every leg runs SINGLE-THREADED.
+- Verilator runs with NO timing flags (per Ravi: `--timing` has known
+  issues, and `--no-timing` would silently ignore stray delays).
+  Instead: `BSV_ASSIGNMENT_DELAY` is \`define'd away, bsc's literal
+  `#0;` system-task ordering guards are stripped (inert under the C++
+  driver — the negedge instant is a plain eval long after posedge
+  NBAs settle), and a generic C++ driver toggles CLK/RST_N on the bsc
+  top, so all three legs simulate the same closed testbench module.
+  Anything else timing-shaped errors loudly for explicit handling.
+- Designs terminate themselves (`$finish`): identical workload per
+  leg, no `-m` games.
+- Cross-leg stdout is byte-compared (Verilator's own `$finish`
+  trailer normalized away).  `$random` designs are exempt on the
+  Verilator leg only — Verilator's RNG is not glibc's, so the operand
+  stream legitimately differs; Bluesim and trs must still match.
+- Numbers from an uncalibrated or shared box are INDICATIVE.  The
+  authoritative fence runs on the calibrated machine.
+
+## In-repo pool (from sweep telemetry: per-cycle weight + distinct stress characters)
+
+| design | character |
+|---|---|
+| Long | raw edge/rule dispatch floor (300M posedges, one rule) |
+| ConflictFreeLarge | huge rule count per cycle (scheduler-bound) |
+| DFT64 v1/v5 | FP dataflow pipeline, FIFO-heavy |
+| FloatTest | FP arithmetic battery, wide values |
+| TrafficBRAM | BRAM + MIMO buffering, memory-port bound |
+| BRAM0Test | BRAM variants battery, wide state |
+| Sudoku | deep combinational cones, backtracking search |
+| Dividers | iterative arithmetic + $random operands |
+| SparseRF | RegFile range traffic |
+| Mesa | app-scale packet pipeline |
+
+## External macro pool (clones under the session scratchpad, integration staged)
+
+- **Flute** (bluespec/Flute, RV32/64 5-stage) and **Toooba**
+  (bluespec/Toooba, RiscyOO superscalar OOO) — per Ravi, Piccolo is
+  NOT worth a third slot: it is Flute's 3-stage sibling from the same
+  lineage with a near-identical simulation profile (byte-identical
+  Include_bluesim.mk); keep it only as a fallback if Flute fights the
+  build.  Both share one recipe: `bsc -u -elab -sim` →
+  `bsc -sim -e mkTop_HW_Side` + C_Imported_Functions.c → `Mem.hex` +
+  `symbol_table.txt` in CWD (elf_to_hex, needs libelf) →
+  `./exe +v1 +tohost` → PASS/FAIL + `$finish`.  In-repo workloads are
+  the RISC-V ISA ELFs (short — fine for correctness and BUILD
+  benchmarking; Toooba's elaboration is a compile benchmark all by
+  itself).  Meaningful core RUNTIME numbers need a Dhrystone/CoreMark
+  hex — not shipped in-repo; build via a riscv-gnu toolchain or fetch
+  prebuilt when integrating.  Toooba additionally needs its BlueStuff
+  submodule (network).
+- **BlueLight** (kammoh/bluelight, LWC crypto: Ascon/Xoodyak/GIFT-COFB/
+  Gimli/Subterranean) — compute-dense and modern-bsc-friendly, but it
+  has NO Bluesim testbench (cocotb/Verilog only) and its `lwc` top is
+  not `Empty`, so it needs a small closed BSV TB wrapper (drive
+  LwcIfc with in-BSV vectors, self-check, `$finish`) before it can
+  enter the pool.  Staged as follow-up.
+- BlueCheck / CHERI variants / further candidates: web survey in
+  progress; add here as they qualify.
+
+## Running
+
+    BSC=.../bsc TRS=.../trs python3 tools/bench.py \
+        [--filter substr] [--runs 3] [--legs bluesim,verilator,trs]
+
+Emits a table per design and `bench-results.json`.  Run only on an
+otherwise-idle machine.

--- a/src/trs/docs/BENCH.md
+++ b/src/trs/docs/BENCH.md
@@ -48,9 +48,21 @@
 
 ## External macro pool (clones under the session scratchpad, integration staged)
 
-- **Flute** (bluespec/Flute, RV32/64 5-stage) and **Toooba**
-  (bluespec/Toooba, RiscyOO superscalar OOO) — per Ravi, Piccolo is
-  NOT worth a third slot: it is Flute's 3-stage sibling from the same
+- **Flute** (bluespec/Flute, RV32/64 5-stage) and **CHERI-Toooba**
+  (CTSRD-CHERI/Toooba — per Ravi it DISPLACES upstream Toooba: it is
+  strictly the heavier stressor (129-bit capability datapaths
+  everywhere, plus a TagController — an extra cache level for tag
+  traffic — on top of RiscyOO's superscalar OOO), it is the more
+  actively maintained fork (2026-07 vs 2026-04), and its
+  `Tests/benchmarks` submodule is `CTSRD-CHERI/toooba-sim-benchmarks`:
+  PREBUILT MiBench/Olden-class RISC-V binaries (dijkstra, qsort,
+  picojpeg, rsa, basicmath, adpcm, bisort) with a Makefile — the
+  in-repo real-workload runtime images every other surveyed repo
+  lacks.  src_Core is only ~9% more BSV text than upstream Toooba
+  (58.7k -> 63.9k lines) but the submodule libs (cheri-cap-lib,
+  TagController, BlueStuff) and the widened state put the real
+  simulation delta well beyond that.  Per Ravi, Piccolo is
+  NOT worth a slot either: it is Flute's 3-stage sibling from the same
   lineage with a near-identical simulation profile (byte-identical
   Include_bluesim.mk); keep it only as a fallback if Flute fights the
   build.  Both share one recipe: `bsc -u -elab -sim` →
@@ -58,11 +70,11 @@
   `symbol_table.txt` in CWD (elf_to_hex, needs libelf) →
   `./exe +v1 +tohost` → PASS/FAIL + `$finish`.  In-repo workloads are
   the RISC-V ISA ELFs (short — fine for correctness and BUILD
-  benchmarking; Toooba's elaboration is a compile benchmark all by
-  itself).  Meaningful core RUNTIME numbers need a Dhrystone/CoreMark
-  hex — not shipped in-repo; build via a riscv-gnu toolchain or fetch
-  prebuilt when integrating.  Toooba additionally needs its BlueStuff
-  submodule (network).
+  benchmarking; Toooba-class elaboration is a compile benchmark all
+  by itself).  Core RUNTIME numbers come from the
+  toooba-sim-benchmarks binaries above (upstream repos ship no
+  Dhrystone/CoreMark).  CHERI-Toooba needs its submodules fetched
+  (BlueStuff, TagController, cheri-cap-lib, Tests/benchmarks).
 - **BlueLight** (kammoh/bluelight, LWC crypto: Ascon/Xoodyak/GIFT-COFB/
   Gimli/Subterranean) — compute-dense and modern-bsc-friendly, but it
   has NO Bluesim testbench (cocotb/Verilog only) and its `lwc` top is

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -91,7 +91,11 @@ POOL = [
     # packet-processing app (mesa)
     dict(name="Mesa", dir="testsuite/bsc.bsv_examples/mesa/spiless-tx-bsv",
          src="TestMesa.bsv", top="sysTestMesa", cycles=None,
-         character="app-scale packet pipeline"),
+         character="app-scale packet pipeline",
+         no_verilator="non-terminating under the generic C++ driver "
+                      "(packet input side free-runs; same Verilog "
+                      "passes the suite under iverilog with bsc's "
+                      "main.v) — under investigation"),
 ]
 
 VL_MAIN = r"""

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -242,6 +242,13 @@ def bench_one(d, legs, runs, work):
                        "+define+BSV_ASSIGNMENT_DELAY=",
                        "+define+BSV_TASKS_DELAY=",
                        "+define+BSV_ZERO_DELAY=",  # transitional name, harmless if unused
+                       # every leg's generated C++ builds -O3: Bluesim
+                       # ships c++ -O3, but Verilator's packaged
+                       # verilated.mk defaults OPT_FAST/OPT_GLOBAL to
+                       # -Os — a size-optimized eval loop measured 34%
+                       # slower on the dispatch floor (mkLong)
+                       "-MAKEFLAGS", "OPT_FAST=-O3",
+                       "-MAKEFLAGS", "OPT_GLOBAL=-O3",
                        "-O3", "-Wno-fatal",
                        "--x-assign", "fast", "--x-initial", "fast",
                        "-y", os.path.abspath(vdir),

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Three-simulator benchmark: Bluesim vs Verilator vs trs.
+
+Two axes per design:
+  build   bsc frontend (elab) + backend-specific build:
+            bluesim  = bsc -sim -e (C++ codegen + g++)
+            verilator= bsc -verilog -u -g + verilator --cc + make
+            trs      = bsc -sim -bir -e (.bir export) + trs link
+  run     wall time to natural $finish (median of --runs), peak RSS.
+          cycles/s where the design's cycle count is known.
+
+Fairness ground rules (docs/BENCH.md):
+  - every leg runs SINGLE-THREADED;
+  - Verilator runs WITHOUT --timing (known issues; per Ravi) — a
+    generic C++ clock driver toggles CLK/RST_N on the bsc top instead
+    of the reference main.v, so all three legs simulate the same
+    closed testbench module;
+  - designs terminate themselves ($finish): no -m games, identical
+    workload per leg;
+  - numbers from an uncalibrated/shared box are INDICATIVE — the
+    authoritative fence runs on the calibrated machine.
+
+Usage:
+  bench.py [--filter substr] [--runs 3] [--legs bluesim,verilator,trs]
+           [--out bench-results.json]
+  env: BSC, TRS, BENCH_WORK (workdir; default: fresh temp)
+"""
+
+import argparse
+import json
+import os
+import re
+import resource
+import shutil
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+BSC = os.environ.get("BSC", "bsc")
+TRS = os.environ.get("TRS", "trs")
+
+# The pool: closed ($finish-terminating) testbenches chosen from sweep
+# telemetry for per-cycle weight, covering distinct simulator stress
+# characters.  `cycles` is the design's own workload when known (for
+# cycles/s); None = report wall time only.
+POOL = [
+    # pure edge throughput: one rule, one counter, 300M posedges
+    dict(name="Long", dir="testsuite/bsc.bluesim/interactive",
+         src="Long.bsv", top="mkLong", cycles=300_000_001,
+         character="raw edge/rule dispatch floor"),
+    # scheduling weight: very large rule count with conflict analysis
+    dict(name="ConflictFreeLarge", dir="testsuite/bsc.long_tests/conflict_free_large",
+         src="ConflictFreeOKLarge.bsv", top="sysConflictFreeOKLarge", cycles=None,
+         character="huge rule count per cycle (scheduler-bound)"),
+    # FP pipeline dataflow (PAClib DFT, 64-pt): FIFOs + FP mul/add
+    dict(name="DFT64v1", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
+         src="Tb.bsv", top="sysTb_v1", cycles=None,
+         character="FP dataflow pipeline, FIFO-heavy"),
+    dict(name="DFT64v5", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
+         src="Tb.bsv", top="sysTb_v5", cycles=None,
+         character="FP dataflow, deeper variant"),
+    # FP arithmetic battery (add/mul/div/sqrt corner cases)
+    dict(name="FloatTest", dir="testsuite/bsc.lib/FloatingPoint",
+         src="FloatTest.bsv", top="sysFloatTest", cycles=None,
+         character="FP arithmetic battery, wide values"),
+    # BRAM traffic through a MIMO buffer
+    dict(name="TrafficBRAM", dir="testsuite/bsc.bsv_examples/mimo",
+         src="TrafficBRAM.bsv", top="sysTrafficBRAM", cycles=None,
+         character="BRAM + MIMO buffering, memory-port bound"),
+    # BRAM byte-enable/init battery
+    dict(name="BRAM0Test", dir="testsuite/bsc.lib/BRAM/BRAM0Test",
+         src="BRAM0Test.bsv", top="sysBRAM0Test", cycles=None,
+         character="BRAM variants battery, wide state"),
+    # combinational search (sudoku generator)
+    dict(name="Sudoku", dir="testsuite/bsc.bsv_examples/sudoku",
+         src="GenerateTest.bsv", top="mkGenerateTest3", cycles=None,
+         character="deep combinational cones, backtracking search"),
+    # iterative arithmetic (Randomize-fed dividers)
+    dict(name="Dividers", dir="testsuite/bsc.lib/Divide",
+         src="Test_mkNonPipelinedDivider.bsv", top="sysTest_mkNonPipelinedDivider",
+         cycles=None, character="iterative arithmetic + $random operands",
+         random=True),
+    # sparse RegFile addressing
+    dict(name="SparseRF", dir="testsuite/bsc.bluesim/misc",
+         src="SparseRF.bsv", top="sysSparseRF", cycles=None,
+         character="RegFile range traffic"),
+    # packet-processing app (mesa)
+    dict(name="Mesa", dir="testsuite/bsc.bsv_examples/mesa",
+         src="mkTestMesa.bsv", top="sysTestMesa", cycles=None,
+         character="app-scale packet pipeline"),
+]
+
+VL_MAIN = r"""
+// generic Verilator driver for a closed bsc top (CLK/RST_N only) —
+// replaces main.v so no --timing is needed
+#include "V%TOP%.h"
+#include "verilated.h"
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    V%TOP%* top = new V%TOP%;
+    vluint64_t half = 0;
+    top->RST_N = 0;
+    top->CLK = 0;
+    top->eval();
+    while (!Verilated::gotFinish()) {
+        ++half;
+        if (half == 4) top->RST_N = 1;   // 2 full cycles of reset
+        top->CLK = !top->CLK;
+        top->eval();
+        if (half > 8000000000ULL) break; // 4G-cycle safety cap
+    }
+    top->final();
+    delete top;
+    return 0;
+}
+"""
+
+
+def sh(cmd, cwd, env=None, timeout=7200):
+    t0 = time.monotonic()
+    r = subprocess.run(cmd, cwd=cwd, env=env or os.environ,
+                       capture_output=True, text=True, timeout=timeout)
+    return r, time.monotonic() - t0
+
+
+def run_measured(cmd, cwd, runs):
+    """Median wall + max RSS over `runs` executions (children rusage)."""
+    walls, rss = [], 0
+    out = None
+    for _ in range(runs):
+        before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        r, w = sh(cmd, cwd)
+        after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        if r.returncode not in (0,):
+            return None, r
+        walls.append(w)
+        rss = max(rss, after if after > before else before)
+        out = r
+    walls.sort()
+    return dict(wall=walls[len(walls) // 2], walls=walls,
+                max_rss_kb=rss), out
+
+
+def bench_one(d, legs, runs, work):
+    res = dict(name=d["name"], top=d["top"], character=d["character"], legs={})
+    src_dir = os.path.join(REPO, d["dir"])
+    top = d["top"]
+    outputs = {}
+    for leg in legs:
+        wk = os.path.join(work, d["name"], leg)
+        os.makedirs(wk, exist_ok=True)
+        for f in os.listdir(src_dir):
+            if f.endswith((".bsv", ".bs", ".c", ".h", ".hex", ".bin", ".dat", ".txt", ".vec")):
+                try:
+                    shutil.copy(os.path.join(src_dir, f), wk)
+                except OSError:
+                    pass
+        common = ["-bdir", wk, "-info-dir", wk, "-simdir", wk, "-vdir", wk,
+                  "-p", wk + ":+"]
+        L = {}
+        if leg in ("bluesim", "trs"):
+            r, t = sh([BSC, "-sim", "-u", "-g", top] + common + [d["src"]], wk)
+            if r.returncode != 0:
+                L["error"] = "bsc compile: " + (r.stderr or r.stdout)[-300:]
+                res["legs"][leg] = L
+                continue
+            L["frontend_s"] = round(t, 2)
+            if leg == "bluesim":
+                r, t = sh([BSC, "-sim", "-e", top, "-o", "simb"] + common, wk)
+                if r.returncode != 0:
+                    L["error"] = "bluesim link: " + (r.stderr or r.stdout)[-300:]
+                    res["legs"][leg] = L
+                    continue
+                L["backend_s"] = round(t, 2)
+                m, r = run_measured(["./simb"], wk, runs)
+                exe = "./simb"
+            else:
+                r, t = sh([BSC, "-sim", "-bir", "-e", top, "-o", "simr"] + common, wk)
+                bir = os.path.join(wk, top + ".bir")
+                if not os.path.exists(bir):
+                    L["error"] = "no .bir: " + (r.stderr or r.stdout)[-300:]
+                    res["legs"][leg] = L
+                    continue
+                r2, t2 = sh([TRS, "link", bir, "-o", "art"], wk)
+                if r2.returncode != 0:
+                    L["error"] = "trs link: " + (r2.stderr or r2.stdout)[-300:]
+                    res["legs"][leg] = L
+                    continue
+                L["backend_s"] = round(t2, 2)
+                L["bir_export_s"] = round(t, 2)
+                m, r = run_measured(["./art"], wk, runs)
+                exe = "./art"
+        else:  # verilator
+            r, t = sh([BSC, "-verilog", "-u", "-g", top] + common + [d["src"]], wk)
+            if r.returncode != 0:
+                L["error"] = "bsc -verilog: " + (r.stderr or r.stdout)[-300:]
+                res["legs"][leg] = L
+                continue
+            L["frontend_s"] = round(t, 2)
+            # bsc's system-task blocks open with a literal `#0;` (an
+            # intra-negedge ordering guard).  Under the C++ driver the
+            # negedge instant is a plain eval long after posedge NBAs
+            # settle, so the guard is inert — strip it rather than
+            # reaching for --timing/--no-timing (per Ravi: --timing has
+            # known issues; --no-timing would ignore delays silently).
+            for vf in os.listdir(wk):
+                if vf.endswith(".v"):
+                    pv = os.path.join(wk, vf)
+                    txt = open(pv).read()
+                    txt2 = re.sub(r"^\s*#0;\s*$", "", txt, flags=re.M)
+                    if txt2 != txt:
+                        open(pv, "w").write(txt2)
+            with open(os.path.join(wk, "bench_main.cpp"), "w") as f:
+                f.write(VL_MAIN.replace("%TOP%", top))
+            vdir = os.path.join(os.path.dirname(shutil.which(BSC) or BSC),
+                                "..", "lib", "Verilog")
+            # no timing flags at all (per Ravi: --timing has known
+            # issues, and --no-timing would silently ignore stray
+            # delays): the assignment delay is `define'd away instead,
+            # so the Verilog is genuinely delay-free and anything else
+            # timing-shaped errors loudly for explicit handling
+            r, t = sh(["verilator", "--cc", "--exe", "--build", "-j", "4",
+                       "+define+BSV_ASSIGNMENT_DELAY=", "-O3", "-Wno-fatal",
+                       "--x-assign", "fast", "--x-initial", "fast",
+                       "-y", os.path.abspath(vdir),
+                       top + ".v", "bench_main.cpp", "-o", "simv"], wk)
+            if r.returncode != 0:
+                L["error"] = "verilator: " + (r.stderr or r.stdout)[-300:]
+                res["legs"][leg] = L
+                continue
+            L["backend_s"] = round(t, 2)
+            m, r = run_measured(["./obj_dir/simv"], wk, runs)
+            exe = "./obj_dir/simv"
+        if m is None:
+            L["error"] = f"run {exe}: rc={r.returncode} " + (r.stderr or "")[-200:]
+        else:
+            L["run_s"] = round(m["wall"], 3)
+            L["runs_s"] = [round(x, 3) for x in m["walls"]]
+            L["max_rss_kb"] = m["max_rss_kb"]
+            if d.get("cycles"):
+                L["mcycles_per_s"] = round(d["cycles"] / m["wall"] / 1e6, 2)
+            outputs[leg] = (r.stdout or "").strip()
+        res["legs"][leg] = L
+    # cross-leg output check: same testbench must print the same thing.
+    # Verilator appends its own "$finish" trailer — normalize it away;
+    # $random designs are exempt on the verilator leg (Verilator's RNG
+    # is not glibc's, so the operand stream legitimately differs).
+    def norm(t):
+        return "\n".join(
+            l for l in t.strip().splitlines()
+            if not re.match(r"^- .*Verilog \$finish", l)
+        ).strip()
+    outs = {k: norm(v) for k, v in outputs.items()}
+    if d.get("random"):
+        outs.pop("verilator", None)
+    if len(set(outs.values())) > 1:
+        res["output_mismatch"] = {k: v[-200:] for k, v in outs.items()}
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--filter", default="")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--legs", default="bluesim,verilator,trs")
+    ap.add_argument("--out", default="bench-results.json")
+    args = ap.parse_args()
+    legs = [l for l in args.legs.split(",") if l]
+    work = os.environ.get("BENCH_WORK") or os.path.join(
+        os.environ.get("TMPDIR", "/tmp"), f"trs-bench-{os.getpid()}")
+    os.makedirs(work, exist_ok=True)
+    results = []
+    for d in POOL:
+        if args.filter and args.filter not in d["name"]:
+            continue
+        print(f"== {d['name']} ({d['character']})", flush=True)
+        res = bench_one(d, legs, args.runs, work)
+        results.append(res)
+        for leg, L in res["legs"].items():
+            if "error" in L:
+                print(f"   {leg:9} ERROR {L['error'][:120]}")
+            else:
+                extra = f" {L['mcycles_per_s']} Mc/s" if "mcycles_per_s" in L else ""
+                print(f"   {leg:9} build {L.get('frontend_s', 0):7.2f}+"
+                      f"{L.get('backend_s', 0):7.2f}s  run {L.get('run_s', 0):8.3f}s"
+                      f"  rss {L.get('max_rss_kb', 0) // 1024}MB{extra}")
+        if "output_mismatch" in res:
+            print("   !! OUTPUT MISMATCH across legs")
+    with open(args.out, "w") as f:
+        json.dump(results, f, indent=1)
+    print(f"results: {args.out}  (workdir kept: {work})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -56,10 +56,10 @@ POOL = [
          character="huge rule count per cycle (scheduler-bound)"),
     # FP pipeline dataflow (PAClib DFT, 64-pt): FIFOs + FP mul/add
     dict(name="DFT64v1", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
-         src="Tb.bsv", top="sysTb_v1", cycles=None,
+         src="Tb_v1.bsv", top="sysTb_v1", cycles=None,
          character="FP dataflow pipeline, FIFO-heavy"),
     dict(name="DFT64v5", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
-         src="Tb.bsv", top="sysTb_v5", cycles=None,
+         src="Tb_v5.bsv", top="sysTb_v5", cycles=None,
          character="FP dataflow, deeper variant"),
     # FP arithmetic battery (add/mul/div/sqrt corner cases)
     dict(name="FloatTest", dir="testsuite/bsc.lib/FloatingPoint",
@@ -75,7 +75,7 @@ POOL = [
          character="BRAM variants battery, wide state"),
     # combinational search (sudoku generator)
     dict(name="Sudoku", dir="testsuite/bsc.bsv_examples/sudoku",
-         src="GenerateTest.bsv", top="mkGenerateTest3", cycles=None,
+         src="GenerateTest3.bsv", top="mkGenerateTest3", cycles=None,
          character="deep combinational cones, backtracking search"),
     # iterative arithmetic (Randomize-fed dividers)
     dict(name="Dividers", dir="testsuite/bsc.lib/Divide",
@@ -85,10 +85,12 @@ POOL = [
     # sparse RegFile addressing
     dict(name="SparseRF", dir="testsuite/bsc.bluesim/misc",
          src="SparseRF.bsv", top="sysSparseRF", cycles=None,
-         character="RegFile range traffic"),
+         character="RegFile range traffic",
+         no_verilator="RegFile over a 42-bit index elaborates to a "
+                      "2^42-entry Verilog array"),
     # packet-processing app (mesa)
-    dict(name="Mesa", dir="testsuite/bsc.bsv_examples/mesa",
-         src="mkTestMesa.bsv", top="sysTestMesa", cycles=None,
+    dict(name="Mesa", dir="testsuite/bsc.bsv_examples/mesa/spiless-tx-bsv",
+         src="TestMesa.bsv", top="sysTestMesa", cycles=None,
          character="app-scale packet pipeline"),
 ]
 
@@ -160,12 +162,24 @@ def run_measured(cmd, cwd, runs):
                 max_rss_kb=rss), out
 
 
+def _err(r):
+    """Error lines from a failed command, not just the output tail —
+    bsc prints warnings after errors, so a blind tail shows the wrong
+    thing."""
+    txt = (r.stderr or "") + "\n" + (r.stdout or "")
+    lines = [l for l in txt.splitlines() if re.search(r"\berror\b", l, re.I)]
+    return (" | ".join(lines)[:300]) if lines else txt[-300:]
+
+
 def bench_one(d, legs, runs, work):
     res = dict(name=d["name"], top=d["top"], character=d["character"], legs={})
     src_dir = os.path.join(REPO, d["dir"])
     top = d["top"]
     outputs = {}
     for leg in legs:
+        if leg == "verilator" and d.get("no_verilator"):
+            res["legs"][leg] = {"skipped": d["no_verilator"]}
+            continue
         wk = os.path.join(work, d["name"], leg)
         os.makedirs(wk, exist_ok=True)
         for f in os.listdir(src_dir):
@@ -174,20 +188,23 @@ def bench_one(d, legs, runs, work):
                     shutil.copy(os.path.join(src_dir, f), wk)
                 except OSError:
                     pass
-        common = ["-bdir", wk, "-info-dir", wk, "-simdir", wk, "-vdir", wk,
-                  "-p", wk + ":+"]
+        # no -p: -bdir already heads the search path with wk (an
+        # explicit "-p wk:+" duplicates it and bsc's S0073 warning then
+        # buries real errors in the reported tail), and the default
+        # path keeps "." (= wk, the cwd) and the libraries
+        common = ["-bdir", wk, "-info-dir", wk, "-simdir", wk, "-vdir", wk]
         L = {}
         if leg in ("bluesim", "trs"):
             r, t = sh([BSC, "-sim", "-u", "-g", top] + common + [d["src"]], wk)
             if r.returncode != 0:
-                L["error"] = "bsc compile: " + (r.stderr or r.stdout)[-300:]
+                L["error"] = "bsc compile: " + _err(r)
                 res["legs"][leg] = L
                 continue
             L["frontend_s"] = round(t, 2)
             if leg == "bluesim":
                 r, t = sh([BSC, "-sim", "-e", top, "-o", "simb"] + common, wk)
                 if r.returncode != 0:
-                    L["error"] = "bluesim link: " + (r.stderr or r.stdout)[-300:]
+                    L["error"] = "bluesim link: " + _err(r)
                     res["legs"][leg] = L
                     continue
                 L["backend_s"] = round(t, 2)
@@ -197,12 +214,12 @@ def bench_one(d, legs, runs, work):
                 r, t = sh([BSC, "-sim", "-bir", "-e", top, "-o", "simr"] + common, wk)
                 bir = os.path.join(wk, top + ".bir")
                 if not os.path.exists(bir):
-                    L["error"] = "no .bir: " + (r.stderr or r.stdout)[-300:]
+                    L["error"] = "no .bir: " + _err(r)
                     res["legs"][leg] = L
                     continue
                 r2, t2 = sh([TRS, "link", bir, "-o", "art"], wk)
                 if r2.returncode != 0:
-                    L["error"] = "trs link: " + (r2.stderr or r2.stdout)[-300:]
+                    L["error"] = "trs link: " + _err(r2)
                     res["legs"][leg] = L
                     continue
                 L["backend_s"] = round(t2, 2)
@@ -212,7 +229,7 @@ def bench_one(d, legs, runs, work):
         else:  # verilator
             r, t = sh([BSC, "-verilog", "-u", "-g", top] + common + [d["src"]], wk)
             if r.returncode != 0:
-                L["error"] = "bsc -verilog: " + (r.stderr or r.stdout)[-300:]
+                L["error"] = "bsc -verilog: " + _err(r)
                 res["legs"][leg] = L
                 continue
             L["frontend_s"] = round(t, 2)
@@ -254,7 +271,7 @@ def bench_one(d, legs, runs, work):
                        "-y", os.path.abspath(vdir),
                        top + ".v", "bench_main.cpp", "-o", "simv"], wk)
             if r.returncode != 0:
-                L["error"] = "verilator: " + (r.stderr or r.stdout)[-300:]
+                L["error"] = "verilator: " + _err(r)
                 res["legs"][leg] = L
                 continue
             L["backend_s"] = round(t, 2)
@@ -282,7 +299,21 @@ def bench_one(d, legs, runs, work):
     outs = {k: norm(v) for k, v in outputs.items()}
     if d.get("random"):
         outs.pop("verilator", None)
-    if len(set(outs.values())) > 1:
+    # Verilator's $finish sets a flag but finishes evaluating the
+    # instant, so sibling always-blocks may print same-instant lines
+    # that abort-immediately semantics (Bluesim, trs) never reach: the
+    # bsc legs must match byte-exactly, and the verilator leg must
+    # EXTEND that common output (prefix match), never diverge from it.
+    vl = outs.pop("verilator", None)
+    mismatch = len(set(outs.values())) > 1
+    if not mismatch and vl is not None and outs:
+        base = next(iter(outs.values()))
+        if not (vl == base or vl.startswith(base)):
+            mismatch = True
+        outs["verilator"] = vl
+    if mismatch:
+        if vl is not None:
+            outs["verilator"] = vl
         res["output_mismatch"] = {k: v[-200:] for k, v in outs.items()}
     return res
 

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -118,9 +118,18 @@ int main(int argc, char** argv) {
 """
 
 
+# Benchmark hygiene: a stray TRS_SELFCHECK=1 in the caller's shell
+# (say, right after a suite run) would silently run lockstep shadows
+# inside the trs leg and triple its numbers.  The selfcheck is a
+# validation mode, never a benchmark mode — scrub its knobs (and the
+# jit trace) from every child environment.
+_ENV = {k: v for k, v in os.environ.items()
+        if not k.startswith("TRS_SELFCHECK") and k != "TRS_JIT_TRACE"}
+
+
 def sh(cmd, cwd, env=None, timeout=7200):
     t0 = time.monotonic()
-    r = subprocess.run(cmd, cwd=cwd, env=env or os.environ,
+    r = subprocess.run(cmd, cwd=cwd, env=env or _ENV,
                        capture_output=True, text=True, timeout=timeout)
     return r, time.monotonic() - t0
 

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -30,10 +30,10 @@ import argparse
 import json
 import os
 import re
-import resource
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -135,17 +135,25 @@ def sh(cmd, cwd, env=None, timeout=7200):
 
 
 def run_measured(cmd, cwd, runs):
-    """Median wall + max RSS over `runs` executions (children rusage)."""
+    """Median wall + max RSS over `runs` executions.
+
+    RSS comes from /usr/bin/time %M per run, NOT from
+    getrusage(RUSAGE_CHILDREN): ru_maxrss there is a cumulative
+    high-water mark over every child ever waited on, so one big build
+    child (bsc peaks ~300MB) masquerades as every later run's RSS.
+    """
     walls, rss = [], 0
     out = None
     for _ in range(runs):
-        before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-        r, w = sh(cmd, cwd)
-        after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-        if r.returncode not in (0,):
-            return None, r
+        with tempfile.NamedTemporaryFile(mode="r", suffix=".rss") as tf:
+            r, w = sh(["/usr/bin/time", "-f", "%M", "-o", tf.name] + cmd, cwd)
+            if r.returncode not in (0,):
+                return None, r
+            try:
+                rss = max(rss, int(tf.read().strip().splitlines()[-1]))
+            except (ValueError, IndexError):
+                pass
         walls.append(w)
-        rss = max(rss, after if after > before else before)
         out = r
     walls.sort()
     return dict(wall=walls[len(walls) // 2], walls=walls,

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -199,12 +199,12 @@ def bench_one(d, legs, runs, work):
                 res["legs"][leg] = L
                 continue
             L["frontend_s"] = round(t, 2)
-            # bsc's system-task blocks open with a literal `#0;` (an
-            # intra-negedge ordering guard).  Under the C++ driver the
-            # negedge instant is a plain eval long after posedge NBAs
-            # settle, so the guard is inert — strip it rather than
-            # reaching for --timing/--no-timing (per Ravi: --timing has
-            # known issues; --no-timing would ignore delays silently).
+            # bsc >= this tree emits the system-task blocks' 0-tick
+            # ordering guard as `BSV_ZERO_DELAY (defined away below);
+            # the strip stays as a fallback for benchmarking OLDER bsc
+            # revisions, whose literal `#0;` predates the macro.  It is
+            # inert under the C++ driver either way (the negedge
+            # instant is a plain eval long after posedge NBAs settle).
             for vf in os.listdir(wk):
                 if vf.endswith(".v"):
                     pv = os.path.join(wk, vf)
@@ -222,7 +222,8 @@ def bench_one(d, legs, runs, work):
             # so the Verilog is genuinely delay-free and anything else
             # timing-shaped errors loudly for explicit handling
             r, t = sh(["verilator", "--cc", "--exe", "--build", "-j", "4",
-                       "+define+BSV_ASSIGNMENT_DELAY=", "-O3", "-Wno-fatal",
+                       "+define+BSV_ASSIGNMENT_DELAY=",
+                       "+define+BSV_ZERO_DELAY=", "-O3", "-Wno-fatal",
                        "--x-assign", "fast", "--x-initial", "fast",
                        "-y", os.path.abspath(vdir),
                        top + ".v", "bench_main.cpp", "-o", "simv"], wk)

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -183,7 +183,13 @@ def bench_one(d, legs, runs, work):
         wk = os.path.join(work, d["name"], leg)
         os.makedirs(wk, exist_ok=True)
         for f in os.listdir(src_dir):
-            if f.endswith((".bsv", ".bs", ".c", ".h", ".hex", ".bin", ".dat", ".txt", ".vec")):
+            # same input set as diffsweep's _GOLD_INPUTS: data files
+            # shape the OUTPUT (Mesa's LPM tables load from
+            # .handbuilt via RegFileLoad — without them every leg
+            # simulates empty tables, Verilator's $readmem fatally)
+            if f.endswith((".bsv", ".bs", ".c", ".h", ".hex", ".bin",
+                           ".dat", ".txt", ".vec", ".mem", ".input",
+                           ".vectors", ".handbuilt", ".rom", ".data")):
                 try:
                     shutil.copy(os.path.join(src_dir, f), wk)
                 except OSError:
@@ -193,6 +199,16 @@ def bench_one(d, legs, runs, work):
         # buries real errors in the reported tail), and the default
         # path keeps "." (= wk, the cwd) and the libraries
         common = ["-bdir", wk, "-info-dir", wk, "-simdir", wk, "-vdir", wk]
+        # BDPI designs need the user's C files at link (diffsweep does
+        # the same); bsc's -e link also emits the .bdpi.so the trs
+        # artifact loads
+        cfiles = sorted(f for f in os.listdir(wk)
+                        if f.endswith(".c") and not f.startswith("vpi_"))
+        has_bdpi = any('import "BDPI"' in open(os.path.join(wk, f),
+                                               errors="replace").read()
+                       for f in os.listdir(wk) if f.endswith(".bsv"))
+        if not has_bdpi:
+            cfiles = []
         L = {}
         if leg in ("bluesim", "trs"):
             r, t = sh([BSC, "-sim", "-u", "-g", top] + common + [d["src"]], wk)
@@ -202,7 +218,7 @@ def bench_one(d, legs, runs, work):
                 continue
             L["frontend_s"] = round(t, 2)
             if leg == "bluesim":
-                r, t = sh([BSC, "-sim", "-e", top, "-o", "simb"] + common, wk)
+                r, t = sh([BSC, "-sim", "-e", top, "-o", "simb"] + common + cfiles, wk)
                 if r.returncode != 0:
                     L["error"] = "bluesim link: " + _err(r)
                     res["legs"][leg] = L
@@ -211,7 +227,7 @@ def bench_one(d, legs, runs, work):
                 m, r = run_measured(["./simb"], wk, runs)
                 exe = "./simb"
             else:
-                r, t = sh([BSC, "-sim", "-bir", "-e", top, "-o", "simr"] + common, wk)
+                r, t = sh([BSC, "-sim", "-bir", "-e", top, "-o", "simr"] + common + cfiles, wk)
                 bir = os.path.join(wk, top + ".bir")
                 if not os.path.exists(bir):
                     L["error"] = "no .bir: " + _err(r)
@@ -227,7 +243,8 @@ def bench_one(d, legs, runs, work):
                 m, r = run_measured(["./art"], wk, runs)
                 exe = "./art"
         else:  # verilator
-            r, t = sh([BSC, "-verilog", "-u", "-g", top] + common + [d["src"]], wk)
+            t_dpi = ["-use-dpi"] if cfiles else []
+            r, t = sh([BSC, "-verilog", "-u", "-g", top] + t_dpi + common + [d["src"]], wk)
             if r.returncode != 0:
                 L["error"] = "bsc -verilog: " + _err(r)
                 res["legs"][leg] = L
@@ -269,7 +286,7 @@ def bench_one(d, legs, runs, work):
                        "-O3", "-Wno-fatal",
                        "--x-assign", "fast", "--x-initial", "fast",
                        "-y", os.path.abspath(vdir),
-                       top + ".v", "bench_main.cpp", "-o", "simv"], wk)
+                       top + ".v", "bench_main.cpp"] + cfiles + ["-o", "simv"], wk)
             if r.returncode != 0:
                 L["error"] = "verilator: " + _err(r)
                 res["legs"][leg] = L
@@ -337,6 +354,9 @@ def main():
         res = bench_one(d, legs, args.runs, work)
         results.append(res)
         for leg, L in res["legs"].items():
+            if "skipped" in L:
+                print(f"   {leg:9} skipped: {L['skipped']}")
+                continue
             if "error" in L:
                 print(f"   {leg:9} ERROR {L['error'][:120]}")
             else:

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -57,10 +57,14 @@ POOL = [
     # FP pipeline dataflow (PAClib DFT, 64-pt): FIFOs + FP mul/add
     dict(name="DFT64v1", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
          src="Tb_v1.bsv", top="sysTb_v1", cycles=None,
-         character="FP dataflow pipeline, FIFO-heavy"),
+         character="FP dataflow pipeline, FIFO-heavy",
+         vl_out_exempt="prints %t (always 0 untimed) and BDPI printf "
+                       "interleaves differently with $display"),
     dict(name="DFT64v5", dir="testsuite/bsc.lib/PAClib/dft64/bsv",
          src="Tb_v5.bsv", top="sysTb_v5", cycles=None,
-         character="FP dataflow, deeper variant"),
+         character="FP dataflow, deeper variant",
+         vl_out_exempt="prints %t (always 0 untimed) and BDPI printf "
+                       "interleaves differently with $display"),
     # FP arithmetic battery (add/mul/div/sqrt corner cases)
     dict(name="FloatTest", dir="testsuite/bsc.lib/FloatingPoint",
          src="FloatTest.bsv", top="sysFloatTest", cycles=None,
@@ -269,6 +273,15 @@ def bench_one(d, legs, runs, work):
                         open(pv, "w").write(txt2)
             with open(os.path.join(wk, "bench_main.cpp"), "w") as f:
                 f.write(VL_MAIN.replace("%TOP%", top))
+            # Verilator's makefile compiles user .c with $(CXX), which
+            # mangles the symbols the DPI imports expect unmangled —
+            # wrap each user C file in an extern "C" include shim
+            vl_cfiles = []
+            for i, cf in enumerate(cfiles):
+                shim = f"bench_dpi_{i}.cpp"
+                with open(os.path.join(wk, shim), "w") as f:
+                    f.write('extern "C" {\n#include "%s"\n}\n' % cf)
+                vl_cfiles.append(shim)
             vdir = os.path.join(os.path.dirname(shutil.which(BSC) or BSC),
                                 "..", "lib", "Verilog")
             # no timing flags at all (per Ravi: --timing has known
@@ -290,7 +303,7 @@ def bench_one(d, legs, runs, work):
                        "-O3", "-Wno-fatal",
                        "--x-assign", "fast", "--x-initial", "fast",
                        "-y", os.path.abspath(vdir),
-                       top + ".v", "bench_main.cpp"] + cfiles + ["-o", "simv"], wk)
+                       top + ".v", "bench_main.cpp"] + vl_cfiles + ["-o", "simv"], wk)
             if r.returncode != 0:
                 L["error"] = "verilator: " + _err(r)
                 res["legs"][leg] = L
@@ -318,7 +331,7 @@ def bench_one(d, legs, runs, work):
             if not re.match(r"^- .*Verilog \$finish", l)
         ).strip()
     outs = {k: norm(v) for k, v in outputs.items()}
-    if d.get("random"):
+    if d.get("random") or d.get("vl_out_exempt"):
         outs.pop("verilator", None)
     # Verilator's $finish sets a flag but finishes evaluating the
     # instant, so sibling always-blocks may print same-instant lines

--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -209,7 +209,7 @@ def bench_one(d, legs, runs, work):
                 continue
             L["frontend_s"] = round(t, 2)
             # bsc >= this tree emits the system-task blocks' 0-tick
-            # ordering guard as `BSV_ZERO_DELAY (defined away below);
+            # ordering guard as `BSV_TASKS_DELAY (defined away below);
             # the strip stays as a fallback for benchmarking OLDER bsc
             # revisions, whose literal `#0;` predates the macro.  It is
             # inert under the C++ driver either way (the negedge
@@ -232,7 +232,9 @@ def bench_one(d, legs, runs, work):
             # timing-shaped errors loudly for explicit handling
             r, t = sh(["verilator", "--cc", "--exe", "--build", "-j", "4",
                        "+define+BSV_ASSIGNMENT_DELAY=",
-                       "+define+BSV_ZERO_DELAY=", "-O3", "-Wno-fatal",
+                       "+define+BSV_TASKS_DELAY=",
+                       "+define+BSV_ZERO_DELAY=",  # transitional name, harmless if unused
+                       "-O3", "-Wno-fatal",
                        "--x-assign", "fast", "--x-initial", "fast",
                        "-y", os.path.abspath(vdir),
                        top + ".v", "bench_main.cpp", "-o", "simv"], wk)

--- a/testsuite/bsc.arrays/dynamic/sysActionVec.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysActionVec.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/dynamic/sysActionVec.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysActionVec.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/dynamic/sysActionVecShortIndex.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysActionVecShortIndex.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/dynamic/sysActionVecShortIndex.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysActionVecShortIndex.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/dynamic/sysDisplayConstArray.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysDisplayConstArray.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -81,7 +86,7 @@ module sysDisplayConstArray(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display(CASE_idx_0_17_1_2_2_42_3_22_DONTCARE__q1);
   end

--- a/testsuite/bsc.arrays/dynamic/sysDisplayConstArray.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysDisplayConstArray.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -86,7 +86,7 @@ module sysDisplayConstArray(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display(CASE_idx_0_17_1_2_2_42_3_22_DONTCARE__q1);
   end

--- a/testsuite/bsc.arrays/dynamic/sysDisplayDynConstArray.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysDisplayDynConstArray.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -105,7 +105,7 @@ module sysDisplayDynConstArray(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display(CASE_idx_0_IF_c_THEN_1_ELSE_4_1_IF_c_THEN_2_EL_ETC__q1);
   end

--- a/testsuite/bsc.arrays/dynamic/sysDisplayDynConstArray.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysDisplayDynConstArray.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -100,7 +105,7 @@ module sysDisplayDynConstArray(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display(CASE_idx_0_IF_c_THEN_1_ELSE_4_1_IF_c_THEN_2_EL_ETC__q1);
   end

--- a/testsuite/bsc.arrays/dynamic/sysRegOfVec.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysRegOfVec.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/dynamic/sysRegOfVec.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysRegOfVec.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/dynamic/sysRegToReg.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysRegToReg.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -110,7 +115,7 @@ module sysRegToReg(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (done) $finish(32'd0);
   end
   // synopsys translate_on

--- a/testsuite/bsc.arrays/dynamic/sysRegToReg.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysRegToReg.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -115,7 +115,7 @@ module sysRegToReg(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (done) $finish(32'd0);
   end
   // synopsys translate_on

--- a/testsuite/bsc.arrays/dynamic/sysVecCondAction.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysVecCondAction.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/dynamic/sysVecCondAction.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysVecCondAction.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/dynamic/sysVecOfReg.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysVecOfReg.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/dynamic/sysVecOfReg.v.expected
+++ b/testsuite/bsc.arrays/dynamic/sysVecOfReg.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/undefined/sysSelectActionUndefinedIndex.v.expected
+++ b/testsuite/bsc.arrays/undefined/sysSelectActionUndefinedIndex.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/undefined/sysSelectActionUndefinedIndex.v.expected
+++ b/testsuite/bsc.arrays/undefined/sysSelectActionUndefinedIndex.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.arrays/undefined/sysSelectListActionUndefinedIndex.v.expected
+++ b/testsuite/bsc.arrays/undefined/sysSelectListActionUndefinedIndex.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.arrays/undefined/sysSelectListActionUndefinedIndex.v.expected
+++ b/testsuite/bsc.arrays/undefined/sysSelectListActionUndefinedIndex.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b1354/mkMulti.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1354/mkMulti.v.expected
@@ -32,9 +32,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b1354/mkMulti.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1354/mkMulti.v.expected
@@ -32,6 +32,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1390/mkTest2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b1540/mkFOO.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1540/mkFOO.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -72,7 +72,7 @@ module mkFOO(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (addr[31:4] == 28'h0) $display("a");
     if (RST_N != `BSV_RESET_VALUE)
       if (addr[31:4] == 28'h0000001) $display("b");

--- a/testsuite/bsc.bugs/bluespec_inc/b1540/mkFOO.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b1540/mkFOO.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -67,7 +72,7 @@ module mkFOO(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (addr[31:4] == 28'h0) $display("a");
     if (RST_N != `BSV_RESET_VALUE)
       if (addr[31:4] == 28'h0000001) $display("b");

--- a/testsuite/bsc.bugs/bluespec_inc/b262/sysBug262Opt.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b262/sysBug262Opt.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -86,7 +91,7 @@ module sysBug262Opt(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (done) $finish(32'd0);
   end
   // synopsys translate_on

--- a/testsuite/bsc.bugs/bluespec_inc/b262/sysBug262Opt.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b262/sysBug262Opt.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -91,7 +91,7 @@ module sysBug262Opt(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) if (done) $finish(32'd0);
   end
   // synopsys translate_on

--- a/testsuite/bsc.bugs/bluespec_inc/b264/foo.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/foo.v.expected
@@ -32,9 +32,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b264/foo.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/foo.v.expected
@@ -32,6 +32,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign_in.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign_in.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign_in.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/mkDesign_in.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b264/top.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/top.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b264/top.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/top.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b264/top2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/top2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b264/top2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b264/top2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b292/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b292/mkDesign.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b292/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b292/mkDesign.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b293/mkDesign1.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b293/mkDesign1.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b293/mkDesign1.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b293/mkDesign1.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
@@ -20,9 +20,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b302/mkDesign.v.expected
@@ -20,6 +20,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b378/mkCTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b378/mkCTest.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b378/mkCTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b378/mkCTest.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b378/mkTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b378/mkTest.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b378/mkTest.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b378/mkTest.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b405/module_cmsb.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b405/module_cmsb.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b405/module_cmsb.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b405/module_cmsb.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b569/mkAddSub.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b569/mkAddSub.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.bugs/bluespec_inc/b569/mkAddSub.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b569/mkAddSub.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b569/tb.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b569/tb.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -57,7 +57,7 @@ module tb(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display("5+6=%d", dut$start);
     $finish(32'd0);
   end

--- a/testsuite/bsc.bugs/bluespec_inc/b569/tb.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b569/tb.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -52,7 +57,7 @@ module tb(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display("5+6=%d", dut$start);
     $finish(32'd0);
   end

--- a/testsuite/bsc.bugs/bluespec_inc/b834/mkRegisterFileFixed_3_2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b834/mkRegisterFileFixed_3_2.v.expected
@@ -42,9 +42,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.bugs/bluespec_inc/b834/mkRegisterFileFixed_3_2.v.expected
+++ b/testsuite/bsc.bugs/bluespec_inc/b834/mkRegisterFileFixed_3_2.v.expected
@@ -42,6 +42,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.codegen/vector_interfaces/mkClockListNPassThrough.v.expected
+++ b/testsuite/bsc.codegen/vector_interfaces/mkClockListNPassThrough.v.expected
@@ -25,6 +25,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.codegen/vector_interfaces/mkClockListNPassThrough.v.expected
+++ b/testsuite/bsc.codegen/vector_interfaces/mkClockListNPassThrough.v.expected
@@ -25,9 +25,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.codegen/vector_interfaces/mkClockVectorPassThrough.v.expected
+++ b/testsuite/bsc.codegen/vector_interfaces/mkClockVectorPassThrough.v.expected
@@ -29,9 +29,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.codegen/vector_interfaces/mkClockVectorPassThrough.v.expected
+++ b/testsuite/bsc.codegen/vector_interfaces/mkClockVectorPassThrough.v.expected
@@ -29,6 +29,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.doc/UserGuide_mkGCD.v.expected
+++ b/testsuite/bsc.doc/UserGuide_mkGCD.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.doc/UserGuide_mkGCD.v.expected
+++ b/testsuite/bsc.doc/UserGuide_mkGCD.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.doc/sysUserGuide_RegInsts.v.expected
+++ b/testsuite/bsc.doc/sysUserGuide_RegInsts.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.doc/sysUserGuide_RegInsts.v.expected
+++ b/testsuite/bsc.doc/sysUserGuide_RegInsts.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/curry/mkWhenCurry.v.expected
+++ b/testsuite/bsc.evaluator/curry/mkWhenCurry.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -94,7 +99,7 @@ module mkWhenCurry(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (WILL_FIRE_RL_go) $display($signed(switch ? 32'd6 : 32'd7));
     if (RST_N != `BSV_RESET_VALUE) if (WILL_FIRE_RL_go) $finish(32'd0);

--- a/testsuite/bsc.evaluator/curry/mkWhenCurry.v.expected
+++ b/testsuite/bsc.evaluator/curry/mkWhenCurry.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -99,7 +99,7 @@ module mkWhenCurry(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (WILL_FIRE_RL_go) $display($signed(switch ? 32'd6 : 32'd7));
     if (RST_N != `BSV_RESET_VALUE) if (WILL_FIRE_RL_go) $finish(32'd0);

--- a/testsuite/bsc.evaluator/opt/mkBigRangeUpdate.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigRangeUpdate.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkBigRangeUpdate.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigRangeUpdate.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkBigReplaceBitOpt.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigReplaceBitOpt.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkBigReplaceBitOpt.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigReplaceBitOpt.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkBigXor.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigXor.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkBigXor.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigXor.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkBigXor2.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigXor2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkBigXor2.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkBigXor2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkLTEMinusOne.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkLTEMinusOne.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkLTEMinusOne.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkLTEMinusOne.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkReplaceBitOpt.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkReplaceBitOpt.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkReplaceBitOpt.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkReplaceBitOpt.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkSLTZero.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkSLTZero.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/opt/mkSLTZero.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkSLTZero.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkShiftBit1.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkShiftBit1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/opt/mkShiftBit1.v.expected
+++ b/testsuite/bsc.evaluator/opt/mkShiftBit1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/sysITransformConcatIf.v.expected
+++ b/testsuite/bsc.evaluator/sysITransformConcatIf.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.evaluator/sysITransformConcatIf.v.expected
+++ b/testsuite/bsc.evaluator/sysITransformConcatIf.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.evaluator/undefined/sysArrayReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysArrayReg3D.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -1383,7 +1383,7 @@ module sysArrayReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("r3[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysArrayReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysArrayReg3D.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -1378,7 +1383,7 @@ module sysArrayReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("r3[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysListNReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysListNReg3D.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -1320,7 +1320,7 @@ module sysListNReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("lns[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysListNReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysListNReg3D.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -1315,7 +1320,7 @@ module sysListNReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("lns[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysListReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysListReg3D.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -1320,7 +1320,7 @@ module sysListReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("ls[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysListReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysListReg3D.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -1315,7 +1320,7 @@ module sysListReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("ls[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysRegSelect2.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysRegSelect2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -6222,7 +6222,7 @@ module sysRegSelect2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (count == 17'd512) $display("%0d", regs_0);
     if (RST_N != `BSV_RESET_VALUE)

--- a/testsuite/bsc.evaluator/undefined/sysRegSelect2.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysRegSelect2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -6217,7 +6222,7 @@ module sysRegSelect2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (count == 17'd512) $display("%0d", regs_0);
     if (RST_N != `BSV_RESET_VALUE)

--- a/testsuite/bsc.evaluator/undefined/sysVectorReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysVectorReg3D.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -1378,7 +1383,7 @@ module sysVectorReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("vs[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.evaluator/undefined/sysVectorReg3D.v.expected
+++ b/testsuite/bsc.evaluator/undefined/sysVectorReg3D.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -1383,7 +1383,7 @@ module sysVectorReg3D(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       if (k == 8'd4)
 	$display("vs[%0d][%0d][%0d] = %0d",

--- a/testsuite/bsc.lib/Cntrs/sysCntrSched.v.expected
+++ b/testsuite/bsc.lib/Cntrs/sysCntrSched.v.expected
@@ -25,6 +25,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.lib/Cntrs/sysCntrSched.v.expected
+++ b/testsuite/bsc.lib/Cntrs/sysCntrSched.v.expected
@@ -25,9 +25,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.lib/IsModule/mkFIFOContextTest.v.expected
+++ b/testsuite/bsc.lib/IsModule/mkFIFOContextTest.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -172,7 +177,7 @@ module mkFIFOContextTest(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display("I love the number %0d", $signed(32'd7));
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/IsModule/mkFIFOContextTest.v.expected
+++ b/testsuite/bsc.lib/IsModule/mkFIFOContextTest.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -177,7 +177,7 @@ module mkFIFOContextTest(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display("I love the number %0d", $signed(32'd7));
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire.v1.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire.v1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -84,7 +89,7 @@ module mkTestENBypassWire(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display("Wire: %h", counter_MUL_counter___d5[31:0]);
   end

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire.v1.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire.v1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -89,7 +89,7 @@ module mkTestENBypassWire(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE)
       $display("Wire: %h", counter_MUL_counter___d5[31:0]);
   end

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire.v2.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire.v2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -99,7 +99,7 @@ module mkTestENBypassWire(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire.v2.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire.v2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -94,7 +99,7 @@ module mkTestENBypassWire(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -96,7 +101,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -101,7 +101,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.no-inline-rwire.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.no-inline-rwire.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -99,7 +99,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.no-inline-rwire.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v.no-inline-rwire.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -94,7 +99,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$WGET);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -90,7 +95,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$wget);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
+++ b/testsuite/bsc.lib/rwire/mkTestENBypassWire2.v1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -95,7 +95,7 @@ module mkTestENBypassWire2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (RST_N != `BSV_RESET_VALUE) $display("Wire: %h", testWire$wget);
   end
   // synopsys translate_on

--- a/testsuite/bsc.lib/rwire/sysBypassReg.v.expected
+++ b/testsuite/bsc.lib/rwire/sysBypassReg.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.lib/rwire/sysBypassReg.v.expected
+++ b/testsuite/bsc.lib/rwire/sysBypassReg.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.lib/rwire/sysConfigReg.v.expected
+++ b/testsuite/bsc.lib/rwire/sysConfigReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.lib/rwire/sysConfigReg.v.expected
+++ b/testsuite/bsc.lib/rwire/sysConfigReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue1.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue1.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK1.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK1.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK2.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK2.v.expected
+++ b/testsuite/bsc.mcd/DisabledClocks/mkDefaultValue2OK2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.names/portRenaming/vectorTests/mkTest01.v.expected
+++ b/testsuite/bsc.names/portRenaming/vectorTests/mkTest01.v.expected
@@ -36,6 +36,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.names/portRenaming/vectorTests/mkTest01.v.expected
+++ b/testsuite/bsc.names/portRenaming/vectorTests/mkTest01.v.expected
@@ -36,9 +36,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.names/portRenaming/vectorTests/mkTest02.v.expected
+++ b/testsuite/bsc.names/portRenaming/vectorTests/mkTest02.v.expected
@@ -96,6 +96,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.names/portRenaming/vectorTests/mkTest02.v.expected
+++ b/testsuite/bsc.names/portRenaming/vectorTests/mkTest02.v.expected
@@ -96,9 +96,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqCross.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqCross.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -99,7 +104,7 @@ module sysUseCondEqCross(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqCross.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqCross.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqCross.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -104,7 +104,7 @@ module sysUseCondEqCross(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqCross.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -104,7 +104,7 @@ module sysUseCondEqNEqCross1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqNEqCross1.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source1.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -99,7 +104,7 @@ module sysUseCondEqNEqCross1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqNEqCross1.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source1.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -104,7 +104,7 @@ module sysUseCondEqNEqCross2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqNEqCross2.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqNEqCross2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -99,7 +104,7 @@ module sysUseCondEqNEqCross2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display(shared__h204);
     if (a == 16'd1)
       $display("Error: \"UseCondEqNEqCross2.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVar1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVar1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -93,7 +98,7 @@ module sysUseCondEqVar1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a == 16'd1 || a == 16'd0)
       $display("Error: \"UseCondEqVar1.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVar1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVar1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -98,7 +98,7 @@ module sysUseCondEqVar1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a == 16'd1 || a == 16'd0)
       $display("Error: \"UseCondEqVar1.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -104,7 +109,7 @@ module sysUseCondEqVars1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a == 16'd1 && b == 16'd1 || a == 16'd0 && b == 16'd0)
       $display("Error: \"UseCondEqVars1.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -109,7 +109,7 @@ module sysUseCondEqVars1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a == 16'd1 && b == 16'd1 || a == 16'd0 && b == 16'd0)
       $display("Error: \"UseCondEqVars1.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -112,7 +117,7 @@ module sysUseCondEqVars2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if ((a == 16'd1 || a == 16'd0) && b == 16'd0)
       $display("Error: \"UseCondEqVars2.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondEqVars2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -117,7 +117,7 @@ module sysUseCondEqVars2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if ((a == 16'd1 || a == 16'd0) && b == 16'd0)
       $display("Error: \"UseCondEqVars2.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondFalseFalse.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondFalseFalse.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -112,7 +117,7 @@ module sysUseCondFalseFalse(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if ((!c || !b) && !a)
       $display("Error: \"UseCondFalseFalse.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondFalseFalse.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondFalseFalse.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -117,7 +117,7 @@ module sysUseCondFalseFalse(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if ((!c || !b) && !a)
       $display("Error: \"UseCondFalseFalse.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -107,7 +112,7 @@ module sysUseCondNEqVar1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar1.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -112,7 +112,7 @@ module sysUseCondNEqVar1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar1.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1b.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1b.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -112,7 +112,7 @@ module sysUseCondNEqVar1b(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar1b.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1b.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar1b.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -107,7 +112,7 @@ module sysUseCondNEqVar1b(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar1b.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -112,7 +112,7 @@ module sysUseCondNEqVar2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd2 && a != 16'd3 || a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar2.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -107,7 +112,7 @@ module sysUseCondNEqVar2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd2 && a != 16'd3 || a != 16'd0 && a != 16'd1)
       $display("Error: \"UseCondNEqVar2.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar3.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar3.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -107,7 +112,7 @@ module sysUseCondNEqVar3(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if ((a != 16'd2 || a != 16'd1) && a != 16'd0)
       $display("Error: \"UseCondNEqVar3.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar3.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar3.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -112,7 +112,7 @@ module sysUseCondNEqVar3(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if ((a != 16'd2 || a != 16'd1) && a != 16'd0)
       $display("Error: \"UseCondNEqVar3.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar4.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar4.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -112,7 +112,7 @@ module sysUseCondNEqVar4(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if ((a != 16'd2 || a != 16'd1) && a != 16'd0)
       $display("Error: \"UseCondNEqVar4.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar4.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVar4.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -107,7 +112,7 @@ module sysUseCondNEqVar4(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if ((a != 16'd2 || a != 16'd1) && a != 16'd0)
       $display("Error: \"UseCondNEqVar4.bsv\", line 16, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -104,7 +109,7 @@ module sysUseCondNEqVars1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd2 && b != 16'd3 || a != 16'd0 && b != 16'd1)
       $display("Error: \"UseCondNEqVars1.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -109,7 +109,7 @@ module sysUseCondNEqVars1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd2 && b != 16'd3 || a != 16'd0 && b != 16'd1)
       $display("Error: \"UseCondNEqVars1.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -109,7 +109,7 @@ module sysUseCondNEqVars2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if ((a != 16'd2 || a != 16'd0) && b != 16'd3)
       $display("Error: \"UseCondNEqVars2.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -104,7 +109,7 @@ module sysUseCondNEqVars2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if ((a != 16'd2 || a != 16'd0) && b != 16'd3)
       $display("Error: \"UseCondNEqVars2.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars3.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars3.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -104,7 +109,7 @@ module sysUseCondNEqVars3(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd2 && b != 16'd3)
       $display("Error: \"UseCondNEqVars3.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars3.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars3.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -109,7 +109,7 @@ module sysUseCondNEqVars3(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd2 && b != 16'd3)
       $display("Error: \"UseCondNEqVars3.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars4.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars4.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -123,7 +123,7 @@ module sysUseCondNEqVars4(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a != 16'd2 && a != 16'd3 || b != 16'd2 && b != 16'd3)
       $display("Error: \"UseCondNEqVars4.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars4.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondNEqVars4.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -118,7 +123,7 @@ module sysUseCondNEqVars4(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a != 16'd2 && a != 16'd3 || b != 16'd2 && b != 16'd3)
       $display("Error: \"UseCondNEqVars4.bsv\", line 17, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalse.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalse.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -112,7 +117,7 @@ module sysUseCondTrueFalse(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a && (!c || !b))
       $display("Error: \"UseCondTrueFalse.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalse.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalse.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -117,7 +117,7 @@ module sysUseCondTrueFalse(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a && (!c || !b))
       $display("Error: \"UseCondTrueFalse.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -103,7 +103,7 @@ module sysUseCondTrueFalseCross1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display(shared__h204);
     if (a)
       $display("Error: \"UseCondTrueFalseCross1.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source1.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross1.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -98,7 +103,7 @@ module sysUseCondTrueFalseCross1(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display(shared__h204);
     if (a)
       $display("Error: \"UseCondTrueFalseCross1.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source1.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -103,7 +103,7 @@ module sysUseCondTrueFalseCross2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display(shared__h204);
     if (!a)
       $display("Error: \"UseCondTrueFalseCross2.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross2.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueFalseCross2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -98,7 +103,7 @@ module sysUseCondTrueFalseCross2(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display(shared__h204);
     if (!a)
       $display("Error: \"UseCondTrueFalseCross2.bsv\", line 23, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source2.\n");

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueTrue.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueTrue.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -117,7 +117,7 @@ module sysUseCondTrueTrue(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     if (a && (c || b))
       $display("Error: \"UseCondTrueTrue.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.scheduler/use_cond/sysUseCondTrueTrue.v.expected
+++ b/testsuite/bsc.scheduler/use_cond/sysUseCondTrueTrue.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -112,7 +117,7 @@ module sysUseCondTrueTrue(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     if (a && (c || b))
       $display("Error: \"UseCondTrueTrue.bsv\", line 18, column 9: (R0002)\n  Conflict-free rules RL_test2 and RL_test1 called conflicting methods read\n  and write of module instance source.\n");
   end

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkClockFamily.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkClockFamily.v.expected
@@ -20,9 +20,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkClockFamily.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkClockFamily.v.expected
@@ -20,6 +20,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkPragmas.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkPragmas.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkPragmas.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkPragmas.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkProperties.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkProperties.v.expected
@@ -19,9 +19,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkProperties.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkProperties.v.expected
@@ -19,6 +19,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkSynthesize.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkSynthesize.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/mkSynthesize.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/mkSynthesize.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysGateDefaultClock.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysGateDefaultClock.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysGateDefaultClock.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysGateDefaultClock.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysGateExplicitClock.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysGateExplicitClock.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysGateExplicitClock.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysGateExplicitClock.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysPrefixes.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysPrefixes.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bh/bh_pragmas/sysPrefixes.v.expected
+++ b/testsuite/bsc.syntax/bh/bh_pragmas/sysPrefixes.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModule.v.expected
+++ b/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModule.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModule.v.expected
+++ b/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModule.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModuleClkGate.v.expected
+++ b/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModuleClkGate.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModuleClkGate.v.expected
+++ b/testsuite/bsc.syntax/bsv05/import-foreign/sysImportForeignModuleClkGate.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.syntax/bsv05/strings/sysOctalChars.v.expected
+++ b/testsuite/bsc.syntax/bsv05/strings/sysOctalChars.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -39,7 +39,7 @@ module sysOctalChars(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display("\000");
     $display("\001");
     $display("\002");

--- a/testsuite/bsc.syntax/bsv05/strings/sysOctalChars.v.expected
+++ b/testsuite/bsc.syntax/bsv05/strings/sysOctalChars.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -34,7 +39,7 @@ module sysOctalChars(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display("\000");
     $display("\001");
     $display("\002");

--- a/testsuite/bsc.typechecker/error_recovery/sysDefErrorRecovery.v.expected
+++ b/testsuite/bsc.typechecker/error_recovery/sysDefErrorRecovery.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge
@@ -34,7 +39,7 @@ module sysDefErrorRecovery(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    #0;
+    `BSV_ZERO_DELAY;
     $display("Test passed\n");
   end
   // synopsys translate_on

--- a/testsuite/bsc.typechecker/error_recovery/sysDefErrorRecovery.v.expected
+++ b/testsuite/bsc.typechecker/error_recovery/sysDefErrorRecovery.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET
@@ -39,7 +39,7 @@ module sysDefErrorRecovery(CLK,
   // synopsys translate_off
   always@(negedge CLK)
   begin
-    `BSV_ZERO_DELAY;
+    `BSV_TASKS_DELAY;
     $display("Test passed\n");
   end
   // synopsys translate_on

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1Test.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1Test.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1aReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1aReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1aReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1aReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1aTest.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1aTest.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt1aTest.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt1aTest.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt2Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt2Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt2Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt2Test.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt2Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt2Test.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt3Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt3Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt3Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt3Test.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt3Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt3Test.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt4Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt4Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt4Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt4Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt4Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt4Test.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt4Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt4Test.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt5Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt5Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt5Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt5Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt5Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt5Test.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt5Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt5Test.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt6Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt6Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt6Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt6Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkAlt6Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt6Test.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkAlt6Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkAlt6Test.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkC0Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC0Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkC0Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC0Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkC0Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC0Test.v.expected
@@ -36,6 +36,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkC0Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC0Test.v.expected
@@ -36,9 +36,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkC1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC1Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkC1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC1Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkC1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC1Test.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkC1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkC1Test.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType1Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType1Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType1Test.v.expected
@@ -34,6 +34,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType1Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType1Test.v.expected
@@ -34,9 +34,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType2Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType2Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType2Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType2Test.v.expected
@@ -34,6 +34,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType2Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType2Test.v.expected
@@ -34,9 +34,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType3Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType3Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType3Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType3Test.v.expected
@@ -34,6 +34,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkEnumType3Test.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkEnumType3Test.v.expected
@@ -34,9 +34,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkLeftBigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkLeftBigReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkLeftBigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkLeftBigReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1aReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1aReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1aReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt1aReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt2Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt2Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt2Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt3Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt3Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt3Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt4Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt4Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt4Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt4Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt5Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt5Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt5Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt5Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt6Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt6Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeAlt6Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeAlt6Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeC0Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeC0Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeC0Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeC0Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeC1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeC1Reg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeC1Reg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeC1Reg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeOrigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeOrigReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeOrigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeOrigReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkMaybeReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkMaybeReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkOrigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkOrigReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkOrigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkOrigReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkOrigTest.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkOrigTest.v.expected
@@ -24,6 +24,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkOrigTest.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkOrigTest.v.expected
@@ -24,9 +24,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/derived_bits/mkRightBigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkRightBigReg.v.expected
@@ -21,6 +21,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/derived_bits/mkRightBigReg.v.expected
+++ b/testsuite/bsc.verilog/derived_bits/mkRightBigReg.v.expected
@@ -21,9 +21,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkArgImpConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkArgImpConnect.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkArgImpConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkArgImpConnect.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkFourInoutBuses.v.expected
+++ b/testsuite/bsc.verilog/inout/mkFourInoutBuses.v.expected
@@ -22,6 +22,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkFourInoutBuses.v.expected
+++ b/testsuite/bsc.verilog/inout/mkFourInoutBuses.v.expected
@@ -22,9 +22,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkImpArgConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpArgConnect.v.expected
@@ -17,6 +17,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkImpArgConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpArgConnect.v.expected
@@ -17,9 +17,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkImpImpConnect1.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpImpConnect1.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkImpImpConnect1.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpImpConnect1.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkImpImpConnect2.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpImpConnect2.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkImpImpConnect2.v.expected
+++ b/testsuite/bsc.verilog/inout/mkImpImpConnect2.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkInoutBus1.v.expected
+++ b/testsuite/bsc.verilog/inout/mkInoutBus1.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkInoutBus1.v.expected
+++ b/testsuite/bsc.verilog/inout/mkInoutBus1.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkInoutBus2.v.expected
+++ b/testsuite/bsc.verilog/inout/mkInoutBus2.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkInoutBus2.v.expected
+++ b/testsuite/bsc.verilog/inout/mkInoutBus2.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkRedoInoutConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkRedoInoutConnect.v.expected
@@ -18,9 +18,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkRedoInoutConnect.v.expected
+++ b/testsuite/bsc.verilog/inout/mkRedoInoutConnect.v.expected
@@ -18,6 +18,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/inout/mkTwoInoutBuses.v.expected
+++ b/testsuite/bsc.verilog/inout/mkTwoInoutBuses.v.expected
@@ -20,9 +20,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/inout/mkTwoInoutBuses.v.expected
+++ b/testsuite/bsc.verilog/inout/mkTwoInoutBuses.v.expected
@@ -20,6 +20,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/noinline/module_test.v.expected
+++ b/testsuite/bsc.verilog/noinline/module_test.v.expected
@@ -19,9 +19,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/noinline/module_test.v.expected
+++ b/testsuite/bsc.verilog/noinline/module_test.v.expected
@@ -19,6 +19,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/quirks/mkSRAZero.v.expected
+++ b/testsuite/bsc.verilog/quirks/mkSRAZero.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/quirks/mkSRAZero.v.expected
+++ b/testsuite/bsc.verilog/quirks/mkSRAZero.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET

--- a/testsuite/bsc.verilog/sysInitialBlocks.v.expected
+++ b/testsuite/bsc.verilog/sysInitialBlocks.v.expected
@@ -16,6 +16,11 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
+`ifdef BSV_ZERO_DELAY
+`else
+  `define BSV_ZERO_DELAY #0
+`endif
+
 `ifdef BSV_POSITIVE_RESET
   `define BSV_RESET_VALUE 1'b1
   `define BSV_RESET_EDGE posedge

--- a/testsuite/bsc.verilog/sysInitialBlocks.v.expected
+++ b/testsuite/bsc.verilog/sysInitialBlocks.v.expected
@@ -16,9 +16,9 @@
   `define BSV_ASSIGNMENT_DELAY
 `endif
 
-`ifdef BSV_ZERO_DELAY
+`ifdef BSV_TASKS_DELAY
 `else
-  `define BSV_ZERO_DELAY #0
+  `define BSV_TASKS_DELAY #0
 `endif
 
 `ifdef BSV_POSITIVE_RESET


### PR DESCRIPTION
Top of the trs stack: a measured, fairness-ruled benchmark of the three simulators, and the one codegen change it motivated.

**Harness** (`tools/bench.py`, methodology in `docs/BENCH.md`): per design, a build axis (bsc frontend + backend-specific build) and a run axis (median-of-N wall to natural `$finish`, per-run peak RSS, Mc/s where the cycle count is known). Ten in-repo designs chosen from sweep telemetry to isolate distinct stress characters (dispatch floor, scheduler weight, FP, BRAM traffic, deep cones, BDPI I/O, app-scale pipeline). Fairness rules: every leg single-threaded; every leg's generated code compiles `-O3` (Verilator's packaged `-Os` default measured 34% slower on the dispatch floor); Verilator runs with **no timing flags** — a generic C++ driver toggles CLK/RST_N and bsc's delays are `` `define ``'d empty; cross-leg stdout is byte-compared (the bsc legs exactly; Verilator may only *extend* the common output with same-instant post-`$finish` lines). Every exemption is stated in the pool with its reason, never silent.

**Codegen** (`BSV_TASKS_DELAY`): the system-task always-blocks' 0-tick guard was the one delay in bsc's generated Verilog no macro guarded ("a hack to pacify VCS and NC"). It is now `` `BSV_TASKS_DELAY `` with an ifdef default of `#0` — existing VCS/NC/iverilog flows see identical text after preprocessing, and `+define+BSV_TASKS_DELAY=` makes the output genuinely delay-free for timing-less Verilator, replacing the harness's old literal-`#0;` strip (kept only as a fallback for older bsc revisions). Validated: byte-identical witness output across iverilog-default / iverilog-empty / Verilator-empty; all 150 Verilog goldens updated; all 38 golden-bearing testsuite dirs localcheck green.

**CI**: a nightly + on-demand Linux workflow runs the pass and archives the stamped JSON into MatX-inc/bsc-benchmarks (the pinned corpus + results repo, Toooba-style) when the archive token is configured.

**First indicative pass** (shared 4-CPU container, archived as `results/2026-08-20-6d0753bd7-cloud4.json`):

| design | build b/v/t (s) | run b/v/t |
|---|---|---|
| mkLong (300M cyc) | 1.9 / 6.9 / **0.6** | 45.0 / 13.5 / **169.8 Mc/s** |
| ConflictFreeLarge | 489.2 / 32.4 / **25.1** | 82 / **9** / 63 ms |
| FloatTest | 101.4 / 104.8 / **52.7** | **122** / 52 / 1068 ms |
| BRAM0Test | 60.0 / **48.5** / 182.9 | 72 / **7** / 130 ms |
| Sudoku | 55.8 / 53.0 / **50.8** | 342 / 393 / **298 ms** |

Honest readings: trs wins the dispatch floor ~3.8× over Bluesim and the build axis dramatically on scheduler-heavy designs (CFL: 25s vs 489s); Bluesim leads trs on FP-battery and BRAM runtime (FloatTest 9×, ledger items); trs AOT link time is heavy on wide-state batteries (BRAM0Test 159s). Beyond mkLong this pool's run axis is sub-second — real-workload runtimes arrive with the external corpus (Flute, CHERI-Toooba running MiBench/Olden binaries), staged as pinned submodules in bsc-benchmarks.

Two Verilator legs are skipped with stated reasons: SparseRF (`RegFile#(UInt#(42))` elaborates to a 2⁴²-entry Verilog array) and Mesa (non-terminating under the generic driver; same Verilog passes the suite under iverilog with bsc's `main.v` — under investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_