### PR TITLE
bluetcl: make wiretypemap and porttypes scale to large modules

### DIFF
--- a/src/comp/Pragma.hs
+++ b/src/comp/Pragma.hs
@@ -19,6 +19,7 @@ module Pragma(
               extractSchedPragmaIds,
 
               isAlwaysRdy,
+              mkIsAlwaysRdy,
               isAlwaysEn,
               isEnWhenRdy,
 
@@ -52,6 +53,7 @@ import Prelude hiding ((<>))
 #endif
 
 import qualified Data.Map as M
+import qualified Data.Set as S
 import Data.Maybe(listToMaybe)
 import Data.List(sort)
 import qualified Data.Generics as Generic
@@ -657,6 +659,23 @@ isAlwaysRdy ((PPalwaysEnabled is):pps) i =
    then True
    else isAlwaysRdy pps i
 isAlwaysRdy (pp:pps) i = isAlwaysRdy pps i
+
+-- Precomputed form of "isAlwaysRdy", for callers that query many
+-- methods: "isAlwaysRdy" rebuilds and rescans the pragma method lists
+-- per query, which goes quadratic when both the interface and the
+-- always_ready/always_enabled lists are large.  Equivalent because a
+-- list match implies isRdyId (the list elements are mkRdyId-built) and
+-- the whole-module case returns isRdyId directly, so pragma order
+-- never affects the result.
+mkIsAlwaysRdy :: [PProp] -> (Id -> Bool)
+mkIsAlwaysRdy pps =
+    let whole_module =
+            or [ null is | PPalwaysReady is <- pps ] ||
+            or [ null is | PPalwaysEnabled is <- pps ]
+        ar_ids = S.fromList $
+            [ mkRdyId (flattenUSId m) | PPalwaysReady is <- pps, m <- is ] ++
+            [ mkRdyId (flattenUSId m) | PPalwaysEnabled is <- pps, m <- is ]
+    in  \ i -> isRdyId i && (whole_module || i `S.member` ar_ids)
 
 
 -- NOTE: always_enabled implies enabled_when_ready

--- a/src/comp/WireAnalysis.hs
+++ b/src/comp/WireAnalysis.hs
@@ -27,9 +27,9 @@
 -- dict can index by VCD wire name and match whichever form appears.
 module WireAnalysis (getWireTypeMap) where
 
-import Data.List(nub)
 import qualified Data.Map as M
 
+import Util(stableOrdNub)
 import Id(getIdString, mkRdyId, isRdyId, mkIdCanFire, mkIdWillFire)
 import ISyntax(IType)
 import ISyntaxUtil(itBool, itClock, itReset)
@@ -53,7 +53,9 @@ getWireTypeMap apkg =
         en_rdy_entries = concatMap methodEnRdyEntries ifc
         rule_entries = concatMap ruleFireEntries (apkg_rules apkg)
         sub_entries = concatMap submodEntries (apkg_state_instances apkg)
-    in  nub $
+        -- dedup must not be quadratic: a large flat module yields one
+        -- candidate list entry per wire form, easily 10^5-10^6 entries
+    in  stableOrdNub $
         ext_entries
             ++ clk_entries ++ outClk_entries
             ++ rst_entries ++ outRst_entries

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -1219,8 +1219,14 @@ tclModule ["wiretypemap",modname] = do
        Nothing -> return $ TLst []
        Just abmi -> do
            let apkg = abemi_apkg abmi
-               mkEntryObj (name, t) = TLst [TStr name, TStr (pfpString t)]
-           return $ TLst $ map mkEntryObj $ getWireTypeMap apkg
+               entries = getWireTypeMap apkg
+               -- render each distinct type once: a large module has many
+               -- wires but few distinct types, and pfpString would
+               -- otherwise dominate, re-run per entry
+               typeObjs = M.fromList [ (t, TStr (pfpString t))
+                                     | (_, t) <- entries ]
+               mkEntryObj (name, t) = TLst [TStr name, typeObjs M.! t]
+           return $ TLst $ map mkEntryObj entries
 ------
 tclModule ["flags",modname] = do
   if (isPrimitiveModule modname)

--- a/src/comp/bluetcl.hs
+++ b/src/comp/bluetcl.hs
@@ -33,7 +33,7 @@ import qualified Data.Map as M
 
 -- Bluespec imports
 import Util(quote, concatMapM, concatUnzip3, lastOrErr, fromJustOrErr, fst3,
-            thd, readOrErr)
+            thd, readOrErr, stableOrdNub)
 import IOUtil(getEnvDef)
 
 import Util(mapFst, mapSnd)
