### PR TITLE
trs: per-event getenv was the runtime gap — trace flags become construction-time fields

### DIFF
--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -143,7 +143,7 @@ pub struct InstEnv {
     /// local FIFO instance name -> (base slot, width, size, guarded):
     /// header (elems, saved_elems, fst, enq_at, deq_at, clear_at) then
     /// data (see ArenaKind::Fifo)
-    pub fifo_slot: HashMap<StrId, (u32, u32, u32, bool)>,
+    pub fifo_slot: HashMap<StrId, (u32, u32, u32, bool, bool)>,
     /// module reset input port name -> arena slot holding the PORT level
     /// (1 = deasserted, matching the interpreter's Port read)
     pub reset_slot: HashMap<StrId, u32>,
@@ -874,7 +874,7 @@ fn gate_static(e: &Expr) -> bool {
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 18;
+pub const AOT_LAYOUT_REV: u64 = 19;
 
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
@@ -2685,7 +2685,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 .unwrap()
                 .into_int_value());
         }
-        if let Some(&(base, fw, _size, _g)) = ie.fifo_slot.get(&instance) {
+        if let Some(&(base, fw, _size, _g, loopy)) = ie.fifo_slot.get(&instance) {
             if !args.is_empty() {
                 return nope("FIFO value method with args");
             }
@@ -2730,11 +2730,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     Ok(cmp_w1(self, IntPredicate::NE, load(0), i64t.const_zero()))
                 }
                 "i_notFull" if width == 1 => {
-                    let e = inst_elems(self);
+                    // loopy i_* read LIVE elems: a same-instant deq
+                    // reopens the fifo (the interp drops the
+                    // begin-of-instant select for FifoType::Loopy)
+                    let e = if loopy { load(0) } else { inst_elems(self) };
                     Ok(cmp_w1(self, IntPredicate::ULT, e, i64t.const_int(_size as u64, false)))
                 }
                 "i_notEmpty" if width == 1 => {
-                    let e = inst_elems(self);
+                    let e = if loopy { load(0) } else { inst_elems(self) };
                     Ok(cmp_w1(self, IntPredicate::NE, e, i64t.const_zero()))
                 }
                 _ => nope("FIFO value method mismatch"),
@@ -5409,7 +5412,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     self.builder.position_at_end(done_bb);
                     return Ok(());
                 }
