### PR TITLE
trs: BRAM/CReg arena + compiled ticks — the central loop covers CPU-scale designs

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -110,6 +110,10 @@ pub struct InstEnv {
     /// header [upd_at, upd_addr, upd_prev(w)] then dense data
     /// (see ArenaKind::RegFile)
     pub regfile_slot: HashMap<StrId, (u32, u32, u64, u64)>,
+    /// local BRAM instance name -> (base slot, width, size, chunk_size,
+    /// num_wens, dual, pipelined): per-port headers then dense data
+    /// (see ArenaKind::Bram)
+    pub bram_slot: HashMap<StrId, (u32, u32, u64, u32, u32, bool, bool)>,
     /// local FIFO instance name -> (base slot, width, size, guarded):
     /// header (elems, saved_elems, fst, enq_at, deq_at, clear_at) then
     /// data (see ArenaKind::Fifo)
@@ -475,7 +479,7 @@ pub const STRING_CONCAT_FUNC: StrId = u32::MAX - 1;
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 20;
+pub const AOT_LAYOUT_REV: u64 = 21;
 /// How a caller reaches an outlined def-piece helper: a baked address
 /// (JIT: the helper engine compiled first) or a named symbol (AOT: ld
 /// resolves it inside the artifact .so).

--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -545,6 +545,157 @@ pub struct EdgeSsaPlan {
     /// of RWire/PulseWire::tick (the boxed `written` latch only feeds
     /// VCD, where the interpreter runs ticks itself)
     pub wire_clears: Vec<Vec<u32>>,
+    /// per composition: (value base slot, words) of ungated CReg ticks —
+    /// the compiled form of CReg::tick is a copy of the live value into
+    /// the registered value (arena words [base, base+w) -> [base+w,
+    /// base+2w)); the boxed per-port history only feeds VCD
+    pub creg_copies: Vec<Vec<(u32, u32)>>,
+    /// per composition: packed trs_bram_tick argument triples of
+    /// ungated BRAM port ticks — the edge fn calls the helper through
+    /// the trs_bram_tick_cb pointer-global (filled at artifact load)
+    pub bram_ticks: Vec<Vec<[u64; 3]>>,
+}
+
+/// Pack one BRAM port tick into trs_bram_tick's (a0, a1, a2) args.
+pub fn bram_tick_args(
+    base: u32,
+    port_b: bool,
+    width: u32,
+    size: u64,
+    chunk_size: u32,
+    num_wens: u32,
+    dual: bool,
+) -> [u64; 3] {
+    [
+        base as u64 | (port_b as u64) << 32,
+        width as u64 | (chunk_size as u64) << 32,
+        size | (num_wens as u64) << 32 | (dual as u64) << 62,
+    ]
+}
+
+/// Compiled BRAM end-of-edge tick (the arena form of Bram::clk): the
+/// fused edge fn calls this through the trs_bram_tick_cb
+/// pointer-global once per BRAM port tick.  Layout per
+/// ArenaKind::Bram; args packed by bram_tick_args.  Must mirror the
+/// interpreter's Bram::clk exactly: out2 <- out rotation, pending-put
+/// latch, byte-enable lane merge, cross-port same-instant bypass,
+/// out-of-range -> undet (the WARNING printed at put time on the
+/// trampoline).
+///
+/// # Safety
+/// `arena` must be the design arena; the packed args must describe a
+/// BRAM block passB allocated inside it.
+pub unsafe extern "C" fn trs_bram_tick(
+    arena: *mut u64,
+    now: u64,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+) {
+    let base = (a0 & 0xffff_ffff) as usize;
+    let port_b = a0 >> 32 & 1 != 0;
+    let width = (a1 & 0xffff_ffff) as u32;
+    let chunk = (a1 >> 32) as u32;
+    let size = a2 & 0xffff_ffff;
+    let num_wens = ((a2 >> 32) & 0x3fff_ffff) as u32;
+    let dual = a2 >> 62 & 1 != 0;
+    let w = (width.max(1) as usize).div_ceil(64);
+    let wenw = (num_wens.max(1) as usize).div_ceil(64);
+    let pw = 3 + wenw + 4 * w;
+    let me = base + if port_b { pw } else { 0 };
+    let other = base + if port_b { 0 } else { pw };
+    let (o_wens, o_val) = (3, 3 + wenw);
+    let (o_prev, o_out, o_out2) =
+        (3 + wenw + w, 3 + wenw + 2 * w, 3 + wenw + 3 * w);
+    // out2 <- out (unconditional rotation, like the boxed clk)
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            arena.add(me + o_out),
+            arena.add(me + o_out2),
+            w,
+        );
+        if *arena.add(me) != now {
+            return;
+        }
+        let addr = *arena.add(me + 1);
+        let wens_zero =
+            (0..wenw).all(|i| *arena.add(me + o_wens + i) == 0);
+        if addr >= size {
+            // out-of-range: undet pattern, masked to width
+            for i in 0..w {
+                *arena.add(me + o_out + i) = 0xAAAA_AAAA_AAAA_AAAA;
+            }
+            mask_top(arena.add(me + o_out), width, w);
+            return;
+        }
+        let daddr = base + pw * if dual { 2 } else { 1 } + addr as usize * w;
+        // cross-port same-instant bypass: the other port wrote this
+        // address at this instant -> its pre-write value
+        let other_hit = dual
+            && *arena.add(other + 2) == now
+            && *arena.add(other + 1) == addr;
+        if !wens_zero {
+            // write: prev <- (bypass ? other.prev : data), then merge
+            // the enabled lanes of upd_val into data, out <- merged
+            *arena.add(me + 2) = now;
+            if other_hit {
+                std::ptr::copy_nonoverlapping(
+                    arena.add(other + o_prev),
+                    arena.add(me + o_prev),
+                    w,
+                );
+            } else {
+                std::ptr::copy_nonoverlapping(
+                    arena.add(daddr),
+                    arena.add(me + o_prev),
+                    w,
+                );
+            }
+            for n in 0..num_wens {
+                let lane = *arena.add(me + o_wens + (n / 64) as usize)
+                    >> (n % 64)
+                    & 1;
+                if lane == 0 {
+                    continue;
+                }
+                if n * chunk >= width {
+                    continue;
+                }
+                let lo = (n * chunk) as usize;
+                let len = chunk.min(width - n * chunk) as usize;
+                for b in lo..lo + len {
+                    let bit =
+                        *arena.add(me + o_val + b / 64) >> (b % 64) & 1;
+                    let d = arena.add(daddr + b / 64);
+                    *d = *d & !(1u64 << (b % 64)) | bit << (b % 64);
+                }
+            }
+            std::ptr::copy_nonoverlapping(
+                arena.add(daddr),
+                arena.add(me + o_out),
+                w,
+            );
+        } else {
+            // read: bypassed pre-write value or the stored data
+            let src = if other_hit { other + o_prev } else { daddr };
+            std::ptr::copy_nonoverlapping(
+                arena.add(src),
+                arena.add(me + o_out),
+                w,
+            );
+        }
+    }
+}
+
+/// Mask the top word of a `words`-long little-endian value to `width`.
+///
+/// # Safety
+/// `p` must point at `words` valid u64s.
+unsafe fn mask_top(p: *mut u64, width: u32, words: usize) {
+    let rem = width % 64;
+    if width != 0 && rem != 0 {
+        unsafe { *p.add(words - 1) &= (1u64 << rem) - 1 };
+    }
 }
 
 /// One node of a fused per-composition edge function.