@@ -1208,7 +1208,9 @@ tclModule ["porttypes",modname] = do
            (arginfo, ifcinfo) <- getModPortInfo apkg pps tifc
            let h_arg_types = concatMap dispPortsModArg arginfo
                h_ifc_types = concatMap dispPortsIfc ifcinfo
-           return $ TLst $ nub (h_arg_types ++ h_ifc_types)
+           -- dedup must not be quadratic: a module can have thousands
+           -- of ports, one entry each
+           return $ TLst $ stableOrdNub (h_arg_types ++ h_ifc_types)
 ------
 tclModule ["wiretypemap",modname] = do
   if (isPrimitiveModule modname)
@@ -3583,9 +3585,10 @@ getModPortInfo apkg pps tifc = do
     let ifc' :: [AIFace]
         ifc' = apkg_interface apkg
         -- need to filter out ready methods that are always ready
+        -- (precomputed form: one query per interface field)
+        isARdy = mkIsAlwaysRdy pps
         notAlwaysRdy :: AIFace -> Bool
-        notAlwaysRdy aif = let mid = aif_name aif
-                           in not $ (isRdyId mid) && (isAlwaysRdy pps mid)
+        notAlwaysRdy aif = not (isARdy (aif_name aif))
         ifc = filter notAlwaysRdy ifc'
 
     -- interface hierarchy

--- a/src/vendor/htcl/HTcl.hs
+++ b/src/vendor/htcl/HTcl.hs
@@ -831,7 +831,7 @@ data HTclObj  = TLst [HTclObj]
               | TInt Int
               | TDbl Double
               | TCL TclObj
- deriving (Show, Eq)
+ deriving (Show, Eq, Ord)
 
 -- instance for HTclObj
 instance  TclObjCvt HTclObj where

--- a/testsuite/bsc.bluetcl/fst_correlation/correlate_fst.tcl
+++ b/testsuite/bsc.bluetcl/fst_correlation/correlate_fst.tcl
@@ -117,14 +117,25 @@ proc confirmType { label comps modName dutScope } {
     }
 }
 
