### PR TITLE
SimExportIR: export-scaling fixes — indexed Kahn, Id-keyed probes, and dropping the rules² disjointness export

### DIFF
--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -494,8 +494,10 @@ encComposition instToMod msis topGates ss = do
         stepME (seen, acc) (i, Sched n) =
             let q = qp i (getIdBaseString n)
                 inh = S.intersection (M.findWithDefault S.empty q disjQ) seen
-            in  (seen, acc ++ [ (d, q) | d <- S.toList inh ])
-        crossPairs = snd (foldl' stepME (S.empty, []) composedNodes)
+            -- Chunk-accumulate and concat once, so the fold stays linear
+            -- in the number of emitted pairs.
+            in  (seen, [ (d, q) | d <- S.toList inh ] : acc)
+        crossPairs = concat (reverse (snd (foldl' stepME (S.empty, []) composedNodes)))
 
         -- direction-filter the primitive ticks against the primMap tick
         -- specs (doTickCall): a posedge schedule also produces a

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -64,7 +64,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 1
+birVersion = 2
 
 -- ===============
 -- String interning
@@ -220,7 +220,6 @@ data ModSchedInfo = ModSchedInfo
       -- node key -> ((domain, segment), position within segment)
     , msi_segIdx  :: M.Map String ((Int, Int), Int)
     , msi_execPos :: M.Map String Int         -- rule name -> local exec pos
-    , msi_disj    :: M.Map String (S.Set String) -- rule -> disjoint rules
     , msi_taskRules   :: S.Set String  -- rules with system/foreign tasks
     , msi_finishRules :: S.Set String  -- rules calling $finish/$fatal/$stop
     }
@@ -250,14 +249,6 @@ analyzeModule pkgNames pkg =
         execPos = M.fromList
             [ (getIdBaseString i, p)
             | (Exec i, p) <- zip order [(0 :: Int) ..] ]
-
-        disj0 = exclRulesDBToDisjRulesDB (asi_exclusive_rules_db asi)
-        isRule s = M.member s ruleDom
-        disj = M.fromList
-            [ (rs, S.filter isRule (S.map getIdBaseString ds))
-            | (r, ds) <- M.toList disj0
-            , let rs = getIdBaseString r
-            , isRule rs ]
 
         doms = nub (M.elems ruleDom)
 
@@ -324,7 +315,6 @@ analyzeModule pkgNames pkg =
         ModSchedInfo { msi_domains = domSegs
                      , msi_segIdx = segIdx
                      , msi_execPos = execPos
-                     , msi_disj = disj
                      , msi_taskRules = taskRules
                      , msi_finishRules = finishRules }
 
@@ -755,15 +745,9 @@ encSchedule msi pkg = do
                             bsE <- mapM idE blockers
                             return (encPair rE (encList bsE)))
                          esposito
-    disjEnc <- mapM (\(r, ds) -> do
-                       rE <- strE r
-                       dsE <- mapM strE (S.toList ds)
-                       return (encPair rE (encList dsE)))
-                    (M.toList (msi_disj msi))
     return $ encStruct
       [ ("domains", encList domsEnc)
       , ("conflicts", encList conflictsEnc)
-      , ("disjoint", encList disjEnc)
       ]
 
 encModSched :: (Int, [Seg]) -> EncM C.Encoding

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -378,8 +378,21 @@ encComposition instToMod msis topGates ss = do
         -- rules singleton per-node segments so the endpoints are
         -- independently placeable).  A same-unit pair is only legal if
         -- the segment's internal order already agrees.
-        schedPosQ = M.fromList [ (qualPath i, p)
+        -- Keyed by Id: comparison is an interned-index compare, where a
+        -- qualified-path String would be rebuilt and compared character by
+        -- character on every probe.  Probed only, never traversed, so the
+        -- interning-order traversal never reaches the output.
+        schedPosQ = M.fromList [ (i, p)
                                | (Sched i, p) <- zip order [(0 :: Int) ..] ]
+        execPosI  = M.fromList [ (i, p)
+                               | (Exec i, p) <- zip order [(0 :: Int) ..] ]
+        -- `resolveFull` is a pure function of the node and there are
+        -- |order| nodes against O(rules^2) disjoint pairs, so resolve each
+        -- node once here and probe by Id below.
+        resolvedS = M.fromList [ (i, v)
+                               | n@(Sched i) <- order, Just v <- [resolveFull n] ]
+        resolvedE = M.fromList [ (i, v)
+                               | n@(Exec i) <- order, Just v <- [resolveFull n] ]
         -- The disjointness map holds both orientations of every pair
         -- (`combineSchedDRDB`: "the disjoint map should be the same in
         -- both directions"), so one pass over it sees each ordered pair
@@ -390,11 +403,11 @@ encComposition instToMod msis topGates ss = do
         meEdges = S.fromList
             [ (su, eu)
             | (r, d) <- mePairs
-            , Just ps <- [M.lookup (qualPath r) schedPosQ]
-            , Just pe <- [M.lookup (qualPath d) execPos]
+            , Just ps <- [M.lookup r schedPosQ]
+            , Just pe <- [M.lookup d execPosI]
             , ps < pe
-            , Just (su, sj) <- [resolveFull (Sched r)]
-            , Just (eu, ej) <- [resolveFull (Exec d)]
+            , Just (su, sj) <- [M.lookup r resolvedS]
+            , Just (eu, ej) <- [M.lookup d resolvedE]
             , if su == eu
               then if sj < ej
                    then False  -- ordered inside the segment already

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -449,7 +449,10 @@ encComposition instToMod msis topGates ss = do
 
         -- Kahn's algorithm; ties broken by first appearance in the flat
         -- order so the output tracks bsc's own choice.
-        succsOf u = [ b | (a, b) <- S.toList unitEdges, a == u ]
+        -- Successors indexed once: Kahn's asks for them per node, and the
+        -- edge set grows with both instance count and hierarchy depth.
+        succMap = M.fromListWith (++) [ (a, [b]) | (a, b) <- S.toList unitEdges ]
+        succsOf u = M.findWithDefault [] u succMap
         indeg0 = M.fromListWith (+)
                    ([ (u, 0 :: Int) | u <- units ]
                     ++ [ (b, 1) | (_, b) <- S.toList unitEdges ])

--- a/src/comp/SimExportIR.hs
+++ b/src/comp/SimExportIR.hs
@@ -380,12 +380,13 @@ encComposition instToMod msis topGates ss = do
         -- the segment's internal order already agrees.
         schedPosQ = M.fromList [ (qualPath i, p)
                                | (Sched i, p) <- zip order [(0 :: Int) ..] ]
-        mePairs = nub ([ (r, d)
-                       | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
-                       , d <- S.toList ds ]
-                       ++ [ (d, r)
-                          | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
-                          , d <- S.toList ds ])
+        -- The disjointness map holds both orientations of every pair
+        -- (`combineSchedDRDB`: "the disjoint map should be the same in
+        -- both directions"), so one pass over it sees each ordered pair
+        -- exactly once.
+        mePairs = [ (r, d)
+                  | (r, ds) <- M.toList (ss_disjoint_rules_db ss)
+                  , d <- S.toList ds ]
         meEdges = S.fromList
             [ (su, eu)
             | (r, d) <- mePairs

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -22,7 +22,7 @@ pub use schedule::{Composition, ModuleSchedule, SchedNode, Schedule, Segment};
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 1;
+pub const BIR_VERSION: u32 = 2;
 
 /// Snapshot sidecar magic (`<base>.birsnap`, see `Design::snap_encode`).
 /// The trailing byte is the HEADER format; \x02 added the layout rev

--- a/src/trs/crates/trs-ir/src/schedule.rs
+++ b/src/trs/crates/trs-ir/src/schedule.rs
@@ -50,9 +50,6 @@ pub struct Schedule {
     /// construction; already reflected in the WILL_FIRE defs, carried for
     /// verification and diagnostics.
     pub conflicts: Vec<(StrId, Vec<StrId>)>,
-    /// Intra-module disjoint (mutually exclusive) rule pairs; drives the
-    /// per-module-type ME inhibitors in `Rule::me_inhibits`.
-    pub disjoint: Vec<(StrId, Vec<StrId>)>,
 }
 
 /// A module's execution order within one clock domain and edge, split into


### PR DESCRIPTION
Integration of William Howe-Lott's export-side fixes from `william/trs-matx-integration` (all five cherry-picked with authorship intact; they applied cleanly at the top of the trs stack). These attack the BIR export's scaling on exactly the designs it serves — deep hierarchies and rule-heavy modules:

1. **72a175ca8 — drop the unused rules² disjointness export from BIR.** `Schedule::disjoint` is read by no Rust code (the interpreter consumes `Rule::me_inhibits` and the composition's `cross_inhibits`); building it expanded the full pairwise ME relation through per-rule `Set String` at O(rules²) pairs — William measured **216s and 9.1GB of allocation at N=400 disjoint rules vs 0.20s when bsc can't prove disjointness**. The field and the construction both go. BIR_VERSION 1 → 2.
2. **def387b86 — drop the `nub` over ME pairs** (quartic in rule count; his measurement: N=400 link 250.88s → 2.36s, 106×).
3. **06d47a6be — chunk-accumulate cross-instance ME pairs** (the `acc ++ [..]` fold was O(pairs²); latent for single-module designs, fixed before a cross-instance design measures it).
4. **53c103a30 — probe schedule-position maps by Id** instead of rebuilding `qual ++ "." ++ base` per probe and comparing long shared-prefix strings; `resolveFull` once per node instead of twice per pair. (Both maps are probed, never traversed, so Id's interning-order `Ord` can't reach the emitted output.)
5. **15ba72b68 — index the successor lookup in Kahn's algorithm.** `succsOf` rescanned the whole edge set per node — 65.8% of export time on a depth-4 profile; his depth-ladder measurement: D=4 export 231s → 20s.

Verified at this head: bsc + trs build clean (`make install-src`), regress 10/10 (including the two new string batteries and the run-time-load-file check from the follow-up PRs' branches), StrCatBdpi/StrDynSelect byte-exact vs Bluesim under strict AOT. The BIR version bump means artifacts and `.bir`s regenerate on first use — the layout gates make staleness loud, not wrong. Full 3-way selfcheck seal sweep is running at the stack head (trs/18) and will be posted there.

Stacks on #133; the remaining William fixes follow in #135 (link honesty + BDPI libraries) and #136 (runtime fixes + adopted tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_