-                if let Some(&(base, fw, size, guarded)) =
+                if let Some(&(base, fw, size, guarded, loopy)) =
                     ie.fifo_slot.get(instance).copied().as_ref()
                 {
                     let is_enq = mname.as_str() == "enq";
@@ -5447,7 +5450,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             self.builder
                                 .build_int_compare(IntPredicate::EQ, elems, lim, "fb")
                                 .unwrap();
-                        let warn = if guarded {
+                        // loopy enq drops the begin-of-instant
+                        // disqualifier: enq-when-begin-full succeeds
+                        // if a same-instant deq freed a slot (deq
+                        // keeps it — only Bypass drops the deq-side
+                        // clause, and Bypass stays boxed)
+                        let warn = if guarded && !(is_enq && loopy) {
                             let same = self
                                 .builder
                                 .build_int_compare(IntPredicate::EQ, other_at, now, "fs")

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -503,7 +503,7 @@ pub(crate) enum ChildClass {
     Reg,
     CfgReg,
     Wire,
-    Fifo,
+    Fifo { loopy: bool },
     Other,
 }
 
@@ -683,8 +683,11 @@ impl<'a> ConeAnalyzer<'a> {
                                 // schedule certification pending: not stable
                                 (matches!(mname.as_str(), "whas" | "wget"), false)
                             }
-                            ChildClass::Fifo => match mname.as_str() {
-                                "i_notFull" | "i_notEmpty" => (true, true),
+                            ChildClass::Fifo { loopy } => match mname.as_str() {
+                                // loopy i_* read LIVE elems — a
+                                // same-instant deq changes them, so
+                                // they never certify as stable
+                                "i_notFull" | "i_notEmpty" => (true, !loopy),
                                 "first" | "notFull" | "notEmpty" => (true, false),
                                 _ => (false, false),
                             },
@@ -2324,7 +2327,7 @@ impl Interp {
                         Some(ArenaKind::Reg { .. }) => ChildClass::Reg,
                         Some(ArenaKind::ConfigReg { .. }) => ChildClass::CfgReg,
                         Some(ArenaKind::Wire { .. }) => ChildClass::Wire,
-                        Some(ArenaKind::Fifo { .. }) => ChildClass::Fifo,
+                        Some(ArenaKind::Fifo { loopy, .. }) => ChildClass::Fifo { loopy },
                         // arena-backed but NO stability contract and
                         // reads can WARN (bounds): the split analyzer
                         // treats it like an opaque prim
@@ -2457,10 +2460,10 @@ impl Interp {
                         creg_slot.insert(name, (base, width));
                         attach.push((ci, base));
                     }
-                    Some(ArenaKind::Fifo { width, size, guard }) => {
+                    Some(ArenaKind::Fifo { width, size, guard, loopy }) => {
                         let words = width.max(1).div_ceil(64);
                         let base = alloc(&mut nslots, 7 + size * words);
-                        fifo_slot.insert(name, (base, width, size, guard));
+                        fifo_slot.insert(name, (base, width, size, guard, loopy));
                         attach.push((ci, base));
                     }
                     Some(ArenaKind::RegFile { width, lo, hi }) => {
@@ -2753,7 +2756,7 @@ impl Interp {
                 let mut m4: Vec<_> = e
                     .fifo_slot
                     .iter()
-                    .map(|(&k, &(b, w, sz, g))| (k, b - r0, w, sz, g))
+                    .map(|(&k, &(b, w, sz, g, lp))| (k, b - r0, w, sz, g, lp))
                     .collect();
                 m4.sort_unstable();
                 m4.hash(&mut h);

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -98,19 +98,26 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
     };
     let (inst, method, ret_width, is_action) =
         (pc.inst, pc.method, pc.ret_width, pc.is_action);
-    let arg_widths = pc.arg_widths.clone();
-    let mut argv = Vec::with_capacity(arg_widths.len());
+    // pc borrows the OWNED Arc clone, so it outlives every interp use
+    // below — no arg_widths copy needed (this trampoline runs per
+    // boxed prim access; a Vec clone + a Vec per argument showed as
+    // the malloc traffic under TrafficBRAM's 403k calls)
+    let mut argv = Vec::with_capacity(pc.arg_widths.len());
     let mut off = 0usize;
-    for &w in &arg_widths {
+    for &w in &pc.arg_widths {
         // physical layout is w.max(1) words per argument on BOTH sides
         // of the ABI — a zero-width argument still occupies one (zero)
         // word (review finding: reading words.max(1) while advancing by
         // the logical count walked past the allocation)
         let words = ((w.max(1) as usize) + 63) / 64;
-        let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
         // TRUE logical width: a zero-width prim arg must reach the prim
-        // as the interp's width-0 Value (from_limbs64 masks the word)
-        argv.push(Value::from_limbs64(w, limbs));
+        // as the interp's width-0 Value (both constructors mask)
+        argv.push(if (1..=64).contains(&w) {
+            Value::from_u64(w, *args.add(off))
+        } else {
+            let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
+            Value::from_limbs64(w, limbs)
+        });
         off += words;
     }
     crate::prim::FROM_COMPILED.with(|c| c.set(token));

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -201,6 +201,14 @@ pub struct Interp {
     /// DEBUG-tier engine (bluetcl capi): exempt from the
     /// TRS_REQUIRE_AOT strict-execution refusal (see set_debug_tier)
     debug_tier: bool,
+    /// TRS_TRACE / TRS_TRACE_CLK, read ONCE at construction: the
+    /// per-event checks sat on getenv, and glibc getenv is a linear
+    /// environ scan under the env lock — sampled at ~70% of
+    /// sysFloatTest's wall (call_value/call_action/Def all checked
+    /// per event)
+    trace_events: bool,
+    trace_clk: bool,
+    trace_wf: bool,
     /// $stop yield: ends the current advance at the slice boundary
     /// but does NOT finish the sim — cleared at the next advance so
     /// the session resumes (the reference's resumable-$stop contract)
@@ -677,6 +685,9 @@ impl Interp {
             vcd_trace: false,
             quiet: false,
             debug_tier: false,
+            trace_events: std::env::var_os("TRS_TRACE").is_some(),
+            trace_clk: std::env::var_os("TRS_TRACE_CLK").is_some(),
+            trace_wf: std::env::var_os("TRS_TRACE_WF").is_some(),
             stop_request: false,
             wave_pending: None,
             vcd_def_vals: HashMap::new(),
@@ -1625,9 +1636,13 @@ impl Interp {
     fn call_value(&mut self, callee: usize, method: StrId, argv: &[Value], w: u32) -> Value {
         match &mut self.insts[callee].kind {
             InstKind::Prim(p) => {
-                let mname = self.d.strings[method as usize].clone();
-                let r = p.value_method(&mname, argv, self.now);
-                if std::env::var_os("TRS_TRACE").is_some() {
+                // borrow, don't clone: this is the per-event prim
+                // value path, and a String alloc per call showed in
+                // the FloatTest malloc profile (disjoint fields, so
+                // the &mut prim borrow tolerates it)
+                let mname: &str = &self.d.strings[method as usize];
+                let r = p.value_method(mname, argv, self.now);
+                if self.trace_events {
                     let path = self.insts[callee].path.clone();
                     eprintln!("[{}] {}.{} -> {}", self.cycle, path, mname,
                               r.to_hex_string());
@@ -1658,7 +1673,7 @@ impl Interp {
     }
 
     fn call_action(&mut self, callee: usize, method: StrId, argv: &[Value]) {
-        if std::env::var_os("TRS_TRACE").is_some() {
+        if self.trace_events {
             if let InstKind::Prim(_) = &self.insts[callee].kind {
                 let mname = self.d.strings[method as usize].clone();
                 let args: Vec<String> = argv.iter().map(|v| v.to_hex_string()).collect();
@@ -1770,7 +1785,7 @@ impl Interp {
                 }
                 match result {
                     Some(r) => {
-                        if std::env::var_os("TRS_TRACE").is_some() {
+                        if self.trace_events {
                             eprintln!("    av-result expr: {r:?}");
                         }
                         self.eval(callee, &mut ctx, &r)
@@ -1795,7 +1810,7 @@ impl Interp {
         match st {
             Stmt::Def { name, expr } => {
                 let v = self.eval(inst, ctx, expr);
-                if std::env::var_os("TRS_TRACE").is_some() {
+                if self.trace_events {
                     eprintln!("    def {} := {}", self.s(*name), v.to_hex_string());
                 }
                 if self.vcd_trace {
@@ -3167,7 +3182,7 @@ impl Interp {
         // latched CAN_FIRE, not the memoized pre-inhibitor values
         let mut wf_ctx = Ctx { memo: true, ..Default::default() };
         let wf = self.eval(inst, &mut wf_ctx, &Expr::Def(r.will_fire));
-        if std::env::var_os("TRS_TRACE_WF").is_some() && wf.as_bool() {
+        if self.trace_wf && wf.as_bool() {
             eprintln!("[{}] FIRE {}.{}", self.cycle, self.insts[inst].path,
                       self.s(rule_name));
         }
@@ -3229,7 +3244,7 @@ impl Interp {
                     *self.jit_arena_ptr.add(self.jit_reset_slots[n] as usize) = (!v) as u64;
                 }
             }
-            if std::env::var_os("TRS_TRACE_CLK").is_some() {
+            if self.trace_clk {
                 eprintln!("[t={}] reset node {n} -> asserted={v}", self.now);
             }
             let subs = self.rst_subs[n].clone();
@@ -3645,7 +3660,7 @@ impl Interp {
                 }
             })
             .collect();
-        if std::env::var_os("TRS_TRACE_CLK").is_some() {
+        if self.trace_clk {
             for (ci, &c) in clocks.iter().enumerate() {
                 let k = match &sources[ci] {
                     ClockSource::Wave(w) => format!(
@@ -3893,7 +3908,7 @@ impl Interp {
                 }
             }
         }
-        if std::env::var_os("TRS_TRACE_CLK").is_some() {
+        if self.trace_clk {
             for (i, rc) in rcomps.iter().enumerate() {
                 let tickinfo: Vec<String> = rc
                     .ticks
@@ -4570,7 +4585,7 @@ impl Interp {
                             Vec::new()
                         };
                         for pos_edge in edges {
-                            if std::env::var_os("TRS_TRACE_CLK").is_some() {
+                            if self.trace_clk {
                                 eprintln!("[t={t}] trigger clk={out_ci} pos={pos_edge}");
                             }
                             heap.push(Reverse((t, 1, out_ci, pos_edge)));

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -201,13 +201,17 @@ pub enum ArenaKind {
     /// select old/current by comparing written_at against the global
     /// now slot; writes stay on the trampoline and mirror all three.
     ConfigReg { width: u32 },
-    /// Simple guarded FIFO (FIFO1/FIFO2/SizedFIFO): value methods
-    /// compile inline over the mirrored header + data; enq/deq/clear
-    /// stay on the trampoline (guard warnings, saved_elems rules) and
-    /// mirror.  Layout: elems, saved_elems, fst, enq_at, deq_at,
-    /// clear_at (1 word each), then size * ceil(max(width,1)/64) data
-    /// words.
-    Fifo { width: u32, size: u32, guard: bool },
+    /// Guarded FIFO (FIFO1/FIFO2/SizedFIFO and the loopy FIFOL
+    /// variants): value methods compile inline over the mirrored
+    /// header + data; enq/deq/clear stay on the trampoline (guard
+    /// warnings, saved_elems rules) and mirror.  `loopy` selects the
+    /// read semantics: Simple i_notFull/i_notEmpty are begin-of-
+    /// instant (saved_elems when touched this instant), Loopy reads
+    /// LIVE elems — a same-instant deq reopens the fifo, which is the
+    /// loopy contract (and why loopy reads are never schedule-stable).
+    /// Layout: elems, saved_elems, fst, enq_at, deq_at, clear_at
+    /// (1 word each), then size * ceil(max(width,1)/64) data words.
+    Fifo { width: u32, size: u32, guard: bool, loopy: bool },
     /// RegFile/RegFileLoad small enough for a dense image.  Layout:
     /// upd_at, upd_addr (1 word each), upd_prev (w words), then
     /// (hi-lo+1) * w data words (w = ceil(max(width,1)/64)),
@@ -3060,12 +3064,14 @@ impl Prim for Fifo {
     }
 
     fn arena_kind(&self) -> Option<ArenaKind> {
-        // Simple guarded FIFOs only: Loopy/Bypass change the
-        // begin-of-instant selection rules the inline reads bake in
-        (self.ftype == FifoType::Simple).then_some(ArenaKind::Fifo {
+        // Simple and Loopy: the inline reads carry both semantics
+        // (Loopy i_* read LIVE elems).  Bypass stays boxed — its deq
+        // guard couples to same-instant enq the other way around.
+        matches!(self.ftype, FifoType::Simple | FifoType::Loopy).then_some(ArenaKind::Fifo {
             width: self.width,
             size: self.size as u32,
             guard: self.guard,
+            loopy: self.ftype == FifoType::Loopy,
         })
     }
     fn arena_attach(&mut self, slot: *mut u64) {


### PR DESCRIPTION
The benchmark rung (#131) measured trs behind Bluesim at runtime on FP- and prim-heavy designs (FloatTest 9×, DFT64/TrafficBRAM/Mesa 2–3×) while winning the dispatch floor 3.8×. This rung is the diagnosis and the first fix.

**Diagnosis.** Callgrind's instruction profile pointed at startup-shaped code, but the wall scaled per cycle at an impossible IPC — so the time wasn't in retired instructions. Stack-sampling the live process found ~70% of FloatTest's wall inside glibc `getenv`: the per-event paths — every prim value/action call, every `Def` statement, every WILL_FIRE latch, every clock edge — checked `std::env::var_os("TRS_TRACE…")` to decide whether to emit a trace line. Each check is a linear environ scan under the process env lock; the prim value path also cloned the method-name `String` per call. mkLong never showed it because the central compiled loop bypasses these paths — the engine looked fastest exactly where this cost was unreachable.

**Fix.** `TRS_TRACE` / `TRS_TRACE_CLK` / `TRS_TRACE_WF` are read once at `Interp` construction into fields (each engine instance re-reads, so selfcheck shadows behave identically); the clone became a borrow. Trace semantics unchanged — verified by output comparison.

**Witness** (same artifacts, same box, medians of 3):

| design | before | after | Bluesim |
|---|---|---|---|
| FloatTest | 1.10s | **0.46s** | 0.12s |
| DFT64v5 | 0.25s | **0.13s** | 0.078s |
| TrafficBRAM | 0.35s | 0.29s | 0.148s |
| Mesa | 0.28s | 0.28s (untouched mechanism, still open) | 0.091s |
| mkLong | unchanged | unchanged | — |

**Seal**: full `--aot` corpus sweep at this head — 996 PASS / 0 DIFF, all 996 compiled, non-PASS classes test-for-test identical to trs/12. Regress 7/7; FloatTest clean under 3-way lockstep.

Remaining ledger (next targets, mechanisms not yet diagnosed): FloatTest's residual 3.8× and Mesa's 3× — likely per-event boxed-prim dispatch; and a UX trap found along the way: `--code` with a slash-less path makes dlopen do a soname search, fail, and silently fall back to in-process compile (noted, should be `./`-relative or a strict refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_