### PR TITLE
trs: RunCore mem-file overlay boot — sidecar v5 with the two-fill soundness gate (rung 26)

### DIFF
--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1750,6 +1750,9 @@ pub(crate) struct RunCoreStageA {
     /// BRAM warn registry rows keyed back to relative arena slots:
     /// (slot, addr_bits, full name)
     pub(crate) warns: Vec<(u64, u32, String)>,
+    /// mem-file loads (overlay rung): (inst, file, binary_format) in
+    /// construction order; every load inst is also in prim_rows
+    pub(crate) load_rows: Vec<(u64, String, u64)>,
 }
 
 /// Parsed sidecar-v2 boot descriptor (clock + comp order +
@@ -1793,6 +1796,12 @@ pub(crate) const RC_SEC_WSTATE: u64 = 8;
 // prims over their live slots and services compiled prim call sites
 // natively (runcore_prim_cb)
 pub(crate) const RC_SEC_PRIMS: u64 = 9;
+// mem-file loads (overlay rung): per row [inst, file_len, file, bin]
+// in construction order — the boot rewrites each prim's data region
+// from the CURRENT file over the baked window image (the two-fill
+// bake gate proved the rest of the window independent of it).  Every
+// LOADS inst also has a PRIMS seed row.
+pub(crate) const RC_SEC_LOADS: u64 = 10;
 
 /// RLE-encode `words` as (value, run) LE u64 pairs onto `out`.
 fn rle_push(words: &[u64], out: &mut Vec<u8>) {
@@ -1837,9 +1846,10 @@ impl Interp {
     /// [version, AOT_LAYOUT_REV, salted bir hash, nslots], then
     /// (value, run) u64 pairs covering nslots.  Version 1 ends there;
     /// runcore_desc_finish appends the boot-descriptor sections and
-    /// bumps the version to 2.  Mem-file designs (RegFileLoad /
-    /// BRAM*Load) return None: their arena content tracks files that
-    /// may legitimately change between link and run.
+    /// bumps the version.  Mem-file designs are included (overlay
+    /// rung): the link never reads load files, so the image is
+    /// file-independent; the witnesses mask the data regions and the
+    /// boot overlays them from the live file.
     fn runcore_image_encode(&self) -> Option<Vec<u8>> {
         if self.jit_arena_ptr.is_null()
             || self.jit_arena_len == 0
@@ -1849,17 +1859,10 @@ impl Interp {
         {
             return None;
         }
-        for m in &self.d.modules {
-            for i in &m.instances {
-                if let ir::InstanceKind::Prim(ir::Primitive::Other { name }) =
-                    &i.kind
-                {
-                    if self.d.strings[*name as usize].contains("Load") {
-                        return None;
-                    }
-                }
-            }
-        }
+        // mem-file designs are back in (overlay rung): the link never
+        // reads load files (set_load_memfiles(false)), so this image
+        // is file-independent by construction; the witnesses mask the
+        // data regions and the boot overlays them from the live file
         let words = unsafe {
             std::slice::from_raw_parts(self.jit_arena_ptr, self.jit_arena_len)
         };
@@ -1938,6 +1941,12 @@ impl Interp {
         // belt-and-braces against that ever changing.
         if rcomps.iter().any(|rc| !rc.alts.is_empty()) {
             ineligible(&mut r_reason, "dynamic scheduling (alts)");
+        }
+        // the boot parser caps LOADS rows (hostile-file bound): refuse
+        // HERE, where a reason can be recorded, rather than bake a
+        // sidecar every boot silently rejects (review finding)
+        if sa.load_rows.len() > 1 << 12 {
+            ineligible(&mut r_reason, "mem-file load count");
         }
         // rung 3b: prim call sites no longer gate eligibility — the
         // PRIMS section bakes a native servicer seed for every
@@ -2022,7 +2031,7 @@ impl Interp {
         };
         let mut p = Vec::new();
         img.extend_from_slice(b"TRSBOOTD");
-        w64(&mut img, 7);
+        w64(&mut img, 8);
         // strings: the full design table (StrDyn tokens may select any)
         p.clear();
         w64(&mut p, self.d.strings.len() as u64);
@@ -2095,13 +2104,25 @@ impl Interp {
             }
         }
         sect(&mut img, RC_SEC_PRIMS, &p);
+        // mem-file loads (construction order; empty for file-free
+        // designs)
+        p.clear();
+        w64(&mut p, sa.load_rows.len() as u64);
+        for (inst, file, bin) in &sa.load_rows {
+            w64(&mut p, *inst);
+            w64(&mut p, file.len() as u64);
+            p.extend_from_slice(file.as_bytes());
+            w64(&mut p, *bin);
+        }
+        sect(&mut img, RC_SEC_LOADS, &p);
         // bump the header version: sections present.  The version IS
         // the eligibility-semantics revision — bump it whenever the
         // gate rules change, so a driver never trusts an `eligible`
         // flag computed under older rules (panel stale-pair finding).
         // 2 = pre-prim-gate; 3 = prim-site + lib-BDPI gates; 4 =
-        // native prim servicing (sites eligible via PRIMS seeds).
-        img[8..16].copy_from_slice(&4u64.to_le_bytes());
+        // native prim servicing (sites eligible via PRIMS seeds); 5 =
+        // mem-file overlay (LOADS rows + two-fill-gated windows).
+        img[8..16].copy_from_slice(&5u64.to_le_bytes());
         self.runcore_pending = Some(img);
     }
 
@@ -2140,8 +2161,8 @@ impl Interp {
         let salted =
             self.bir_hash ^ (self.vcd_trace as u64 * 0x5452_4143_4544);
         let version = rd(0);
-        if version != 1 && version != 4 {
-            // 2, 3 = older eligibility-semantics revisions: stale
+        if version != 1 && version != 5 {
+            // 2-4 = older eligibility-semantics revisions: stale
             fail("unknown or stale version");
             return None;
         }
@@ -2160,6 +2181,12 @@ impl Interp {
         let words = unsafe {
             std::slice::from_raw_parts(self.jit_arena_ptr, self.jit_arena_len)
         };
+        // mem-file data regions legitimately track the file (the link
+        // never reads it, this load did): mask them out of the arena
+        // compares; the LOADS section arm verifies the region claims
+        let mask = self.runcore_load_mask();
+        let masked =
+            |k: usize| mask.iter().any(|&(s, l)| k >= s && k < s + l);
         // find where the RLE runs end (also validates them; every
         // field is file data and must be treated as hostile)
         let mut pos = 8 + 32;
@@ -2183,7 +2210,7 @@ impl Interp {
                 return None;
             }
             for k in slot..slot + run {
-                if words[k] != v {
+                if words[k] != v && !masked(k) {
                     fail(&format!(
                         "slot {k}: image {v:#x}, rebuilt {:#x}",
                         words[k]
@@ -2409,6 +2436,11 @@ impl Interp {
                             want_insts.insert(pc.inst);
                         }
                     }
+                    // mem-file prims are in the PRIMS rows too (the
+                    // boot's overlay drives them) — same union here
+                    want_insts.extend(
+                        self.runcore_live_loads().iter().map(|r| r.0 as usize),
+                    );
                     // mirror the encoder: if ANY bounce-reachable inst
                     // is unattached or unseedable, desc_finish encoded
                     // ZERO rows (and an ineligible reason) — expecting
@@ -2496,6 +2528,34 @@ impl Interp {
                         }
                     }
                 }
+                RC_SEC_LOADS => {
+                    // compare the baked rows against the live prims'
+                    // retained load requests, in construction order
+                    let live_loads = self.runcore_live_loads();
+                    let n = want!(take8(&mut p), "load row count");
+                    if n != live_loads.len() as u64 {
+                        fail(&format!(
+                            "descriptor: {n} load rows baked vs {} live",
+                            live_loads.len()
+                        ));
+                        return None;
+                    }
+                    for want_row in &live_loads {
+                        let inst = want!(take8(&mut p), "load inst");
+                        let file =
+                            want!(take_str(&mut p), "load file").to_string();
+                        let bin = want!(take8(&mut p), "load bin");
+                        if (inst, file.as_str(), bin)
+                            != (want_row.0, want_row.1.as_str(), want_row.2)
+                        {
+                            fail(&format!(
+                                "descriptor: load row drift at inst {inst} \
+                                 ({file})"
+                            ));
+                            return None;
+                        }
+                    }
+                }
                 _ => {
                     fail(&format!("descriptor: unknown section {tag}"));
                     return None;
@@ -2503,8 +2563,8 @@ impl Interp {
             }
             pos = end;
         }
-        // required sections: 1-6 + 9 always; window sections travel
-        // as a pair or not at all
+        // required sections: 1-6 + 9 + 10 always; window sections
+        // travel as a pair or not at all
         for t in [
             RC_SEC_STRINGS,
             RC_SEC_PATHS,
@@ -2513,6 +2573,7 @@ impl Interp {
             RC_SEC_WARNS,
             RC_SEC_ELIG,
             RC_SEC_PRIMS,
+            RC_SEC_LOADS,
         ] {
             if seen_tags & (1 << t) == 0 {
                 fail("descriptor: missing required section");
@@ -2578,18 +2639,69 @@ impl Interp {
         out
     }
 
-    /// Link-time window bake (called on a FRESH interp that has an
-    /// artifact Load request armed): run the reset window quiet on
-    /// the compiled engine, and if it was effect-free and reached the
-    /// central-loop engage point, splice the captured post-window
-    /// sections into the sidecar.  Returns whether the splice
-    /// happened; every non-clean outcome is a silent classic boot.
-    pub fn runcore_bake_window(
-        &mut self,
-        sidecar: &std::path::Path,
-    ) -> Result<bool, String> {
+    // -- link-time window bake (docs/RUNCORE.md): runcore_bake_capture
+    // runs the reset window quiet on a FRESH interp with an artifact
+    // Load request armed; runcore_bake_commit gates (two-fill, for
+    // mem-file designs) and splices the captured sections into the
+    // sidecar.  Every non-clean outcome is a silent classic boot. --
+
+    /// The live mem-file data regions as absolute (word index, len)
+    /// ranges into the arena — the words whose content legitimately
+    /// tracks the load file (masked by every arena witness compare;
+    /// rewritten by the boot's overlay).
+    pub(crate) fn runcore_load_mask(&self) -> Vec<(usize, usize)> {
+        let base = self.jit_arena_ptr as usize;
+        let mut m = Vec::new();
+        for inst in &self.insts {
+            if let InstKind::Prim(p) = &inst.kind {
+                if p.runcore_load().is_some() {
+                    if let (Some(ptr), Some((off, len))) =
+                        (p.runcore_slot(), p.runcore_load_region())
+                    {
+                        if let Some(s) = (ptr as usize).checked_sub(base) {
+                            m.push((s / 8 + off, len));
+                        }
+                    }
+                }
+            }
+        }
+        m
+    }
+
+    /// The live mem-file load rows, (inst, file, binary_format) in
+    /// construction order — the single source both the encoder and
+    /// the witness use (drift between them is exactly what the
+    /// witness compare exists to catch, so they must share one walk).
+    pub(crate) fn runcore_live_loads(&self) -> Vec<(u64, String, u64)> {
+        let mut rows = Vec::new();
+        for (ci, inst) in self.insts.iter().enumerate() {
+            if let InstKind::Prim(p) = &inst.kind {
+                if let Some((f, bin)) = p.runcore_load() {
+                    rows.push((ci as u64, f, bin as u64));
+                }
+            }
+        }
+        rows
+    }
+
+    /// True when the design has mem-file prims (RegFileLoad /
+    /// BRAM*Load) — the link's bake then runs the two-fill gate.
+    pub fn runcore_has_loads(&self) -> bool {
+        self.insts.iter().any(|i| {
+            matches!(&i.kind, InstKind::Prim(p) if p.runcore_load().is_some())
+        })
+    }
+
+    /// Run the reset window on the loaded artifact and capture the
+    /// boundary state (docs/RUNCORE.md).  `fill`: two-fill gate
+    /// pattern written into every mem-file data region at plan time.
+    /// None = not bakeable — never engaged, dirty window, or a
+    /// perturbed region was written during the window (the boot's
+    /// overlay would lose that write) — the design boots classic.
+    pub fn runcore_bake_capture(&mut self, fill: Option<u64>) -> Option<RunCoreBake> {
         self.set_quiet();
         self.runcore_bake = true;
+        self.runcore_bake_fill = fill;
         let before =
             crate::prim::WINDOW_EFFECTS.load(std::sync::atomic::Ordering::Relaxed);
         // TWO cycles: advance(1) finishes cycle 1's timeslice and stops
@@ -2601,7 +2713,20 @@ impl Interp {
         let captured = self.runcore_window.take();
         let clean = captured
             .as_ref()
-            .is_some_and(|(_, at_capture)| *at_capture == before);
+            .is_some_and(|(_, at_capture, _)| *at_capture == before);
+        // regions untouched by the window: with the fill in place, a
+        // window write into a region would leave it != the fill image
+        let regions_hold = fill.is_none_or(|pat| {
+            self.insts.iter().all(|i| match &i.kind {
+                InstKind::Prim(p)
+                    if p.runcore_load().is_some()
+                        && p.runcore_slot().is_some() =>
+                {
+                    p.runcore_region_is(pat)
+                }
+                _ => true,
+            })
+        });
         if std::env::var_os("TRS_STARTUP_TIME").is_some() {
             let bails: Vec<String> = crate::CENTRAL_BAIL
                 .iter()
@@ -2612,19 +2737,72 @@ impl Interp {
                 })
                 .collect();
             eprintln!(
-                "trs runcore: bake engaged={} clean={clean} (bails [{}])",
+                "trs runcore: bake engaged={} clean={clean} \
+                 regions_hold={regions_hold} (bails [{}])",
                 captured.is_some(),
                 bails.join(" ")
             );
         }
-        let Some((sections, _)) = captured else {
-            return Ok(false); // never engaged (bailed) — classic boot
-        };
-        if !clean {
+        let (sections, _, state) = captured?;
+        if !clean || !regions_hold {
+            return None;
+        }
+        let arena = unsafe {
+            std::slice::from_raw_parts(self.jit_arena_ptr, self.jit_arena_len)
+        }
+        .to_vec();
+        Some(RunCoreBake {
+            sections,
+            arena,
+            mask: self.runcore_load_mask(),
+            state,
+        })
+    }
+}
+
+/// One window-bake capture: the encoded window sections plus what the
+/// two-fill gate compares.
+pub struct RunCoreBake {
+    sections: Vec<u8>,
+    /// the post-window (boundary) arena
+    arena: Vec<u64>,
+    /// mem-file data regions, absolute (word index, len)
+    mask: Vec<(usize, usize)>,
+    /// (tp, tn, cycle) at capture
+    state: (u64, u64, u64),
+}
+
+/// Two-fill gate + sidecar splice.  For a mem-file design, `a` and
+/// `b` are captures under DIFFERENT fill patterns: baking is sound
+/// only when every word OUTSIDE the load regions (and the clock
+/// state) agrees — the window provably does not depend on the file
+/// content the boot's overlay will replace.  File-free designs pass
+/// `b = None` (single capture, no gate).
+pub fn runcore_bake_commit(
+    sidecar: &std::path::Path,
+    a: &RunCoreBake,
+    b: Option<&RunCoreBake>,
+) -> Result<bool, String> {
+    if let Some(b) = b {
+        let masked =
+            |k: usize| a.mask.iter().any(|&(s, l)| k >= s && k < s + l);
+        let sound = a.state == b.state
+            && a.mask == b.mask
+            && a.arena.len() == b.arena.len()
+            && (0..a.arena.len()).all(|k| masked(k) || a.arena[k] == b.arena[k]);
+        if !sound {
+            if std::env::var_os("TRS_STARTUP_TIME").is_some() {
+                eprintln!(
+                    "trs runcore: bake refused — window depends on \
+                     mem-file content (two-fill gate)"
+                );
+            }
             return Ok(false);
         }
-        let mut bytes =
-            std::fs::read(sidecar).map_err(|e| format!("{}: {e}", sidecar.display()))?;
+    }
+    let sections = &a.sections;
+    let mut bytes =
+        std::fs::read(sidecar).map_err(|e| format!("{}: {e}", sidecar.display()))?;
         // bump nsect (u64 right after TRSBOOTD) by 2 and append
         let Some(td) = bytes
             .windows(8)
@@ -2636,13 +2814,12 @@ impl Interp {
         let nsect =
             u64::from_le_bytes(bytes[td + 8..td + 16].try_into().unwrap());
         bytes[td + 8..td + 16].copy_from_slice(&(nsect + 2).to_le_bytes());
-        bytes.extend_from_slice(&sections);
+        bytes.extend_from_slice(sections);
         let tmp = sidecar.with_extension("arena.tmp");
         std::fs::write(&tmp, &bytes)
             .and_then(|()| std::fs::rename(&tmp, sidecar))
             .map_err(|e| format!("{}: {e}", sidecar.display()))?;
         Ok(true)
-    }
 }
 
 /// Worker-thread count for compile fan-out (TRS_JIT_THREADS caps).
@@ -5182,6 +5359,12 @@ impl Interp {
                             sites.insert(pc.inst);
                         }
                     }
+                    // mem-file prims join the PRIMS rows (the boot's
+                    // overlay drives them through the same restored
+                    // structs); their load requests become LOADS rows
+                    // in construction order
+                    let load_rows = self.runcore_live_loads();
+                    sites.extend(load_rows.iter().map(|r| r.0 as usize));
                     let prim_rows = sites
                         .iter()
                         .map(|&ci| {
@@ -5218,6 +5401,7 @@ impl Interp {
                         boxed: nprims != attach.len(),
                         prim_rows,
                         warns,
+                        load_rows,
                     });
                 }
                 std::mem::forget(arena);
@@ -5388,6 +5572,19 @@ impl Interp {
         self.jit_arena_ptr = arena_ptr;
         self.jit_arena_len = nslots as usize;
         self.jit_reset_slots = reset_node_slot;
+        // two-fill bake gate: perturb every mem-file data region
+        // (post-attach, pre-advance) so the window capture can prove
+        // the rest of the state independent of file content
+        if let Some(pat) = self.runcore_bake_fill {
+            for inst in &mut self.insts {
+                if let InstKind::Prim(p) = &mut inst.kind {
+                    if p.runcore_load().is_some() && p.runcore_slot().is_some()
+                    {
+                        p.runcore_fill_region(pat);
+                    }
+                }
+            }
+        }
         if trace {
             eprintln!(
                 "trs jit: on ({} rules, {} slots, {} compositions)",

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -28,6 +28,8 @@ pub use topbind::{parse_bind, TopBind};
 #[cfg(feature = "aot")]
 mod jit;
 #[cfg(feature = "aot")]
+pub use jit::{runcore_bake_commit, RunCoreBake};
+#[cfg(feature = "aot")]
 mod runcore;
 
 use foreign::ForeignEnv;
@@ -270,15 +272,20 @@ pub struct Interp {
     /// by the Emit arm for prime's runcore_desc_finish
     #[cfg(feature = "aot")]
     pub(crate) runcore_stage_a: Option<jit::RunCoreStageA>,
-    /// link-time window bake armed (jit::runcore_bake_window): the
+    /// link-time window bake armed (jit::runcore_bake_capture): the
     /// central loop's engage point captures the post-window sections
     /// plus the WINDOW_EFFECTS reading AT capture (the bake advances
     /// one steady cycle past the boundary; its effects must not
     /// pollute the window-clean gate)
     #[cfg(feature = "aot")]
     pub(crate) runcore_bake: bool,
+    /// two-fill gate pattern: the plan tail writes it into every
+    /// mem-file data region (jit::runcore_bake_capture sets it)
     #[cfg(feature = "aot")]
-    pub(crate) runcore_window: Option<(Vec<u8>, u64)>,
+    pub(crate) runcore_bake_fill: Option<u64>,
+    /// (encoded window sections, effects at capture, (tp, tn, cycle))
+    #[cfg(feature = "aot")]
+    pub(crate) runcore_window: Option<(Vec<u8>, u64, (u64, u64, u64))>,
     /// the central loop engaged at least once this run — the inverse
     /// half of the RunCore descriptor's eligibility witness
     central_engaged: bool,
@@ -821,6 +828,8 @@ impl Interp {
             runcore_stage_a: None,
             #[cfg(feature = "aot")]
             runcore_bake: false,
+            #[cfg(feature = "aot")]
+            runcore_bake_fill: None,
             #[cfg(feature = "aot")]
             runcore_window: None,
             central_engaged: false,
@@ -4106,6 +4115,7 @@ impl Interp {
                     self.runcore_window_encode(tp, tn),
                     prim::WINDOW_EFFECTS
                         .load(std::sync::atomic::Ordering::Relaxed),
+                    (tp, tn, self.cycle),
                 ));
                 // the bake wants the BOUNDARY, not simulation: stop
                 // the advance here — no steady cycle executes at link
@@ -4167,9 +4177,19 @@ impl Interp {
                              {wtp}/{wtn}/{wcyc} vs live {tp}/{tn}/{}",
                             self.cycle
                         );
-                    } else if let Some(k) =
-                        (0..live.len()).find(|&k| live[k] != wa[k])
-                    {
+                    } else if let Some(k) = {
+                        // mem-file data regions legitimately differ:
+                        // the bake never read the file (and perturbed
+                        // the regions for the two-fill gate); the
+                        // boot's overlay rewrites them from the file
+                        let mask = self.runcore_load_mask();
+                        (0..live.len()).find(|&k| {
+                            live[k] != wa[k]
+                                && !mask
+                                    .iter()
+                                    .any(|&(s, l)| k >= s && k < s + l)
+                        })
+                    } {
                         eprintln!(
                             "trs runcore: MISMATCH: window slot {k}: baked \
                              {:#x}, live {:#x}",

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -245,6 +245,54 @@ pub trait Prim {
     fn runcore_slot(&self) -> Option<*mut u64> {
         None
     }
+    /// Mem-file prims (RegFileLoad / BRAM*Load): the retained load
+    /// request (file, binary_format).  The overlay rung boots these
+    /// designs by re-running the load against the CURRENT file over
+    /// the baked window arena — Some here puts the inst in the
+    /// sidecar's LOADS section.
+    fn runcore_load(&self) -> Option<(String, bool)> {
+        None
+    }
+    /// The prim's mem-file DATA region as (word offset from the slot
+    /// base, word length): the overlay rewrites exactly these words,
+    /// the two-fill bake gate perturbs them, and the witnesses mask
+    /// them (their content legitimately tracks the file).
+    fn runcore_load_region(&self) -> Option<(usize, usize)> {
+        None
+    }
+    /// Two-fill soundness gate (link bake): overwrite every data
+    /// entry with a word derived from (`key`, address) — see
+    /// runcore_fill_word.  Address-KEYED, not uniform: a uniform
+    /// constant lets fill-invariant predicates (entry equality,
+    /// popcount) escape the gate (review finding).  Must go through
+    /// the prim's own layout so the slots stay valid limbs.
+    fn runcore_fill_region(&mut self, _key: u64) {
+        unreachable!("runcore_fill_region on a prim without a load region")
+    }
+    /// Two-fill gate, checking half: does the data region still hold
+    /// exactly the fill image?  False = the reset window wrote into
+    /// it, and the boot's overlay would lose that write — refuse.
+    fn runcore_region_is(&self, _key: u64) -> bool {
+        unreachable!("runcore_region_is on a prim without a load region")
+    }
+    /// Boot overlay: rewrite the data region exactly as construction
+    /// would — undet everywhere, then the file's in-range entries via
+    /// the same loader (same warnings, same missing-file diagnostic,
+    /// same partial-load behavior).
+    fn runcore_overlay(&mut self, _file: &str, _bin: bool) {
+        unreachable!("runcore_overlay on a prim without a load region")
+    }
+}
+
+/// Two-fill gate fill word for one data entry: the run key mixed with
+/// the entry address (splitmix-style), so no two entries share a
+/// value and the two runs differ at every entry — derived predicates
+/// (equality between entries, popcount classes) cannot be invariant
+/// across both keyed patterns the way they were across uniform fills.
+pub(crate) fn runcore_fill_word(key: u64, addr: u64) -> u64 {
+    let mut z = key ^ addr.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z ^ (z >> 27)
 }
 
 // RunCore seed kind tags (sidecar PRIMS section): stable wire values
@@ -346,6 +394,9 @@ pub(crate) fn runcore_restore(
                 upd_at: u64::MAX,
                 upd_addr: 0,
                 upd_prev: Value::undet(w.max(1)),
+                // the boot's overlay passes file/bin from the LOADS
+                // row — the restored prim never reads this field
+                load: None,
             };
             Some((Box::new(p), fp))
         }
@@ -404,6 +455,8 @@ pub(crate) fn runcore_restore(
             )
             .ok()
             .filter(|&f| f <= 1 << 20)?;
+            // no load request: the boot's overlay passes file/bin
+            // from the LOADS row, never from the restored prim
             let p = Bram::new(
                 pipelined != 0,
                 dual,
@@ -1221,6 +1274,9 @@ struct RegFile {
     upd_at: u64,
     upd_addr: u64,
     upd_prev: Value,
+    /// retained mem-file request (file, binary_format) — RunCore's
+    /// overlay rung re-runs it against the CURRENT file at boot
+    load: Option<(String, bool)>,
 }
 
 /// bs_range_tracker.h: runs of loaded addresses; after loading, report
@@ -1422,6 +1478,7 @@ impl RegFile {
             upd_at: u64::MAX,
             upd_addr: 0,
             upd_prev: Value::undet(width),
+            load: file.clone().map(|f| (f, bin)),
         };
         if let Some(f) = file {
             if load_memfiles() {
@@ -1907,6 +1964,45 @@ impl Prim for RegFile {
     }
     fn runcore_slot(&self) -> Option<*mut u64> {
         self.slot
+    }
+    fn runcore_load(&self) -> Option<(String, bool)> {
+        self.load.clone()
+    }
+    fn runcore_load_region(&self) -> Option<(usize, usize)> {
+        Some((
+            self.data_off(self.lo),
+            (self.hi - self.lo + 1) as usize * self.words(),
+        ))
+    }
+    fn runcore_fill_region(&mut self, key: u64) {
+        for a in self.lo..=self.hi {
+            let w = runcore_fill_word(key, a);
+            let v =
+                Value::from_limbs64(self.width.max(1), vec![w; self.words()]);
+            self.arena_write(self.data_off(a), &v);
+        }
+    }
+    fn runcore_region_is(&self, key: u64) -> bool {
+        (self.lo..=self.hi).all(|a| {
+            let w = runcore_fill_word(key, a);
+            let v =
+                Value::from_limbs64(self.width.max(1), vec![w; self.words()]);
+            self.arena_read(self.data_off(a)) == v
+        })
+    }
+    fn runcore_overlay(&mut self, file: &str, bin: bool) {
+        // construction parity: undet everywhere, then the file's
+        // in-range entries through the same loader (same warnings,
+        // same missing-file diagnostic, same partial-load behavior)
+        let undet = Value::undet(self.width);
+        for a in self.lo..=self.hi {
+            self.arena_write(self.data_off(a), &undet);
+        }
+        let (ab, w, lo, hi) = (self.addr_bits, self.width, self.lo, self.hi);
+        let name = self.mem_name.clone();
+        load_mem_file(file, bin, ab, w, lo, hi, &name, &mut |a, v| {
+            self.arena_write(self.data_off(a), &v)
+        });
     }
 }
 
@@ -5591,6 +5687,11 @@ struct Bram {
     chunk_size: u32,
     num_wens: u32,
     full_name: String,
+    /// leaf instance name (mem-file warnings)
+    mem_name: String,
+    /// retained mem-file request (file, binary_format) — RunCore's
+    /// overlay rung re-runs it against the CURRENT file at boot
+    load: Option<(String, bool)>,
     data: std::collections::HashMap<u64, Value>,
     a: BramPort,
     b: BramPort,
@@ -5639,6 +5740,8 @@ impl Bram {
             chunk_size,
             num_wens,
             full_name,
+            mem_name: leaf.clone(),
+            load: file.clone(),
             data: Default::default(),
             a: BramPort::new(width),
             b: BramPort::new(width),
@@ -6154,6 +6257,44 @@ impl Prim for Bram {
     }
     fn runcore_slot(&self) -> Option<*mut u64> {
         self.slot
+    }
+    fn runcore_load(&self) -> Option<(String, bool)> {
+        self.load.clone()
+    }
+    fn runcore_load_region(&self) -> Option<(usize, usize)> {
+        Some((
+            self.data_base(),
+            (self.hi_addr + 1) as usize * self.vwords(),
+        ))
+    }
+    fn runcore_fill_region(&mut self, key: u64) {
+        for addr in 0..=self.hi_addr {
+            let w = runcore_fill_word(key, addr);
+            let v =
+                Value::from_limbs64(self.width.max(1), vec![w; self.vwords()]);
+            self.mem_set(addr, v);
+        }
+    }
+    fn runcore_region_is(&self, key: u64) -> bool {
+        (0..=self.hi_addr).all(|addr| {
+            let w = runcore_fill_word(key, addr);
+            let v =
+                Value::from_limbs64(self.width.max(1), vec![w; self.vwords()]);
+            self.mem_get(addr) == v
+        })
+    }
+    fn runcore_overlay(&mut self, file: &str, bin: bool) {
+        // construction parity: undet everywhere, then the file's
+        // in-range entries through the same loader
+        let undet = Value::undet(self.width);
+        for addr in 0..=self.hi_addr {
+            self.mem_set(addr, undet.clone());
+        }
+        let (ab, w, hi) = (self.addr_bits, self.width, self.hi_addr);
+        let name = self.mem_name.clone();
+        load_mem_file(file, bin, ab, w, 0, hi, &name, &mut |a, v| {
+            self.mem_set(a, v)
+        });
     }
 }
 

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 
 use crate::foreign::ForeignEnv;
 use crate::format::Arg;
-use crate::jit::{rle_decode, RC_SEC_CLOCK, RC_SEC_COMPS, RC_SEC_ELIG, RC_SEC_PATHS, RC_SEC_PRIMS, RC_SEC_STRINGS, RC_SEC_WARENA, RC_SEC_WARNS, RC_SEC_WSTATE};
+use crate::jit::{rle_decode, RC_SEC_CLOCK, RC_SEC_COMPS, RC_SEC_ELIG, RC_SEC_LOADS, RC_SEC_PATHS, RC_SEC_PRIMS, RC_SEC_STRINGS, RC_SEC_WARENA, RC_SEC_WARNS, RC_SEC_WSTATE};
 use crate::prim::Prim;
 use crate::value::Value;
 use trs_codegen::abi::{self, FArgSpec, FnProtos, TOKEN_KIND_EXEC};
@@ -47,6 +47,8 @@ struct Boot {
     window: Option<(Vec<u64>, u64, u64)>,
     /// bounce-reachable prim seeds: (inst, slot, tag, words, strings)
     prims: Vec<(usize, usize, u64, Vec<u64>, Vec<String>)>,
+    /// mem-file loads: (inst, file, binary_format), construction order
+    loads: Vec<(usize, String, bool)>,
 }
 
 /// Strict sidecar parse for the boot path: every field is hostile,
@@ -60,10 +62,10 @@ fn parse_sidecar(bytes: &[u8]) -> Option<Boot> {
     let rd = |k: usize| {
         u64::from_le_bytes(bytes[8 + 8 * k..16 + 8 * k].try_into().unwrap())
     };
-    // version 4 = current eligibility semantics (native prim
-    // servicing); older versions' eligible flags were computed under
-    // different gate rules — classic boot
-    if rd(0) != 4 || rd(1) != abi::AOT_LAYOUT_REV {
+    // version 5 = current eligibility semantics (mem-file overlay);
+    // older versions' eligible flags were computed under different
+    // gate rules — classic boot
+    if rd(0) != 5 || rd(1) != abi::AOT_LAYOUT_REV {
         return None;
     }
     let hash = rd(2);
@@ -114,6 +116,7 @@ fn parse_sidecar(bytes: &[u8]) -> Option<Boot> {
         eligible: false,
         window: None,
         prims: Vec::new(),
+        loads: Vec::new(),
     };
     let mut warena = None;
     let mut wstate = None;
@@ -228,6 +231,25 @@ fn parse_sidecar(bytes: &[u8]) -> Option<Boot> {
                     return None;
                 }
             }
+            RC_SEC_LOADS => {
+                let n = usize::try_from(take8(&mut p)?).ok()?;
+                if n > 1 << 12 {
+                    return None;
+                }
+                let mut seen_insts = std::collections::HashSet::new();
+                for _ in 0..n {
+                    let inst = usize::try_from(take8(&mut p)?).ok()?;
+                    let file = take_str(&mut p)?;
+                    let bin = take8(&mut p)? != 0;
+                    if !seen_insts.insert(inst) {
+                        return None;
+                    }
+                    b.loads.push((inst, file, bin));
+                }
+                if p > end {
+                    return None;
+                }
+            }
             _ => return None,
         }
         pos = end;
@@ -238,11 +260,28 @@ fn parse_sidecar(bytes: &[u8]) -> Option<Boot> {
         || seen & (1 << RC_SEC_COMPS) == 0
         || seen & (1 << RC_SEC_ELIG) == 0
         || seen & (1 << RC_SEC_PRIMS) == 0
+        || seen & (1 << RC_SEC_LOADS) == 0
     {
         return None;
     }
     // prim seed insts index the instance-path table
     if b.prims.iter().any(|(inst, ..)| *inst >= b.paths.len()) {
+        return None;
+    }
+    // every load row must have a seed row OF A MEM-FILE KIND: the
+    // boot's overlay drives the load through that restored prim, and
+    // only RegFile/Bram implement it — a row pointing at any other
+    // tag would panic in the default runcore_overlay (review finding:
+    // a hostile sidecar must bail to classic, never crash)
+    if b.loads.iter().any(|(inst, ..)| {
+        !b.prims.iter().any(|(pi, _, tag, ..)| {
+            pi == inst
+                && matches!(
+                    *tag,
+                    crate::prim::RC_PRIM_REGFILE | crate::prim::RC_PRIM_BRAM
+                )
+        })
+    }) {
         return None;
     }
     if let (Some(a), Some((tp, cyc))) = (warena, wstate) {
@@ -639,6 +678,19 @@ pub fn try_boot(so: &str, max_cycles: u64, plusargs: &[String]) -> Option<i32> {
             prims,
         };
         rc.fe.plusargs = plusargs.to_vec();
+        // mem-file overlay (docs/RUNCORE.md, overlay rung): rewrite
+        // each load region from the CURRENT file — construction
+        // order, same loader, same diagnostics as a classic boot.
+        // Placed after every bail: the loader may print (missing-file
+        // diagnostics are output), and classic is no longer a sound
+        // fallback once a byte is out.  Membership was checked at
+        // parse, so the lookup cannot fail.
+        for (inst, file, bin) in &boot.loads {
+            rc.prims
+                .get_mut(inst)
+                .expect("load row without a restored prim (parse gate)")
+                .runcore_overlay(file, *bin);
+        }
         let envp = &mut rc as *mut RunCore as *mut core::ffi::c_void;
         let pos_fns: Vec<
             unsafe extern "C" fn(*mut u64, *mut core::ffi::c_void, u64) -> i32,

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -586,8 +586,8 @@ fn main() -> ExitCode {
             }
             // RunCore arena sidecar (validation form): the plan's
             // deterministic post-attach arena image, cross-checked by
-            // loads under TRS_RUNCORE_CHECK=1; None (interp-only link
-            // or a mem-file design) removes any stale sidecar
+            // loads under TRS_RUNCORE_CHECK=1; None (interp-only or
+            // traced link) removes any stale sidecar
             let arena_written = match interp.take_runcore_image() {
                 Some(img) => {
                     let t = format!("{base}.arena.tmp");
@@ -615,21 +615,48 @@ fn main() -> ExitCode {
             if arena_written && compiled {
                 // no binds: a binding design's load refuses without
                 // them, so its bake is a silent no-op and it boots
-                // classic (run_file gates RunCore off under binds)
-                match trs_interp::startup::load_file(path, &[], &[], None) {
-                    Ok(mut b) => {
-                        b.aot_request_code(format!("{base}.so").into());
-                        if let Err(e) = b.runcore_bake_window(
-                            std::path::Path::new(&format!("{base}.arena")),
-                        ) {
-                            eprintln!(
-                                "trs link: note: window bake skipped: {e}"
-                            );
-                        }
+                // classic (run_file gates RunCore off under binds).
+                // Mem-file designs capture the window TWICE under
+                // different fill patterns (the two-fill gate): the
+                // bake is committed only if everything outside the
+                // load regions agrees — proof the boot's overlay
+                // replaces the only file-dependent state.
+                let sidecar = format!("{base}.arena");
+                let bake = (|| -> Result<bool, String> {
+                    let mut b1 =
+                        trs_interp::startup::load_file(path, &[], &[], None)?;
+                    b1.aot_request_code(format!("{base}.so").into());
+                    if !b1.runcore_has_loads() {
+                        let Some(cap) = b1.runcore_bake_capture(None) else {
+                            return Ok(false);
+                        };
+                        return trs_interp::runcore_bake_commit(
+                            std::path::Path::new(&sidecar),
+                            &cap,
+                            None,
+                        );
                     }
-                    Err(e) => {
-                        eprintln!("trs link: note: window bake skipped: {e}")
-                    }
+                    let Some(a) =
+                        b1.runcore_bake_capture(Some(0x5555_5555_5555_5555))
+                    else {
+                        return Ok(false);
+                    };
+                    let mut b2 =
+                        trs_interp::startup::load_file(path, &[], &[], None)?;
+                    b2.aot_request_code(format!("{base}.so").into());
+                    let Some(b) =
+                        b2.runcore_bake_capture(Some(0xAAAA_AAAA_AAAA_AAAA))
+                    else {
+                        return Ok(false);
+                    };
+                    trs_interp::runcore_bake_commit(
+                        std::path::Path::new(&sidecar),
+                        &a,
+                        Some(&b),
+                    )
+                })();
+                if let Err(e) = bake {
+                    eprintln!("trs link: note: window bake skipped: {e}");
                 }
             }
             // the artifact itself: a SYMLINK to the runner — main()'s

--- a/src/trs/docs/RUNCORE.md
+++ b/src/trs/docs/RUNCORE.md
@@ -146,6 +146,28 @@ The `$dump*` decline arms remain classic-boot territory (wave
 machinery needs the interp); they are gated by the wave/plusarg
 routing checks, not by materialization.
 
+## Mem-file overlay (rung 4, landed — sidecar v5)
+
+RegFileLoad / BRAM*Load designs boot RunCore.  The link never reads
+load files, so the baked image and window are file-independent by
+construction; the link proves the WINDOW is too by capturing it
+twice under different address-KEYED fills in every mem-file data
+region (`runcore_fill_word`: splitmix over (key, address) — uniform
+constants would let fill-invariant predicates like entry equality
+escape) and committing only when the captures agree everywhere
+OUTSIDE the regions, the effects gate is clean, and each region
+still holds its exact fill (a window write into a region would be
+lost to the overlay).  The sidecar's LOADS section carries (inst,
+file, bin) rows in construction order, each backed by a mem-file
+PRIMS seed; the boot overlays each region from the CURRENT file
+after every fallible gate — undet-fill then the same load_mem_file
+the classic constructor uses, so warnings, missing-file diagnostics,
+and partial loads are byte-identical.  All witnesses mask the load
+regions.  Live witness: RegFileLoadLink under TRS_RUNCORE=1, file
+absent AND appearing after link.  The remaining classic mem designs
+(Mesa, SparseRF) stop on the BOXED gate — their memories exceed the
+arena slot budget by design — not the mem-file gate.
+
 **Sidecar trust model** (3b panel finding, applies since v1): the
 sidecar is a build artifact, not attacker input — the window arena
 image IS simulator state, so a crafted file could already alter sim


### PR DESCRIPTION
Rung 26 of the trs stack (base: #144). Mem-file designs (RegFileLoad / BRAM*Load) become RunCore-eligible: the boot overlays their data regions from the CURRENT file over the baked window image, and the link proves that safe with a two-fill gate.

## Mechanism

- **The link never reads load files** (`set_load_memfiles(false)`), so the baked arena and window are file-independent by construction. What remained to prove is that the *window* is too: the link now captures the reset window **twice**, writing a different **address-keyed** fill (splitmix over `(key, address)`) into every mem-file data region at plan time, and commits the bake only when the two captures agree everywhere **outside** the regions, the effects gate is clean, and each region still holds its exact fill (a window write into a region would be lost to the overlay). Uniform fill constants were rejected in review: derived predicates like entry-equality or popcount are invariant across two uniform patterns and would escape the gate.
- **Sidecar VERSION 4 → 5** (the version is the eligibility-semantics revision) with a LOADS section: `(inst, file, bin)` rows in construction order, each required to match a PRIMS seed row of a mem-file kind — a row of any other kind is refused at parse, so a hostile sidecar bails to classic rather than reaching the `unreachable!` overlay default (review finding).
- **The boot overlay** runs after every fallible gate (nothing can bail once output starts): undet-fill the region, then the same `load_mem_file` the classic constructor uses — same warnings, same missing-file diagnostic, same partial-load behavior, byte-for-byte.
- **Witnesses mask the load regions** (their content legitimately tracks the file): the `TRS_RUNCORE_CHECK` arena compare, the engage-instant window compare, and a LOADS-row compare against each live prim's retained `(file, bin)` request.

## Witnesses

- RegFileLoadLink under `TRS_RUNCORE=1` exercises the whole path live: boots RunCore with the file **absent** (missing-file diagnostic byte-matched) and again after the file appears — the link-vs-run file-change case — byte-identical to the Bluesim reference both times.
- Battery 22/22 classic AND 22/22 driver-armed; diffsweep census **1003 PASS / 0 DIFF twice** (witnessed + `TRS_RUNCORE=1`), zero mismatches, zero panics.
- Bench pool: **BRAM0Test joins the RunCore boots (7/11)** — warm boot ~1.5ms. Mesa/SparseRF now stop on the boxed-prim gate (their memories exceed the arena slot budget by design), no longer the mem-file gate.
- Code review (high effort) folded pre-seal: keyed fills, parse-time kind validation for LOADS rows, an encode-side row cap matching the boot parser's, doc fixes, and a shared live-loads walk so the encoder and witness cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_