--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -114,6 +114,9 @@ pub struct InstEnv {
     /// num_wens, dual, pipelined): per-port headers then dense data
     /// (see ArenaKind::Bram)
     pub bram_slot: HashMap<StrId, (u32, u32, u64, u32, u32, bool, bool)>,
+    /// local CReg (CRegN5) instance name -> (base slot, width): live
+    /// value then registered value, w words each (see ArenaKind::CReg5)
+    pub creg5_slot: HashMap<StrId, (u32, u32)>,
     /// local FIFO instance name -> (base slot, width, size, guarded):
     /// header (elems, saved_elems, fst, enq_at, deq_at, clear_at) then
     /// data (see ArenaKind::Fifo)

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -2423,6 +2423,41 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             phi.add_incoming(&[(&fv, f_end), (&sv, s_end)]);
             return Ok(phi.as_basic_value().into_int_value());
         }
+        if let Some(&(base, bw, _sz, _cs, nw, _dual, pipelined)) =
+            ie.bram_slot.get(&instance)
+        {
+            // BRAM reads return REGISTERED state (out, or out2 when
+            // pipelined) — a plain load, no bounds or bypass logic
+            // (addressing happened at put/tick)
+            let port_b = match mname.as_str() {
+                "read" | "a_read" => false,
+                "b_read" => true,
+                _ => return nope("bram value method mismatch"),
+            };
+            if bw != width || !args.is_empty() {
+                return nope("bram read shape mismatch");
+            }
+            let w = bw.max(1).div_ceil(64);
+            let wenw = nw.max(1).div_ceil(64);
+            let pw = 3 + wenw + 4 * w;
+            let off = base
+                + if port_b { pw } else { 0 }
+                + 3
+                + wenw
+                + (if pipelined { 3 } else { 2 }) * w;
+            return Ok(self.load_val(f, off, bw));
+        }
+        if let Some(&(base, cw)) = ie.creg5_slot.get(&instance) {
+            // CReg port reads return the LIVE value (schedule order
+            // makes port k's read see earlier ports' writes)
+            if !(mname.starts_with("port") && mname.ends_with("__read")) {
+                return nope("creg value method mismatch");
+            }
+            if cw != width {
+                return nope("creg read width mismatch");
+            }
+            return Ok(self.load_val(f, base, cw));
+        }
         // other prim children: trampoline into the interpreter's prim
         let Some(&child) = ie.children.get(&instance) else {
             return nope("call on unknown child");
@@ -5013,6 +5048,92 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     self.builder.build_unconditional_branch(done_bb).unwrap();
 
                     self.builder.position_at_end(done_bb);
+                    return Ok(());
+                }
+                if let Some(&(base, bw, sz, _cs, nw, dual, _pl)) =
+                    ie.bram_slot.get(instance)
+                {
+                    // put latches the pending update into the port
+                    // header (the tick applies it); in-range is pure
+                    // stores, out-of-range bounces to the boxed prim
+                    // for the bounds warning
+                    let port_b = match mname.as_str() {
+                        "put" | "a_put" => false,
+                        "b_put" => true,
+                        _ => return nope("non-put BRAM action"),
+                    };
+                    if args.len() != 3 || (port_b && !dual) {
+                        return nope("bram put shape mismatch");
+                    }
+                    let Some(&child) = ie.children.get(instance) else {
+                        return nope("call on unknown child");
+                    };
+                    let i64t = self.ctx.i64_type();
+                    let w = bw.max(1).div_ceil(64);
+                    let wenw = nw.max(1).div_ceil(64);
+                    let pw = 3 + wenw + 4 * w;
+                    let pb = base + if port_b { pw } else { 0 };
+                    let ww = self.expr_width(f, &args[0])?;
+                    let w0 = self.expr(f, &args[0])?;
+                    let wens = self.to_w(w0, ww, nw.max(1), false);
+                    let aw = self.expr_width(f, &args[1])?;
+                    let a0 = self.expr(f, &args[1])?;
+                    let a = self.to_w(a0, aw, 64, false);
+                    let vw = self.expr_width(f, &args[2])?;
+                    let v0 = self.expr(f, &args[2])?;
+                    let vv = self.to_w(v0, vw, bw.max(1), false);
+                    let go_bb = self.ctx.append_basic_block(func, "bpg");
+                    let fast_bb = self.ctx.append_basic_block(func, "bpf");
+                    let slow_bb = self.ctx.append_basic_block(func, "bps");
+                    let done_bb = self.ctx.append_basic_block(func, "bpd");
+                    self.builder.build_conditional_branch(cz, go_bb, done_bb).unwrap();
+
+                    self.builder.position_at_end(go_bb);
+                    let inb = self
+                        .builder
+                        .build_int_compare(
+                            IntPredicate::ULT,
+                            a,
+                            i64t.const_int(sz, false),
+                            "bpin",
+                        )
+                        .unwrap();
+                    self.builder.build_conditional_branch(inb, fast_bb, slow_bb).unwrap();
+
+                    self.builder.position_at_end(fast_bb);
+                    let now = self.load_word(f, self.env.now_slot);
+                    self.store_word(f, pb, now);
+                    self.store_word(f, pb + 1, a);
+                    self.store_val(f, pb + 3, nw.max(1), wens);
+                    self.store_val(f, pb + 3 + wenw, bw.max(1), vv);
+                    self.builder.build_unconditional_branch(done_bb).unwrap();
+
+                    self.builder.position_at_end(slow_bb);
+                    let saved: HashMap<StrId, IntValue<'ctx>> = f.ssa.clone();
+                    self.emit_prim_call(f, child, *method, args, 0, true)?;
+                    f.ssa = saved;
+                    self.builder.build_unconditional_branch(done_bb).unwrap();
+
+                    self.builder.position_at_end(done_bb);
+                    return Ok(());
+                }
+                if let Some(&(base, cw)) = ie.creg5_slot.get(instance) {
+                    // branchless port write: value = select(cond, v, old)
+                    if !(mname.starts_with("port") && mname.ends_with("__write"))
+                        || args.is_empty()
+                    {
+                        return nope("non-write CReg action");
+                    }
+                    let vw = self.expr_width(f, &args[0])?;
+                    let v0 = self.expr(f, &args[0])?;
+                    let vv = self.to_w(v0, vw, cw.max(1), false);
+                    let oldv = self.load_val(f, base, cw.max(1));
+                    let selv = self
+                        .builder
+                        .build_select(cz, vv, oldv, "cgw")
+                        .unwrap()
+                        .into_int_value();
+                    self.store_val(f, base, cw.max(1), selv);
                     return Ok(());
                 }
                 if let Some(&(base, fw, size, guarded, loopy)) =

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -487,7 +487,7 @@ pub fn compile_meta_object(
     bir_hash_raw: u64,
     split_thresh: u64,
     protos: &[u8],
-    edge_wire_ticks: bool,
+    edge_tick_level: u64,
     bdpi_names: &[String],
     snap: &[u8],
     plan_a: &[u8],
@@ -510,17 +510,22 @@ pub fn compile_meta_object(
     // loader must plan with the SAME value or refuse the artifact
     let t = module.add_global(i64t, None, "trs_split_thresh");
     t.set_initializer(&i64t.const_int(split_thresh, false));
-    // edge fns contain the compiled wire ticks: the loader skips the
-    // interp tick loop's covered entries iff this is set (absent in
-    // old artifacts -> loader reads 0)
+    // edge fns contain compiled ticks: the loader skips the interp
+    // tick loop's covered entries per this level (absent in old
+    // artifacts -> loader reads 0).  1 = wire clears only (historic);
+    // 2 = wire clears + CReg copies + BRAM port ticks.
     let wt = module.add_global(i64t, None, "trs_edge_wire_ticks");
-    wt.set_initializer(&i64t.const_int(edge_wire_ticks as u64, false));
+    wt.set_initializer(&i64t.const_int(edge_tick_level, false));
     // single definition of the callback pointer-globals every chunk
     // object references; the loader fills them after dlopen
     for name in ["trs_cb_foreign", "trs_cb_sigfpe", "trs_cb_prim", "trs_cb_stdio"] {
         let g = module.add_global(ptrt, None, name);
         g.set_initializer(&ptrt.const_null());
     }
+    // compiled-BRAM-tick helper pointer (edge fns call through it;
+    // the loader fills it with abi::trs_bram_tick)
+    let bt = module.add_global(i64t, None, "trs_bram_tick_cb");
+    bt.set_initializer(&i64t.const_zero());
     // direct-BDPI callee pointers, filled by the loader from the
     // artifact's companion .bdpi.so
     for n in bdpi_names {
@@ -1186,6 +1191,81 @@ fn lower_edge_ssa<'ctx>(
                     .unwrap()
                 };
                 bend.build_store(gepw, i64t.const_zero()).unwrap();
+            }
+        }
+        // compiled CReg ticks: copy the live value into the registered
+        // value (the whole untraced semantics of CReg::tick)
+        if let Some(copies) = plan.creg_copies.get(k) {
+            for &(base, words) in copies {
+                for i in 0..words {
+                    let s = unsafe {
+                        bend.build_gep(
+                            i64t,
+                            arena,
+                            &[i64t.const_int((base + i) as u64, false)],
+                            "cs",
+                        )
+                        .unwrap()
+                    };
+                    let v = bend.build_load(i64t, s, "cv").unwrap();
+                    let d = unsafe {
+                        bend.build_gep(
+                            i64t,
+                            arena,
+                            &[i64t
+                                .const_int((base + words + i) as u64, false)],
+                            "cd",
+                        )
+                        .unwrap()
+                    };
+                    bend.build_store(d, v).unwrap();
+                }
+            }
+        }
+        // compiled BRAM ticks: one helper call per port tick, through
+        // the trs_bram_tick_cb pointer-global (filled at load).  Call
+        // order preserves the rc.ticks walk — the cross-port bypass
+        // reads the other port's just-latched written_at.
+        if let Some(ticks) = plan.bram_ticks.get(k) {
+            if !ticks.is_empty() {
+                // external declaration: the meta object owns the single
+                // definition (loader fills it after dlopen)
+                let cbg = module
+                    .get_global("trs_bram_tick_cb")
+                    .unwrap_or_else(|| {
+                        module.add_global(i64t, None, "trs_bram_tick_cb")
+                    });
+                let fp64 = bend
+                    .build_load(i64t, cbg.as_pointer_value(), "btc")
+                    .unwrap()
+                    .into_int_value();
+                let fp =
+                    bend.build_int_to_ptr(fp64, ptrt, "btp").unwrap();
+                let tick_ty = ctx.void_type().fn_type(
+                    &[
+                        ptrt.into(),
+                        i64t.into(),
+                        i64t.into(),
+                        i64t.into(),
+                        i64t.into(),
+                    ],
+                    false,
+                );
+                for a in ticks {
+                    bend.build_indirect_call(
+                        tick_ty,
+                        fp,
+                        &[
+                            arena.into(),
+                            now.into(),
+                            i64t.const_int(a[0], false).into(),
+                            i64t.const_int(a[1], false).into(),
+                            i64t.const_int(a[2], false).into(),
+                        ],
+                        "bt",
+                    )
+                    .unwrap();
+                }
             }
         }
         bend.build_return(Some(&i32t.const_int(0, false))).unwrap();

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2712,6 +2712,11 @@ impl Interp {
                         // reads can WARN (bounds): the split analyzer
                         // treats it like an opaque prim
                         Some(ArenaKind::RegFile { .. }) => ChildClass::Other,
+                        // arena-backed; reads are begin-of-instant
+                        // (out changes only at tick) but keep the
+                        // conservative class until the compiled tier
+                        // exploits it
+                        Some(ArenaKind::Bram { .. }) => ChildClass::Other,
                         None => ChildClass::Other,
                     }),
                     InstKind::User { module, .. } => ChildRef::User(mods[*module].ir),
