### PR TITLE
trs: shape-gated O1 tier for huge straight-line functions — BRAM0Test link 155s → 30s

### DIFF
--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -216,6 +216,47 @@ fn module_max_int_width(module: &Module) -> u32 {
     w
 }
 
+/// (instructions, blocks) of the module's largest-by-instructions
+/// function (see the O1 size tier in run_ir_passes).
+fn module_max_fn_shape(module: &Module) -> (u64, u64) {
+    let mut max = (0u64, 0u64);
+    let mut f = module.get_first_function();
+    while let Some(func) = f {
+        let mut n = 0u64;
+        let mut b = 0u64;
+        for bb in func.get_basic_blocks() {
+            b += 1;
+            let mut ins = bb.get_first_instruction();
+            while let Some(i) = ins {
+                n += 1;
+                ins = i.get_next_instruction();
+            }
+        }
+        if n > max.0 {
+            max = (n, b);
+        }
+        f = func.get_next_function();
+    }
+    max
+}
+
+/// Above this size (instructions in one function), a STRAIGHT-LINE
+/// giant drops the default AOT pipeline from O3 to O1.  LLVM's O2/O3
+/// function passes are superlinear in function size: a rule-heavy
+/// composition's fused edge fn (sysBRAM0Test: 67k insns / 3.4k blocks
+/// from 776 inlined rules, ~20 insns/block) measured 139.6s under
+/// default<O3> vs 24.8s under default<O1> — and the O1 artifact RAN
+/// faster too (24.5 vs 34.9ms; the over-optimized giant loses on
+/// I-cache), output byte-exact.  The tier is shape-gated: a BRANCH-
+/// LADDER giant (sysTb_v1's exec_i2_20: 24.3k insns over 24.0k
+/// blocks, ~1 insn/block) must KEEP O3 — only jump threading and
+/// aggressive SimplifyCFG collapse the ladder, and without them the
+/// backend's TailDuplicator (MachineSSAUpdater PHI search) runs for
+/// hours on the surviving block graph.  Straight-line = at least
+/// IR_PASS_LINE_RATIO instructions per block, on average.
+const IR_PASS_FN_SIZE_CAP: u64 = 20_000;
+const IR_PASS_LINE_RATIO: u64 = 8;
+
 /// Run the LLVM middle-end pipeline on a module when TRS_JIT_OPT
 /// asks for optimization.  The engine/object paths only apply BACKEND
 /// codegen opts; without this the IR pass pipeline (GVN, instcombine,
@@ -239,8 +280,20 @@ fn run_ir_passes(module: &Module) -> Result<(), Ineligible> {
                 return Ok(());
             }
             // O3 default (measured on the edge-SSA + outline-model
-            // IR: ~22% run for +1s link vs O1; reference ships -O3)
-            3
+            // IR: ~22% run for +1s link vs O1; reference ships -O3),
+            // tiered down to O1 for a huge STRAIGHT-LINE function
+            // (see IR_PASS_FN_SIZE_CAP — faster to compile AND to
+            // run; branch-ladder giants must keep O3)
+            {
+                let (insns, blocks) = module_max_fn_shape(module);
+                if insns > IR_PASS_FN_SIZE_CAP
+                    && insns >= blocks.saturating_mul(IR_PASS_LINE_RATIO)
+                {
+                    1
+                } else {
+                    3
+                }
+            }
         }
         Err(_) => return Ok(()),
     };


### PR DESCRIPTION
The last bad number in the stamped 3-way table (per Ravi: *"Fix the wide state now"*). One commit (5d31b6668); the diagnosis found **two distinct pathologies wearing one symptom**:

1. **BRAM0Test (155.5s link):** the fused edge fn is **67k instructions / 3.4k blocks** of straight-line code (776 rules inlined), and LLVM's O2/O3 function passes are superlinear in function size — 139.6s of the link was `default&lt;O3&gt;`. Under `default&lt;O1&gt;` the same module optimizes in 24.8s **and the artifact runs faster** (24.5ms vs 34.9ms — the over-optimized giant loses on I-cache), output byte-exact.
2. **DFT64 (the trap):** its giant is one exec body of **24.3k instructions over 24.0k blocks** — a branch ladder. Tiering it to O1 sent the un-collapsed ladder into the backend, where `TailDuplicator`'s `MachineSSAUpdater` PHI search ran for hours (witnessed by stack-sampling the hang). Only O3's jump threading tames that shape.

So the tier is **shape-gated**: the module's largest function drops the pipeline to O1 only when it is both huge (&gt;20k instructions) and straight-line (≥8 instructions/block on average); branch ladders keep O3. Same doctrine as the existing i65536 width cap: a measured escape hatch, default behavior otherwise unchanged.

**Results:** BRAM0Test link **155.5s → 30.4s** (its total build is now ~54s — parity with Bluesim's 56s, near Verilator's 49s, vs 3–9× worse before); DFT64v1 unchanged at its working 71s; both artifacts byte-exact vs their O3 predecessors; regress 10/10.

**Seal:** 3-way selfcheck corpus sweep at this head — **996 PASS / 0 DIFF / 0 divergences**, terminal classes test-for-test identical to every prior seal.

Two honest notes from the seal:
- PERF_REGRESS count ran high (83 vs the usual 24–42). Investigated: **not this change** — a direct binary A/B on a flagged link (sysLoopUpdate) shows trs/20 0.84s vs trs/21 0.92s, and the flagged run regression (sysDMA 4.15s) measures 0.01s standalone with the tier provably not firing (its largest fn is 4.9k insns). The fence baselines date from trs/13, and small-design link time has grown ~3.5× cumulatively since (0.26s → 0.9s on sysLoopUpdate — LLVM passes 313ms + backend 488ms on a 3k-insn module). That cumulative growth is now a **ledgered follow-up** (suspects: embedded-snap byte-array globals and per-artifact machinery in the backend), as is re-baselining the fence once it's understood.
- The DFT64 branch-ladder shape itself (case cones lowered as branch chains; its remaining 71s link) is the other ledgered follow-up.

Stacks on #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_