### PR TITLE
trs link: fail rather than substitute, and link the user's libraries into the BDPI object

### DIFF
--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1962,8 +1962,7 @@ trsLink errh flags toplevel user_cfiles user_ofiles = do
     -- AOT: let the trs driver compile the design and write the
     -- artifact (wrapper script + model .so + pinned options) — the
     -- same amortization as the C++ backend's g++ link, at a fraction
-    -- of the cost.  Any failure (trs not on PATH, built without the
-    -- jit feature, infra error) falls back to the interpreter wrapper.
+    -- of the cost.
     -- like the C++ backend, trs dumps waveforms only in VCD and FST
     let bad_fmts2 = filter (`notElem` ["vcd", "fst"]) (dumpFormats flags)
     when (not (null bad_fmts2)) $
@@ -1991,25 +1990,23 @@ trsLink errh flags toplevel user_cfiles user_ofiles = do
                     _           -> " (interpreted)"
         unless (quiet flags) $
             putStrLnF ("TRS simulation created" ++ how ++ ": " ++ outFile)
-      _ -> do
-        -- honor a strict-mode refusal: converting `trs link`'s
-        -- TRS_REQUIRE_AOT failure into an interpreter wrapper would
-        -- reintroduce the silent degrade at this layer
-        strictRc <- system "test -n \"$TRS_REQUIRE_AOT\""
-        when (strictRc == ExitSuccess) $
-            exitFailWith errh 86
-        writeFileCatch errh outFile $
-            unlines [ "#!/bin/sh"
-                    , ""
-                    , "TRS=${TRS:-trs}"
-                    , "exec \"$TRS\" run \"$0.bir\" \"$@\""
-                    ]
-        stat <- getFileStatus outFile
-        let mode = fileMode stat
-            mode' = foldl1 unionFileModes [mode, ownerExecuteMode, groupExecuteMode]
-        setFileMode outFile mode'
-        unless (quiet flags) $
-            putStrLnF ("TRS simulation created (interpreted): " ++ outFile)
+      ExitFailure 86 ->
+        -- `trs link`'s own strict-mode refusal (TRS_REQUIRE_AOT):
+        -- propagate the code so strict callers see the same contract
+        -- at every layer
+        exitFailWith errh 86
+      ExitFailure n ->
+        -- -trs asks for a trs simulation specifically: `trs link`
+        -- exits 0 for everything it handles (ineligible designs get
+        -- its own interpreter wrapper), so a non-zero exit is a
+        -- genuine failure (trs not on PATH, unresolved BDPI symbol,
+        -- infra error).  Standing in an interpreter wrapper here
+        -- turned those into silent successes that failed later, far
+        -- from the cause.  Report the failure and stop.
+        bsError errh
+            [(cmdPosition,
+              EGeneric ("TRS link failed with exit code " ++ show n ++
+                        ": " ++ linkCmd))]
 
 -- ===============
 -- vLink

--- a/src/comp/bsc.hs
+++ b/src/comp/bsc.hs
@@ -1525,6 +1525,8 @@ simLink errh flags toplevel afilenames cfilenames = do
                  user_ofiles ++ compiled_user_ofiles ++
                  ofiles_reused
 