+# One wiretypemap per module, however many scopes it appears at --
+# the map is keyed by module name, so instances share it.
+set typeDictCache [dict create]
+proc typeDictFor { modName } {
+    global typeDictCache
+    if { ![dict exists $typeDictCache $modName] } {
+        set typeDict [dict create]
+        foreach entry [module wiretypemap $modName] {
+            dict set typeDict [lindex $entry 0] [lindex $entry 1]
+        }
+        dict set typeDictCache $modName $typeDict
+    }
+    return [dict get $typeDictCache $modName]
+}
+
 set totalHits 0
 set typesOk 1
 foreach { modName dutScope } $::env(MOD_AT_LIST) {
-    set tmap [module wiretypemap $modName]
-    set typeDict [dict create]
-    foreach entry $tmap {
-        dict set typeDict [lindex $entry 0] [lindex $entry 1]
-    }
+    set typeDict [typeDictFor $modName]
     puts "##### module: $modName  @  $dutScope #####"
     if { [llength $veriVars] > 0 } {
         incr totalHits [correlate "Verilog" $veriVars $dutScope $typeDict]

--- a/testsuite/bsc.bluetcl/vcd_correlation/correlate.tcl
+++ b/testsuite/bsc.bluetcl/vcd_correlation/correlate.tcl
@@ -103,13 +103,24 @@ proc correlate { label vars dutScope typeDict } {
     return $hitCount
 }
 
+# One wiretypemap per module, however many scopes it appears at --
+# the map is keyed by module name, so instances share it.
+set typeDictCache [dict create]
+proc typeDictFor { modName } {
+    global typeDictCache
+    if { ![dict exists $typeDictCache $modName] } {
+        set typeDict [dict create]
+        foreach entry [module wiretypemap $modName] {
+            dict set typeDict [lindex $entry 0] [lindex $entry 1]
+        }
+        dict set typeDictCache $modName $typeDict
+    }
+    return [dict get $typeDictCache $modName]
+}
+
 set totalHits 0
 foreach { modName dutScope } $::env(MOD_AT_LIST) {
-    set tmap [module wiretypemap $modName]
-    set typeDict [dict create]
-    foreach entry $tmap {
-        dict set typeDict [lindex $entry 0] [lindex $entry 1]
-    }
+    set typeDict [typeDictFor $modName]
     puts "##### module: $modName  @  $dutScope #####"
     if { [llength $veriVars] > 0 } {
         incr totalHits [correlate "Verilog" $veriVars $dutScope $typeDict]


### PR DESCRIPTION
`module wiretypemap` and `module porttypes` both went quadratic in their entry counts, which made them unusable on large modules (tens of thousands of primitive instances, or thousands of interface ports).

## Changes

**wiretypemap** (commits `c19412a`, `7f15bed`):
- **WireAnalysis**: replace the final `Data.List.nub` over the candidate list with `Util.stableOrdNub`. Exact drop-in: `IType`'s `Eq` and `Ord` are both defined by the same comparison, so the survivors and their order are identical — only the cost changes, O(n²) → O(n log n).
- **bluetcl**: render each distinct type once instead of running `pfpString` per entry. A large module has many wires but few distinct types; lookups are cheap because ITypes are hash-consed.
- **correlation reference scripts** (`vcd_correlation`/`fst_correlation`): compute one wiretypemap per *module* instead of per (module, scope) instance pair, matching the per-.ba design the scripts' own comments describe. Output unchanged.

**porttypes** (commit `d046ead`):
- **htcl**: `HTclObj` gains an `Ord` instance (`TclObj` is a `ForeignPtr`, whose base `Ord` agrees with its `Eq`), so the per-port entry list can be deduplicated with `stableOrdNub` instead of `nub` — same survivors, same order.
- **Pragma**: new `mkIsAlwaysRdy` precomputes the always-ready set once; `isAlwaysRdy` rebuilds and rescans the pragma method lists per query, which goes quadratic when both the interface and the `always_ready`/`always_enabled` lists are large. `getModPortInfo` (behind `ports`/`porttypes`) uses it; the equivalence argument is at the definition.

## Measurements

wiretypemap — stress module with 2×N registers (`Bit#(32)` + a struct type):

| map entries | before | after |
|---|---|---|
| 22,532 | 15.1 s | 0.83 s |
| 90,116 | 155.4 s | 3.45 s |
| 360,452 | ~40 min (extrapolated) | ~14 s |

porttypes — stress module with a `Vector#(N, Reg#(Bit#(32)))` interface (~5 ports per element):

| port entries | before | after |
|---|---|---|
| 2,562 | 0.27 s | 0.10 s |
| 5,122 | 1.35 s | 0.21 s |

Doubling entries scaled the old porttypes ×5.1 and the fixed one ×2.1 — quadratic replaced by linear; at ~20k ports the old code extrapolates to ~20 s per call.

## Validation

- Raw (unsorted) wiretypemap dumps byte-identical to an unmodified baseline build at 22,532 and 90,116 entries; porttypes output byte-identical at 2,562 and 5,122 entries — content and order both preserved, no golden churn.
- Testsuite: `bsc.bluetcl/commands` 72 PASS (re-run after each commit), `vcd_correlation` 1 PASS, `fst_correlation` 1 PASS (run with `fstscopes` built so it actually executes), zero failures.

Incidental findings, not addressed here: bsc hits a GHC stack overflow during Verilog codegen at ~32k flat instances **and** at ~1k-element interface vectors (~5k-port wrappers); `+RTS -K256m` works around both. Pre-existing and being handled separately. The ~5k-port wrapper also costs ~538 s to compile (126 s at half size), consistent with the separately-tracked wrapper/typechecker scaling issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wg1HhwabWUK76E5kPj4wHG