@@ -2815,6 +2820,7 @@ impl Interp {
             let mut creg_slot = HashMap::new();
             let mut fifo_slot = HashMap::new();
             let mut regfile_slot = HashMap::new();
+            let mut bram_slot = HashMap::new();
             // sorted iteration: slot assignment must be deterministic
             // across processes so an AOT artifact's baked slot numbers
             // match a fresh planning walk at load time
@@ -2852,6 +2858,28 @@ impl Interp {
                         let base =
                             alloc(&mut nslots, 2 + words * (1 + entries));
                         regfile_slot.insert(name, (base, width, lo, hi));
+                        attach.push((ci, base));
+                    }
+                    Some(ArenaKind::Bram {
+                        width,
+                        size,
+                        chunk_size,
+                        num_wens,
+                        dual,
+                        pipelined,
+                    }) => {
+                        let w = width.max(1).div_ceil(64);
+                        let wenw = num_wens.max(1).div_ceil(64);
+                        let pw = 3 + wenw + 4 * w;
+                        let ports = if dual { 2 } else { 1 };
+                        let base = alloc(
+                            &mut nslots,
+                            pw * ports + (size as u32) * w,
+                        );
+                        bram_slot.insert(
+                            name,
+                            (base, width, size, chunk_size, num_wens, dual, pipelined),
+                        );
                         attach.push((ci, base));
                     }
                     None => {}
@@ -3083,6 +3111,7 @@ impl Interp {
                     creg_slot,
                     fifo_slot,
                     regfile_slot,
+                    bram_slot,
                     reset_slot,
                     en_slot,
                     cfwf_slot,
@@ -3230,6 +3259,15 @@ impl Interp {
                     .collect();
                 m10.sort_unstable();
                 m10.hash(&mut h);
+                let mut m18: Vec<_> = e
+                    .bram_slot
+                    .iter()
+                    .map(|(&k, &(b, w, sz, cs, nw, du, pl))| {
+                        (k, b - r0, w, sz, cs, nw, du, pl)
+                    })
+                    .collect();
+                m18.sort_unstable();
+                m18.hash(&mut h);
                 // traced artifacts: recording layout is an exec input
                 let mut m16: Vec<_> = e
                     .rec_defs

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2936,6 +2936,10 @@ impl Interp {
                         regfile_slot.insert(name, (base, width, lo, hi));
                         attach.push((ci, base));
                     }
+                    // traced plans keep CRegs boxed: the per-port VCD
+                    // bookkeeping (EN/D_IN history) lives in the boxed
+                    // write path, which inline compiled writes bypass
+                    Some(ArenaKind::CReg5 { .. }) if self.vcd_trace => {}
                     Some(ArenaKind::CReg5 { width }) => {
                         let base =
                             alloc(&mut nslots, 2 * width.max(1).div_ceil(64));

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2717,6 +2717,8 @@ impl Interp {
                         // conservative class until the compiled tier
                         // exploits it
                         Some(ArenaKind::Bram { .. }) => ChildClass::Other,
+                        // live port-chained reads: never stable
+                        Some(ArenaKind::CReg5 { .. }) => ChildClass::Other,
                         None => ChildClass::Other,
                     }),
                     InstKind::User { module, .. } => ChildRef::User(mods[*module].ir),
@@ -2821,6 +2823,7 @@ impl Interp {
             let mut fifo_slot = HashMap::new();
             let mut regfile_slot = HashMap::new();
             let mut bram_slot = HashMap::new();
+            let mut creg5_slot = HashMap::new();
             // sorted iteration: slot assignment must be deterministic
             // across processes so an AOT artifact's baked slot numbers
             // match a fresh planning walk at load time
@@ -2858,6 +2861,12 @@ impl Interp {
                         let base =
                             alloc(&mut nslots, 2 + words * (1 + entries));
                         regfile_slot.insert(name, (base, width, lo, hi));
+                        attach.push((ci, base));
+                    }
+                    Some(ArenaKind::CReg5 { width }) => {
+                        let base =
+                            alloc(&mut nslots, 2 * width.max(1).div_ceil(64));
+                        creg5_slot.insert(name, (base, width));
                         attach.push((ci, base));
                     }
                     Some(ArenaKind::Bram {
@@ -3112,6 +3121,7 @@ impl Interp {
                     fifo_slot,
                     regfile_slot,
                     bram_slot,
+                    creg5_slot,
                     reset_slot,
                     en_slot,
                     cfwf_slot,
@@ -3259,6 +3269,13 @@ impl Interp {
                     .collect();
                 m10.sort_unstable();
                 m10.hash(&mut h);
+                let mut m19: Vec<_> = e
+                    .creg5_slot
+                    .iter()
+                    .map(|(&k, &(b, w))| (k, b - r0, w))
+                    .collect();
+                m19.sort_unstable();
+                m19.hash(&mut h);
                 let mut m18: Vec<_> = e
                     .bram_slot
                     .iter()

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -334,6 +334,18 @@ impl LazyJit {
     }
 }
 
+/// Per-comp compiled-tick lists + the covered tick-index sets (see
+/// prim_tick_coverage).
+pub(crate) struct TickCoverage {
+    pub(crate) wire_clears: Vec<Vec<u32>>,
+    pub(crate) creg_copies: Vec<Vec<(u32, u32)>>,
+    pub(crate) bram_ticks: Vec<Vec<[u64; 3]>>,
+    /// ticks covered by a level-1 artifact (wire clears only)
+    pub(crate) covered_wire: Vec<std::collections::HashSet<usize>>,
+    /// ticks covered by a level-2 artifact (wires + cregs + brams)
+    pub(crate) covered_all: Vec<std::collections::HashSet<usize>>,
+}
+
 /// Compiled state carried by the Stepper.
 pub(crate) struct JitPlans {
     /// the shared state arena; register prims and Interp::jit_arena_ptr
@@ -1057,7 +1069,19 @@ fn aot_emit(
             bir_hash_raw,
             split_thresh as u64,
             &encode_protos(protos),
-            edge_plan.is_some_and(|p| p.wire_clears.iter().any(|v| !v.is_empty())),
+            edge_plan
+                .map(|p| {
+                    let any = |vs: &[Vec<u32>]| vs.iter().any(|v| !v.is_empty());
+                    if any(&p.wire_clears)
+                        || p.creg_copies.iter().any(|v| !v.is_empty())
+                        || p.bram_ticks.iter().any(|v| !v.is_empty())
+                    {
+                        2
+                    } else {
+                        0
+                    }
+                })
+                .unwrap_or(0),
             bdpi_names,
             &d.snap_encode(bir_hash).unwrap_or_default(),
             plan_a,
@@ -1244,7 +1268,7 @@ fn aot_emit(
         bir_hash_raw,
         split_thresh as u64,
         &encode_protos(protos),
-        false, // chunked path never carries edge-SSA wire ticks
+        0, // chunked path never carries edge-SSA compiled ticks
         bdpi_names,
         &d.snap_encode(bir_hash).unwrap_or_default(),
         plan_a,
@@ -1441,7 +1465,7 @@ fn aot_load(
     ncomps: usize,
     bdpi_fill: &[(String, usize)],
 ) -> Result<
-    (Vec<CompiledSched>, Vec<CompiledExec>, Vec<FnProtos>, Vec<usize>, bool),
+    (Vec<CompiledSched>, Vec<CompiledExec>, Vec<FnProtos>, Vec<usize>, u64),
     String,
 > {
     unsafe {
@@ -1482,6 +1506,10 @@ fn aot_load(
             let g: libloading::Symbol<*mut usize> =
                 lib.get(name).map_err(|e| e.to_string())?;
             **g = addr;
+        }
+        // compiled-BRAM-tick helper (level-2 tick artifacts)
+        if let Ok(g) = lib.get::<*mut usize>(b"trs_bram_tick_cb") {
+            **g = trs_codegen::abi::trs_bram_tick as usize;
         }
         let pl: libloading::Symbol<*const u64> =
             lib.get(b"trs_protos_len").map_err(|e| e.to_string())?;
@@ -1607,15 +1635,15 @@ fn aot_load(
                 unsafe { **g = *addr };
             }
         }
-        // edge fns carry compiled wire ticks (absent symbol = old
-        // artifact = 0)
-        let wire_ticks = lib
+        // edge fns carry compiled ticks (absent symbol = old artifact
+        // = 0; 1 = wire clears only, 2 = wires + cregs + brams)
+        let tick_level = lib
             .get::<*const u64>(b"trs_edge_wire_ticks")
-            .map(|g| unsafe { **g } != 0)
-            .unwrap_or(false);
+            .map(|g| unsafe { **g })
+            .unwrap_or(0);
         // the artifact stays mapped for the process lifetime
         std::mem::forget(lib);
-        Ok((scheds, execs, protos, fused, wire_ticks))
+        Ok((scheds, execs, protos, fused, tick_level))
     }
 }
 
@@ -1650,25 +1678,46 @@ impl Interp {
     /// rc.ticks indices (runtime skip + central preconditions).  Must
     /// stay deterministic across processes: the linker bakes the
     /// clears, the loader re-derives the covered set.
-    fn wire_tick_coverage(
+    fn prim_tick_coverage(
         &self,
         inst_envs: &HashMap<usize, InstEnv>,
         rcomps: &[RComp],
-    ) -> (Vec<Vec<u32>>, Vec<std::collections::HashSet<usize>>) {
+    ) -> TickCoverage {
         let mut wire_of: HashMap<usize, u32> = HashMap::new();
+        let mut creg_of: HashMap<usize, (u32, u32)> = HashMap::new();
+        let mut bram_of: HashMap<usize, (u32, u32, u64, u32, u32, bool)> =
+            HashMap::new();
         for ie in inst_envs.values() {
             for (name, &(base, _w)) in &ie.wire_slot {
                 if let Some(&gi) = ie.children.get(name) {
                     wire_of.insert(gi, base);
                 }
             }
+            for (name, &(base, w)) in &ie.creg5_slot {
+                if let Some(&gi) = ie.children.get(name) {
+                    creg_of.insert(gi, (base, w.max(1).div_ceil(64)));
+                }
+            }
+            for (name, &(base, w, sz, cs, nw, du, _pl)) in &ie.bram_slot {
+                if let Some(&gi) = ie.children.get(name) {
+                    bram_of.insert(gi, (base, w, sz, cs, nw, du));
+                }
+            }
         }
-        let mut clears = Vec::with_capacity(rcomps.len());
-        let mut covered = Vec::with_capacity(rcomps.len());
+        let mut out = TickCoverage {
+            wire_clears: Vec::with_capacity(rcomps.len()),
+            creg_copies: Vec::with_capacity(rcomps.len()),
+            bram_ticks: Vec::with_capacity(rcomps.len()),
+            covered_wire: Vec::with_capacity(rcomps.len()),
+            covered_all: Vec::with_capacity(rcomps.len()),
+        };
         for rc in rcomps {
             let mut cl: Vec<u32> = Vec::new();
-            let mut cov = std::collections::HashSet::new();
-            for (ti, (inst, _pname, is_rst, _owner, gexpr)) in
+            let mut cc: Vec<(u32, u32)> = Vec::new();
+            let mut bt: Vec<[u64; 3]> = Vec::new();
+            let mut cov_w = std::collections::HashSet::new();
+            let mut cov_a = std::collections::HashSet::new();
+            for (ti, (inst, pname, is_rst, _owner, gexpr)) in
                 rc.ticks.iter().enumerate()
             {
                 if *is_rst || gexpr.is_some() || self.rstgen_out.contains_key(inst)
@@ -1677,14 +1726,36 @@ impl Interp {
                 }
                 if let Some(&slot) = wire_of.get(inst) {
                     cl.push(slot);
-                    cov.insert(ti);
+                    cov_w.insert(ti);
+                    cov_a.insert(ti);
+                } else if let Some(&(base, words)) = creg_of.get(inst) {
+                    cc.push((base, words));
+                    cov_a.insert(ti);
+                } else if let Some(&(base, w, sz, cs, nw, du)) =
+                    bram_of.get(inst)
+                {
+                    // tick order is preserved (the cross-port bypass
+                    // reads the other port's just-latched written_at)
+                    bt.push(trs_codegen::abi::bram_tick_args(
+                        base,
+                        pname == "clkB",
+                        w,
+                        sz,
+                        cs,
+                        nw,
+                        du,
+                    ));
+                    cov_a.insert(ti);
                 }
             }
             cl.sort_unstable();
-            clears.push(cl);
-            covered.push(cov);
+            out.wire_clears.push(cl);
+            out.creg_copies.push(cc);
+            out.bram_ticks.push(bt);
+            out.covered_wire.push(cov_w);
+            out.covered_all.push(cov_a);
         }
-        (clears, covered)
+        out
     }
 
     /// Task #24 M1: gap-wise cross-rule def-sharing legality census.
@@ -2479,6 +2550,8 @@ impl Interp {
             hoists,
             outlined_execs,
             wire_clears: Vec::new(),
+            creg_copies: Vec::new(),
+            bram_ticks: Vec::new(),
             export_slots,
         }
     }
@@ -3758,7 +3831,7 @@ impl Interp {
         // falls back to in-process compilation (which trials below)
         sl.lap("plan classes+nodes");
         let mut preloaded: Option<(Vec<CompiledSched>, Vec<CompiledExec>)> = None;
-        let mut wire_ticks_flag = false;
+        let mut tick_level_flag: u64 = 0;
         let mut protos_opt: Option<Vec<FnProtos>> = None;
         let mut fused_opt: Option<Vec<usize>> = None;
         if let JitRequest::Load { src } = &request {
@@ -3797,7 +3870,7 @@ impl Interp {
                     preloaded = Some((sch, exe));
                     protos_opt = Some(pr);
                     fused_opt = Some(fu);
-                    wire_ticks_flag = wt;
+                    tick_level_flag = wt;
                 }
                 Err(e) => {
                     // mode-mismatch fallbacks are by design (an untraced
@@ -3863,8 +3936,10 @@ impl Interp {
                     // valid through the slot), which a compiled clear
                     // inside the edge fn would starve
                     if !self.vcd_trace {
-                        plan.wire_clears =
-                            self.wire_tick_coverage(&inst_envs, rcomps).0;
+                        let cov = self.prim_tick_coverage(&inst_envs, rcomps);
+                        plan.wire_clears = cov.wire_clears;
+                        plan.creg_copies = cov.creg_copies;
+                        plan.bram_ticks = cov.bram_ticks;
                     }
                     plan
                 });
@@ -4176,8 +4251,10 @@ impl Interp {
             }
         }
         sl.lap("arena+flatmaps+workers");
-        let covered_ticks = if wire_ticks_flag {
-            self.wire_tick_coverage(&lazy.insts, rcomps).1
+        let covered_ticks = if tick_level_flag >= 2 {
+            self.prim_tick_coverage(&lazy.insts, rcomps).covered_all
+        } else if tick_level_flag == 1 {
+            self.prim_tick_coverage(&lazy.insts, rcomps).covered_wire
         } else {
             vec![Default::default(); rcomps.len()]
         };

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -4246,6 +4246,31 @@ impl Interp {
                         || uncovered_tick(rci)
                         || fused[rci] == 0
                     {
+                        // name the disqualifiers: an uncovered tick is
+                        // the actionable one (which prim, which port)
+                        if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                            for (ti, (ii, pname, is_rst, _, _)) in
+                                rc.ticks.iter().enumerate()
+                            {
+                                if !*is_rst
+                                    && !j.covered_ticks
+                                        .get(rci)
+                                        .is_some_and(|c| c.contains(&ti))
+                                {
+                                    eprintln!(
+                                        "trs jit: central bail #9: uncovered \
+                                         tick {} ({})",
+                                        self.insts[*ii].path, pname
+                                    );
+                                }
+                            }
+                            if !rc.early.is_empty() {
+                                eprintln!("trs jit: central bail #9: early rules");
+                            }
+                            if fused[rci] == 0 {
+                                eprintln!("trs jit: central bail #9: comp {rci} not fused");
+                            }
+                        }
                         { CENTRAL_BAIL[9].fetch_add(1, std::sync::atomic::Ordering::Relaxed); break 'central; }
                     }
                     pos_rcis.push(rci);

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -258,6 +258,12 @@ pub enum ArenaKind {
         dual: bool,
         pipelined: bool,
     },
+    /// CReg (CRegN5/CRegUN5, sync-reset or none): the semantic core —
+    /// live value (w words) then registered value (w words).  Port
+    /// reads return the live value, port writes store it; the
+    /// end-of-edge tick copies value into value_reg.  The per-port
+    /// VCD bookkeeping stays boxed (trampoline write path).
+    CReg5 { width: u32 },
 }
 
 /// Construct a primitive by BSV name.  `width` and other shape facts are
@@ -2336,6 +2342,11 @@ struct CReg {
     in_reset: bool,
     async_rst: bool,
     suppress: bool,
+    /// arena base when attached (see ArenaKind::CReg5): value then
+    /// value_reg, w words each — the semantic core.  The VCD
+    /// bookkeeping below stays in fields (maintained by the
+    /// trampoline write path and the interp tick).
+    slot: Option<*mut u64>,
     // VCD state (bs_prim_mod_reg.h:817+): per-port write history, the
     // registered value at cycle start, latched ENs
     write_val: Vec<Value>,
@@ -2361,12 +2372,52 @@ impl CReg {
             in_reset: false,
             async_rst,
             suppress: false,
+            slot: None,
             write_val: (0..5).map(|_| Value::undet(width)).collect(),
             did_write: vec![false; 5],
             did_write_rec: vec![false; 5],
             read_val0: Value::undet(width),
             vcd_base: 0,
             vcd_back: None,
+        }
+    }
+    fn words(&self) -> usize {
+        (self.value.width.max(1) as usize).div_ceil(64)
+    }
+    fn arena_get(&self, second: bool) -> Value {
+        let slot = self.slot.unwrap();
+        let w = self.words();
+        let off = if second { w } else { 0 };
+        let src = unsafe { std::slice::from_raw_parts(slot.add(off), w) };
+        Value::from_limbs64(self.value.width.max(1), src.to_vec())
+    }
+    fn arena_set(&self, second: bool, v: &Value) {
+        let slot = self.slot.unwrap();
+        let w = self.words();
+        let off = if second { w } else { 0 };
+        let dst = unsafe { std::slice::from_raw_parts_mut(slot.add(off), w) };
+        for (i, d) in dst.iter_mut().enumerate() {
+            *d = v.limbs64().get(i).copied().unwrap_or(0);
+        }
+    }
+    fn load_val(&self) -> Value {
+        if self.slot.is_some() { self.arena_get(false) } else { self.value.clone() }
+    }
+    fn store_val(&mut self, v: Value) {
+        if self.slot.is_some() {
+            self.arena_set(false, &v);
+        } else {
+            self.value = v;
+        }
+    }
+    fn load_val_reg(&self) -> Value {
+        if self.slot.is_some() { self.arena_get(true) } else { self.value_reg.clone() }
+    }
+    fn store_val_reg(&mut self, v: Value) {
+        if self.slot.is_some() {
+            self.arena_set(true, &v);
+        } else {
+            self.value_reg = v;
         }
     }
 }
@@ -2380,7 +2431,7 @@ impl Prim for CReg {
     fn sym_read(&mut self, key: &str, _now: u64) -> Option<Value> {
         // live value == registered value at any stop boundary (the
         // edge tick latched it); mid-cycle it is the port-write chain
-        (key.is_empty()).then(|| self.value.clone())
+        (key.is_empty()).then(|| self.load_val())
     }
     fn vcd_defs(
         &mut self,
@@ -2482,7 +2533,7 @@ impl Prim for CReg {
         // portK__read returns the live value (port 0 sees the registered
         // value at cycle start because nothing has written yet)
         if method.starts_with("port") && method.ends_with("__read") {
-            self.value.clone()
+            self.load_val()
         } else {
             panic!("CReg: unknown value method {method:?}")
         }
@@ -2490,7 +2541,7 @@ impl Prim for CReg {
     fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
         if method.starts_with("port") && method.ends_with("__write") {
             if !(self.async_rst && self.suppress) {
-                self.value = args[0].clone();
+                self.store_val(args[0].clone());
                 let i = method.as_bytes()[4].saturating_sub(b'0') as usize;
                 if i < 5 {
                     self.did_write[i] = true;
@@ -2504,8 +2555,9 @@ impl Prim for CReg {
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, gate: bool) {
         if !gate { return; }
         // Q_OUT_0 starts from the value registered before this cycle
-        self.read_val0 = self.value_reg.clone();
-        self.value_reg = self.value.clone();
+        self.read_val0 = self.load_val_reg();
+        let v = self.load_val();
+        self.store_val_reg(v);
         for i in 0..5 {
             self.did_write_rec[i] = self.did_write[i];
             self.did_write[i] = false;
@@ -2513,8 +2565,8 @@ impl Prim for CReg {
     }
     fn rst_tick(&mut self, _now: u64) {
         if self.in_reset {
-            self.value = self.reset_value.clone();
-            self.value_reg = self.reset_value.clone();
+            self.store_val(self.reset_value.clone());
+            self.store_val_reg(self.reset_value.clone());
             self.suppress = true;
         }
     }
@@ -2522,12 +2574,25 @@ impl Prim for CReg {
         self.in_reset = asserted;
         if asserted {
             if self.async_rst {
-                self.value = self.reset_value.clone();
+                self.store_val(self.reset_value.clone());
                 self.suppress = true;
             }
         } else {
             self.suppress = false;
         }
+    }
+
+    fn arena_kind(&self) -> Option<ArenaKind> {
+        // async-reset CRegs suppress writes while in reset (same gate
+        // as Reg): not arena-backable
+        (!self.async_rst)
+            .then_some(ArenaKind::CReg5 { width: self.value.width })
+    }
+    fn arena_attach(&mut self, slot: *mut u64) {
+        self.slot = Some(slot);
+        let (v, vr) = (self.value.clone(), self.value_reg.clone());
+        self.arena_set(false, &v);
+        self.arena_set(true, &vr);
     }
 }
 

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -241,6 +241,23 @@ pub enum ArenaKind {
     /// (sub of the most-recently-updated address returns upd_prev);
     /// out-of-range accesses stay on the trampoline (warnings).
     RegFile { width: u32, lo: u64, hi: u64 },
+    /// BRAM1/BRAM2 (+BE/Load variants) small enough for a dense image.
+    /// Per-port header (port B present only when `dual`):
+    ///   upd_at, upd_addr, written_at (1 word each),
+    ///   upd_wens (wenw words), upd_val, upd_prev, out, out2 (w words
+    ///   each; w = ceil(max(width,1)/64), wenw = ceil(max(num_wens,1)/64)).
+    /// Then size * w data words (addresses are 0-based).  put() is a
+    /// plain header store; the end-of-edge tick (Bram::clk) latches the
+    /// pending update into data/out with the cross-port same-instant
+    /// bypass — reads return out (out2 when `pipelined`).
+    Bram {
+        width: u32,
+        size: u64,
+        chunk_size: u32,
+        num_wens: u32,
+        dual: bool,
+        pipelined: bool,
+    },
 }
 
 /// Construct a primitive by BSV name.  `width` and other shape facts are
@@ -4954,6 +4971,10 @@ struct Bram {
     data: std::collections::HashMap<u64, Value>,
     a: BramPort,
     b: BramPort,
+    /// arena base when attached (see ArenaKind::Bram): the slots are
+    /// then the single source of truth; `data` and the port structs
+    /// hold only the pre-attach (construction/load-file) image
+    slot: Option<*mut u64>,
     vcd_base: u32,
     vcd_back: Option<(BramVcdBack, BramVcdBack)>,
 }
@@ -4998,6 +5019,7 @@ impl Bram {
             data: Default::default(),
             a: BramPort::new(width),
             b: BramPort::new(width),
+            slot: None,
             vcd_base: 0,
             vcd_back: None,
         };
@@ -5015,6 +5037,103 @@ impl Bram {
         addr_dump_val(a, self.addr_bits)
     }
 
+    // ---- arena layout (see ArenaKind::Bram) ----
+    fn vwords(&self) -> usize {
+        (self.width.max(1) as usize).div_ceil(64)
+    }
+    fn wen_words(&self) -> usize {
+        (self.num_wens.max(1) as usize).div_ceil(64)
+    }
+    fn port_words(&self) -> usize {
+        3 + self.wen_words() + 4 * self.vwords()
+    }
+    fn port_base(&self, port_b: bool) -> usize {
+        if port_b { self.port_words() } else { 0 }
+    }
+    fn data_base(&self) -> usize {
+        self.port_words() * if self.dual { 2 } else { 1 }
+    }
+    fn rd_val(&self, off: usize, width: u32, words: usize) -> Value {
+        let slot = self.slot.unwrap();
+        let src = unsafe { std::slice::from_raw_parts(slot.add(off), words) };
+        Value::from_limbs64(width.max(1), src.to_vec())
+    }
+    fn wr_val(&self, off: usize, v: &Value, words: usize) {
+        let slot = self.slot.unwrap();
+        let dst = unsafe { std::slice::from_raw_parts_mut(slot.add(off), words) };
+        for (i, d) in dst.iter_mut().enumerate() {
+            *d = v.limbs64().get(i).copied().unwrap_or(0);
+        }
+    }
+    /// Whole-header view of one port: arena when attached, the
+    /// BramPort struct otherwise.  clk() and VCD use this; the
+    /// per-call paths (put, read) touch only the words they need.
+    fn load_port(&self, port_b: bool) -> BramPort {
+        let Some(slot) = self.slot else {
+            let p = if port_b { &self.b } else { &self.a };
+            return BramPort {
+                upd_at: p.upd_at,
+                upd_addr: p.upd_addr,
+                upd_wens: p.upd_wens.clone(),
+                upd_val: p.upd_val.clone(),
+                written_at: p.written_at,
+                upd_prev: p.upd_prev.clone(),
+                out: p.out.clone(),
+                out2: p.out2.clone(),
+            };
+        };
+        let b = self.port_base(port_b);
+        let (wenw, w) = (self.wen_words(), self.vwords());
+        unsafe {
+            BramPort {
+                upd_at: *slot.add(b),
+                upd_addr: *slot.add(b + 1),
+                written_at: *slot.add(b + 2),
+                upd_wens: self.rd_val(b + 3, self.num_wens, wenw),
+                upd_val: self.rd_val(b + 3 + wenw, self.width, w),
+                upd_prev: self.rd_val(b + 3 + wenw + w, self.width, w),
+                out: self.rd_val(b + 3 + wenw + 2 * w, self.width, w),
+                out2: self.rd_val(b + 3 + wenw + 3 * w, self.width, w),
+            }
+        }
+    }
+    fn store_port(&mut self, port_b: bool, p: BramPort) {
+        let Some(slot) = self.slot else {
+            *(if port_b { &mut self.b } else { &mut self.a }) = p;
+            return;
+        };
+        let b = self.port_base(port_b);
+        let (wenw, w) = (self.wen_words(), self.vwords());
+        unsafe {
+            *slot.add(b) = p.upd_at;
+            *slot.add(b + 1) = p.upd_addr;
+            *slot.add(b + 2) = p.written_at;
+        }
+        self.wr_val(b + 3, &p.upd_wens, wenw);
+        self.wr_val(b + 3 + wenw, &p.upd_val, w);
+        self.wr_val(b + 3 + wenw + w, &p.upd_prev, w);
+        self.wr_val(b + 3 + wenw + 2 * w, &p.out, w);
+        self.wr_val(b + 3 + wenw + 3 * w, &p.out2, w);
+    }
+    fn mem_get(&self, addr: u64) -> Value {
+        if self.slot.is_some() {
+            let w = self.vwords();
+            return self.rd_val(self.data_base() + addr as usize * w, self.width, w);
+        }
+        self.data
+            .get(&addr)
+            .cloned()
+            .unwrap_or_else(|| Value::undet(self.width))
+    }
+    fn mem_set(&mut self, addr: u64, v: Value) {
+        if self.slot.is_some() {
+            let w = self.vwords();
+            self.wr_val(self.data_base() + addr as usize * w, &v, w);
+            return;
+        }
+        self.data.insert(addr, v);
+    }
+
     fn put(&mut self, port_b: bool, wens: Value, addr: u64, val: Value, now: u64, pname: &str) {
         if addr > self.hi_addr {
             qprintln!(
@@ -5025,6 +5144,18 @@ impl Bram {
                 self.addr_hex(addr)
             );
         }
+        if self.slot.is_some() {
+            let b = self.port_base(port_b);
+            let (wenw, w) = (self.wen_words(), self.vwords());
+            unsafe {
+                let slot = self.slot.unwrap();
+                *slot.add(b) = now;
+                *slot.add(b + 1) = addr;
+            }
+            self.wr_val(b + 3, &wens, wenw);
+            self.wr_val(b + 3 + wenw, &val, w);
+            return;
+        }
         let p = if port_b { &mut self.b } else { &mut self.a };
         p.upd_at = now;
         p.upd_addr = addr;
@@ -5033,21 +5164,18 @@ impl Bram {
     }
 
     fn clk(&mut self, port_b: bool, now: u64) {
-        let (pa, pb) = (&mut self.a, &mut self.b);
-        let (me, other) = if port_b { (pb, pa) } else { (pa, pb) };
+        let mut me = self.load_port(port_b);
+        let other = self.load_port(!port_b);
         me.out2 = me.out.clone();
         if me.upd_at != now {
+            self.store_port(port_b, me);
             return;
         }
         let is_write = !me.upd_wens.is_zero();
         if me.upd_addr > self.hi_addr {
             me.out = Value::undet(self.width);
         } else if is_write {
-            let cur = self
-                .data
-                .get(&me.upd_addr)
-                .cloned()
-                .unwrap_or_else(|| Value::undet(self.width));
+            let cur = self.mem_get(me.upd_addr);
             // previous value: if the other port wrote the same address at
             // this instant, use its pre-write value
             me.written_at = now;
@@ -5085,7 +5213,7 @@ impl Bram {
                 }
                 r
             };
-            self.data.insert(me.upd_addr, merged.clone());
+            self.mem_set(me.upd_addr, merged.clone());
             me.out = merged;
         } else {
             // read: if the other port wrote the same address at this
@@ -5093,13 +5221,11 @@ impl Bram {
             let v = if other.written_at == now && other.upd_addr == me.upd_addr {
                 other.upd_prev.clone()
             } else {
-                self.data
-                    .get(&me.upd_addr)
-                    .cloned()
-                    .unwrap_or_else(|| Value::undet(self.width))
+                self.mem_get(me.upd_addr)
             };
             me.out = v;
         }
+        self.store_port(port_b, me);
     }
 }
 
@@ -5165,11 +5291,9 @@ impl Prim for Bram {
         let mut num = self.vcd_base;
         let nports = if self.dual { 2 } else { 1 };
         for pi in 0..nports {
-            let (p, back) = if pi == 0 {
-                (&self.a, &mut back_a)
-            } else {
-                (&self.b, &mut back_b)
-            };
+            let p = self.load_port(pi == 1);
+            let p = &p;
+            let back = if pi == 0 { &mut back_a } else { &mut back_b };
             let en = p.upd_at == now;
             let dout = if self.pipelined { p.out2.clone() } else { p.out.clone() };
             match dt {
@@ -5254,21 +5378,21 @@ impl Prim for Bram {
     }
 
     fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+        let read = |port_b: bool| -> Value {
+            if self.slot.is_some() {
+                let w = self.vwords();
+                let off = self.port_base(port_b)
+                    + 3
+                    + self.wen_words()
+                    + (if self.pipelined { 3 } else { 2 }) * w;
+                return self.rd_val(off, self.width, w);
+            }
+            let p = if port_b { &self.b } else { &self.a };
+            if self.pipelined { p.out2.clone() } else { p.out.clone() }
+        };
         match method {
-            "read" | "a_read" => {
-                if self.pipelined {
-                    self.a.out2.clone()
-                } else {
-                    self.a.out.clone()
-                }
-            }
-            "b_read" => {
-                if self.pipelined {
-                    self.b.out2.clone()
-                } else {
-                    self.b.out.clone()
-                }
-            }
+            "read" | "a_read" => read(false),
+            "b_read" => read(true),
             m => panic!("BRAM: unknown value method {m:?}"),
         }
     }
@@ -5294,6 +5418,39 @@ impl Prim for Bram {
             "clkB" => self.clk(true, now),
             p => panic!("BRAM: unknown tick port {p:?}"),
         }
+    }
+
+    fn arena_kind(&self) -> Option<ArenaKind> {
+        // dense image: gate the slot budget — huge memories stay boxed.
+        // The budget is per-prim and larger than RegFile's (BRAMs are
+        // the caches of CPU-scale designs; a 32K-word cache array is
+        // the point, not the exception).
+        let size = self.hi_addr.checked_add(1)?;
+        let slots = (self.port_words() * if self.dual { 2 } else { 1 }) as u64
+            + size * self.vwords() as u64;
+        (slots <= 1 << 20).then_some(ArenaKind::Bram {
+            width: self.width,
+            size,
+            chunk_size: self.chunk_size,
+            num_wens: self.num_wens,
+            dual: self.dual,
+            pipelined: self.pipelined,
+        })
+    }
+    fn arena_attach(&mut self, slot: *mut u64) {
+        self.slot = Some(slot);
+        let a = std::mem::replace(&mut self.a, BramPort::new(self.width));
+        let b = std::mem::replace(&mut self.b, BramPort::new(self.width));
+        self.store_port(false, a);
+        if self.dual {
+            self.store_port(true, b);
+        }
+        let undet = Value::undet(self.width);
+        for addr in 0..=self.hi_addr {
+            let v = self.data.remove(&addr);
+            self.mem_set(addr, v.unwrap_or_else(|| undet.clone()));
+        }
+        self.data = Default::default();
     }
 }
 


### PR DESCRIPTION
The workload-proven runtime rung (task: Flute's central loop bailed on uncovered BRAM ticks; TrafficBRAM ran 2.3× behind Bluesim). Measured first: the new `TRS_JIT_TRACE` bail-#9 census names every disqualifying tick — TrafficBRAM: 32 dual-port BRAMs; Flute: 17 ticks, of which 10 are its five cache/BTB BRAMs and 7 are **CRegs** (`crg_time`/`crg_timecmp` and the reverting-reg cores of `mkPipelineFIFOF` — all `MOD_CReg`). So the rung is exactly two prim kinds, in four commits:

1. **929543c80 — BRAMs join the state arena** (`ArenaKind::Bram`): dense image, per-port pending-write headers + data; put/tick/reads/VCD all arena-backed once attached; huge memories stay boxed (1&lt;&lt;20-word gate). AOT_LAYOUT_REV 21.
2. **344e30726 — CRegs join the arena** (`ArenaKind::CReg5`): the semantic core (live value + registered value); the per-port VCD bookkeeping stays boxed, and traced plans keep CRegs boxed entirely — their VCD needs the write-path history.
3. **9d12e52ce — prim ticks compile into the fused edge fns.** CReg ticks become a two-word copy; BRAM port ticks call `abi::trs_bram_tick` through a loader-filled pointer-global — the exact arena form of `Bram::clk` (pending-put latch, byte-enable lane merge, cross-port same-instant bypass, out-of-range → undet), plain Rust in the always-built abi layer so slim-runtime exes carry it. The artifact's tick flag becomes a level (1 = historic wire-only, 2 = wires+cregs+brams); the loader recomputes the covered set at the matching level. Call order preserves the interpreter's tick walk (the bypass reads the other port's just-latched `written_at`).
4. **b03c0eb87 — inline compiled access.** BRAM reads are a registered-state load; puts store the header under the call condition (out-of-range bounces to the boxed prim for the put-time warning); CReg port reads/writes are a load / branchless conditional store.

**Scoreboard** (same box, medians):

| design | before | after | Bluesim |
|---|---|---|---|
| TrafficBRAM | 0.29s (2.3× behind) | **0.075s (1.6× ahead)** | 0.118s |
| Flute rv64ui-p-add | ~101k c/s general loop | **315k c/s, central loop engaged** | 54k c/s |

**Witnesses at every commit**: TrafficBRAM byte-exact vs Bluesim (plain, traced `-V`, 3-way lockstep — the shadow engines tick interpreted against the fused main, so the compiled tick semantics are cross-checked cycle by cycle); BramWideBE golden-exact (its 1024-bit/128-lane reference C++ still doesn't compile — the known upstream bs_wide_data.h issue); TestCReg5/U5/U3/A2 byte-exact + lockstep; regress 10/10.

**Seals**: full **RV64ACIMU ISA battery 84/84 PASS, zero output mismatches** (rv64ui/um/ua/uc physical, both engines, wall-clock banner excluded); full 3-way selfcheck corpus sweep at this head — **996 PASS / 0 DIFF / 0 divergences**, terminal classes test-for-test identical to every prior seal.

Remaining on the perf ledger after this rung: Mesa's 3× (RegFileLoad-heavy) and DFT64v5's 1.9× residuals; the BRAM read-stability upgrade in the split analyzer (reads are begin-of-instant — kept conservative here) is noted headroom.

Stacks on #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_