+    bdpi_undef <- bdpiUndefinedFlags errh flags toplevel abis
+
     -- under -bir, also package the user's BDPI objects for the trs
     -- runtime (dlopen), named next to the .bir
     when (genBir flags && not (genTrs flags)
@@ -1533,15 +1535,23 @@ simLink errh flags toplevel afilenames cfilenames = do
         let name3 = createEncodedFullFilePath "placeholder" pwd3
             prefix3 = (dirName name3) ++ "/"
             so3 = prefix3 ++ toplevel ++ ".bdpi.so"
-        cxxCompile errh flags (["-shared", "-fPIC", "-o", so3])
-                   (map show (user_ofiles ++ compiled_user_ofiles))
+        -- The user's -L/-l reach this link too: BDPI implementations may
+        -- live in a library rather than the objects, and an unresolved
+        -- symbol here surfaces only when the runtime dlopens the result.
+        -- show is used for quoting, as in cxxLink.
+        let libdirflags3 = map (("-L" ++) . show) (cLibPath flags)
+            userlibs3    = map (("-l" ++) . show) (cLibs flags)
+        cxxCompile errh flags
+                   (["-shared", "-fPIC"] ++ libdirflags3 ++ bdpi_undef
+                    ++ ["-o", so3])
+                   (map show (user_ofiles ++ compiled_user_ofiles) ++ userlibs3)
     t <- dump errh flags t_before_compilations DFbluesimcompile dumpnames
               ofiles
 
     -- if not generating a SystemC model, link to a Bluesim executable
     start flags DFbluesimlink
     if (genTrs flags)
-      then trsLink errh flags toplevel user_cfiles user_ofiles
+      then trsLink errh flags toplevel user_cfiles user_ofiles bdpi_undef
       else when (not (genSysC flags)) $
              cxxLink errh flags toplevel ofiles creation_time
     t <- dump errh flags t DFbluesimlink dumpnames toplevel
@@ -1924,13 +1934,44 @@ cleanseSharedLib errh flags soFile = do
         ExitSuccess   -> return ()
         ExitFailure n -> exitFailWith errh n
 
+-- The trs runtime resolves each BDPI function out of the .bdpi.so with
+-- dlsym, so nothing inside that shared object refers to them.  A static
+-- library named with -l therefore contributes no members of its own: the
+-- linker extracts only what resolves an outstanding reference.  Naming the
+-- design's BDPI symbols as undefined asks for exactly the members that
+-- define them, leaving the rest of the archive out.
+bdpiUndefinedFlags :: ErrorHandle -> Flags -> String -> [(String, ABin)] ->
+                      IO [String]
+bdpiUndefinedFlags errh flags toplevel abis
+    | null (cLibs flags) = return []
+    | otherwise = do
+        -- a foreign function reaches the link either way round: named
+        -- directly as a .ba on the command line, or reached from a module
+        -- that calls it, whose .ba sits on the search path
+        let cmdline_ffs =
+                [ abffi_foreign_func abffi
+                | (_, ABinForeignFunc { ab_ffuncinfo = abffi }) <- abis ]
+            called = nub [ n
+                         | (_, ABinMod { ab_modinfo = abmi }) <- abis
+                         , n <- getForeignCallNames (abmi_apkg abmi) ]
+            readFF n =
+                let err = (noPosition,
+                           EMissingABinForeignFuncFile n toplevel)
+                in  readAndCheckABinPathCatch errh (verbose flags)
+                        (ifcPath flags) (Just Bluesim) n err
+        called_abis <- mapM readFF called
+        called_ffs <- M.elems `fmap` buildForeignFunctionMap errh called_abis
+        return $ nub [ "-Wl,-u," ++ getIdString (ff_name ff)
+                     | ff <- cmdline_ffs ++ called_ffs ]
+
 -- ===============
 -- trsLink: the TRS backend's link step.  The simulation is the
 -- exported .bir executed by the trs runtime; user BDPI C files are
 -- compiled into a companion shared object that the runtime dlopens.
 
-trsLink :: ErrorHandle -> Flags -> String -> [String] -> [String] -> IO ()
-trsLink errh flags toplevel user_cfiles user_ofiles = do
+trsLink :: ErrorHandle -> Flags -> String -> [String] -> [String] ->
+           [String] -> IO ()
+trsLink errh flags toplevel user_cfiles user_ofiles bdpi_undef = do
     pwd <- getCurrentDirectory
     let name = createEncodedFullFilePath "placeholder" pwd
         prefix = (dirName name) ++ "/"
@@ -1955,8 +1996,12 @@ trsLink errh flags toplevel user_cfiles user_ofiles = do
     when (not (null user_cfiles) || not (null user_ofiles)) $ do
         cofs <- mapM (compileUserCFile errh flags False) user_cfiles
         cxxCompile errh flags
-                   (["-shared", "-fPIC", "-o", soFile])
-                   (map show (cofs ++ user_ofiles))
+                   (["-shared", "-fPIC"]
+                    ++ map (("-L" ++) . show) (cLibPath flags)
+                    ++ bdpi_undef
+                    ++ ["-o", soFile])
+                   (map show (cofs ++ user_ofiles)
+                    ++ map (("-l" ++) . show) (cLibs flags))
         unless (quiet flags) $
             putStrLnF ("BDPI shared library created: " ++ soFile)
     -- AOT: let the trs driver compile the design and write the

--- a/src/trs/Makefile
+++ b/src/trs/Makefile
@@ -37,6 +37,14 @@ TRS_FLAGS = --features aot
 CAPI_FLAGS  = --no-default-features --features aot
 endif
 
+# Strip debug info from a static archive.  GNU binutils spells this
+# --strip-debug; the macOS strip does not accept it and uses -S.
+ifeq ($(shell uname -s),Darwin)
+STRIP_DEBUG = strip -S
+else
+STRIP_DEBUG = strip --strip-debug
+endif
+
 .PHONY: build
 build:
 	$(CARGO) build --release --locked -p trs $(TRS_FLAGS)
@@ -55,9 +63,10 @@ install: build
 	$(INSTALL) -m 644 target/release/libtrs_capi.a $(BINDIR)/libtrs_capi.a
 	$(INSTALL) -m 644 target/release/libtrs_rt.a $(BINDIR)/libtrs_rt.a
 	# debuginfo in the staticlib is dead weight at .so link time
-	# (~420MB -> tens of MB); the interactive link strips the model
-	strip --strip-debug $(BINDIR)/libtrs_capi.a
-	strip --strip-debug $(BINDIR)/libtrs_rt.a
+	# (~420MB -> tens of MB); the interactive link strips the model.
+	# GNU strip spells this --strip-debug; the macOS one only has -S.
+	$(STRIP_DEBUG) $(BINDIR)/libtrs_capi.a
+	$(STRIP_DEBUG) $(BINDIR)/libtrs_rt.a
 	# the shared capi: linked ONCE here instead of once per design;
 	# without it the fast wrapper's -c/-f script tier is absent (the
 	# artifact contract is unchanged), so a cc/LLVM-less environment


### PR DESCRIPTION
Second of the William Howe-Lott integration PRs (from `william/trs-matx-integration`; authorship preserved). Three link/build-side fixes:

1. **1d4439123 — fail the link rather than substitute an interpreted build.** `trs link` exits 0 for everything it handles (ineligible designs get its own interpreter wrapper), so a non-zero exit is a genuine failure — trs missing from PATH, an unresolved BDPI symbol, an infra error. bsc converted those into a hand-written interpreter wrapper plus "TRS simulation created" and exit 0: a silent success that failed later, far from its cause. Now: `bsError` and stop. *Adaptation from William's original:* our stack had since grown the artifact-grep engine-truth report and the `TRS_REQUIRE_AOT` handling, so the resolution keeps those — the success arm reports (compiled)/(interpreted) from the wrapper itself, and `trs link`'s own strict-mode exit 86 propagates as 86 at this layer too.
2. **e5ed8d610 — link the user's `-L`/`-l` libraries into the `.bdpi.so`.** BDPI implementations may live in a library rather than the listed objects; the `.bdpi.so` was linked from the objects alone, so a design that links under Bluesim lost its BDPI symbols under `-bir`/`-trs` — surfacing only at runtime dlopen. And since the runtime resolves BDPI functions by dlsym, nothing in the shared object references them, so a static archive would contribute nothing: the fix names the design's BDPI symbols as undefined (`-Wl,-u,<sym>`, collected from the ABins bsc already read) so the linker extracts exactly the members that define them. Applies to both the `-trs` and the `-bir`-only packaging paths.
3. **f569ed23a — strip debug info portably on macOS** (`strip --strip-debug` is GNU; Darwin spells it `-S`). Extended to the slim `libtrs_rt.a` our Makefile also installs.

Verified: full `make install-src` clean at this head; regress 10/10 with the installed toolchain. Seal sweep runs at the stack head (#136).

Stacks on #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_