### PR TITLE
trs: block-buffer stdout when not a tty (out.rs sink)

### DIFF
--- a/src/trs/crates/trs-capi/src/lib.rs
+++ b/src/trs/crates/trs-capi/src/lib.rs
@@ -159,6 +159,10 @@ fn state<'a>(hdl: *mut c_void) -> &'a mut SimState {
 /// clock waveform and default reset — `prime()` is that protocol.
 #[no_mangle]
 pub extern "C" fn bk_init(model: *mut c_void, _master: u8) -> *mut c_void {
+    // this .so is dlopened into a driver (bluetcl) whose own stdio
+    // interleaves with sim output on fd 1 — a block-buffered sim sink
+    // would reorder against it, so pin line mode (out.rs)
+    trs_interp::stdout_force_line();
     let m = unsafe { &*(model as *const Model) };
     let bir = unsafe { std::slice::from_raw_parts(m.bir_ptr, m.bir_len) };
     // engine set: link-time default (shim Model, TBD) overridden by

--- a/src/trs/crates/trs-interp/src/bdpi.rs
+++ b/src/trs/crates/trs-interp/src/bdpi.rs
@@ -62,13 +62,10 @@ impl Bdpi {
             panic!("BDPI function {name:?} not loaded");
         });
         // user C code prints through libc stdio while the interpreter
-        // prints through Rust's buffered stdout — flush ours before the
-        // call and libc's after so interleaving matches the reference
-        // (where everything shares one stdio buffer)
-        {
-            use std::io::Write;
-            let _ = std::io::stdout().flush();
-        }
+        // prints through the runtime's stdout sink — flush ours before
+        // the call and libc's after so interleaving matches the
+        // reference (where everything shares one stdio buffer)
+        crate::out::flush();
 
         let mut slots: Vec<u64> = Vec::new();
         // keep-alive storage for pointer arguments

--- a/src/trs/crates/trs-interp/src/foreign.rs
+++ b/src/trs/crates/trs-interp/src/foreign.rs
@@ -89,7 +89,7 @@ impl ForeignEnv {
             return;
         }
         let write_slot = |s: &mut FSlot| match s {
-            FSlot::Stdout => print!("{text}"),
+            FSlot::Stdout => crate::out::write_str(text),
             FSlot::Stderr => eprint!("{text}"),
             FSlot::File(f) => {
                 let _ = f.write_all(text.as_bytes());
@@ -144,11 +144,12 @@ impl ForeignEnv {
     }
 
     /// Format a $display-family call into the reused scratch and write
-    /// it to stdout in ONE locked write_all (println!-per-call paid a
-    /// fresh String, a lock, and a core::fmt walk each; the scratch
-    /// survives across calls so the hot path allocates nothing).  Same
-    /// std LineWriter, so flush semantics ($fflush, the BDPI phase-0
-    /// flush, newline-triggered line flushes) are untouched.
+    /// it to the stdout sink in ONE locked write_all (println!-per-call
+    /// paid a fresh String, a lock, and a core::fmt walk each; the
+    /// scratch survives across calls so the hot path allocates
+    /// nothing).  Flush semantics live in out.rs: block-buffered when
+    /// piped like the reference C stdio, with $fflush and the BDPI
+    /// phase-0 flush as the explicit ordering points.
     pub(crate) fn write_display(
         &mut self,
         args: &[Arg],
@@ -164,8 +165,7 @@ impl ForeignEnv {
         if newline {
             out.push('\n');
         }
-        use std::io::Write;
-        let _ = std::io::stdout().lock().write_all(out.as_bytes());
+        crate::out::write_bytes(out.as_bytes());
         self.fmt_out = out;
     }
 
@@ -273,7 +273,7 @@ impl ForeignEnv {
             }
             "$fflush" => {
                 use std::io::Write;
-                let _ = std::io::stdout().flush();
+                crate::out::flush();
                 let key = match args.first() {
                     Some(Arg::Val(v, _)) => Some(v.as_u64()),
                     _ => None,

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2834,13 +2834,13 @@ fn jit_workers(n: usize) -> usize {
         .min(n.max(1))
 }
 
-/// Stdio-flush callback for direct BDPI calls: phase 0 flushes Rust's
-/// buffered stdout BEFORE the C call, phase 1 fflush(NULL)es libc's
-/// buffers after — the interleaving contract bdpi::Bdpi::call keeps.
+/// Stdio-flush callback for direct BDPI calls: phase 0 flushes the
+/// runtime's stdout sink BEFORE the C call, phase 1 fflush(NULL)es
+/// libc's buffers after — the interleaving contract bdpi::Bdpi::call
+/// keeps.
 pub(crate) unsafe extern "C" fn jit_stdio_cb(phase: u64) {
     if phase == 0 {
-        use std::io::Write;
-        let _ = std::io::stdout().flush();
+        crate::out::flush();
     } else {
         unsafe { libc::fflush(std::ptr::null_mut()) };
     }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -23,6 +23,8 @@ use trs_ir::{Action, Design, Expr, PrimOp, SchedNode, Stmt, StrId};
 
 mod bdpi;
 mod foreign;
+pub mod out;
+pub use out::{flush as stdout_flush, force_line as stdout_force_line};
 pub mod topbind;
 pub use topbind::{parse_bind, TopBind};
 #[cfg(feature = "aot")]
@@ -4865,7 +4867,7 @@ pub(crate) fn emit_output_errors(errs: &[String]) {
         return;
     }
     for e in errs.iter().rev() {
-        print!("Output error: {e}");
+        crate::out::write_fmt(format_args!("Output error: {e}"));
     }
 }
 

--- a/src/trs/crates/trs-interp/src/out.rs
+++ b/src/trs/crates/trs-interp/src/out.rs
@@ -1,0 +1,121 @@
+//! Process-level stdout sink.  The reference C engines inherit stdio's
+//! buffering contract: block-buffered when fd 1 is not a terminal,
+//! line-buffered when it is.  Rust's std stdout is ALWAYS a LineWriter,
+//! which costs a write(2) per $display line on piped batch runs.  Every
+//! stdout write in the runtime goes through this sink; when fd 1 is not
+//! a tty it is a 64KiB block buffer over the raw fd, flushed at the
+//! points where ordering is observable from outside the buffer:
+//!
+//!   - $fflush (foreign.rs)
+//!   - the BDPI stdio contract, phase 0 (bdpi.rs / jit_stdio_cb) —
+//!     user C code writes through libc's own buffers
+//!   - run teardown (main.rs exits via libc::_exit, which skips the
+//!     atexit net below; runcore.rs mirrors that teardown)
+//!   - atexit, covering every exit(3) path (registered on block init)
+//!
+//! Panics and signals lose buffered output, exactly like C block
+//! buffering.  Write errors are ignored (the write_display contract
+//! predating the sink).
+//!
+//! Line mode is forced by TRS_STDOUT_LINE (any value) or `force_line()`.
+//! Two tiers pin it: the capi .so is dlopened into a driver (bluetcl)
+//! whose own stdio interleaves with sim output — two independent block
+//! buffers on one fd would reorder — and the in-process script tier
+//! (`trs run -c/-f`) prints command responses through std stdout
+//! between sim advances.
+
+use std::io::Write;
+use std::sync::{Mutex, OnceLock};
+
+enum Sink {
+    /// std stdout (LineWriter): tty, forced, or capi/script tiers
+    Line,
+    Block(Mutex<std::io::BufWriter<std::fs::File>>),
+}
+
+static SINK: OnceLock<Sink> = OnceLock::new();
+
+extern "C" fn flush_at_exit() {
+    flush();
+}
+
+fn sink() -> &'static Sink {
+    SINK.get_or_init(|| {
+        if std::env::var_os("TRS_STDOUT_LINE").is_some()
+            || unsafe { libc::isatty(1) } != 0
+        {
+            Sink::Line
+        } else {
+            // SAFETY: fd 1 is open and stays open for the process
+            // lifetime; the File lives in a never-dropped static, so
+            // the fd is never closed through it.
+            let f = unsafe {
+                <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(1)
+            };
+            unsafe { libc::atexit(flush_at_exit) };
+            Sink::Block(Mutex::new(std::io::BufWriter::with_capacity(
+                1 << 16,
+                f,
+            )))
+        }
+    })
+}
+
+/// Pin the sink to line-buffered std stdout.  Must run before the
+/// first write; a no-op once the sink is initialized.
+pub fn force_line() {
+    let _ = SINK.set(Sink::Line);
+}
+
+pub fn write_bytes(b: &[u8]) {
+    match sink() {
+        Sink::Line => {
+            let _ = std::io::stdout().lock().write_all(b);
+        }
+        Sink::Block(m) => {
+            let _ = m.lock().unwrap_or_else(|e| e.into_inner()).write_all(b);
+        }
+    }
+}
+
+pub fn write_str(s: &str) {
+    write_bytes(s.as_bytes());
+}
+
+pub fn write_fmt(args: std::fmt::Arguments) {
+    match sink() {
+        Sink::Line => {
+            let _ = std::io::stdout().lock().write_fmt(args);
+        }
+        Sink::Block(m) => {
+            let _ = m.lock().unwrap_or_else(|e| e.into_inner()).write_fmt(args);
+        }
+    }
+}
+
+/// println! shape: one lock for the formatted body plus the newline.
+pub fn writeln_fmt(args: std::fmt::Arguments) {
+    match sink() {
+        Sink::Line => {
+            let mut o = std::io::stdout().lock();
+            let _ = o.write_fmt(args);
+            let _ = o.write_all(b"\n");
+        }
+        Sink::Block(m) => {
+            let mut o = m.lock().unwrap_or_else(|e| e.into_inner());
+            let _ = o.write_fmt(args);
+            let _ = o.write_all(b"\n");
+        }
+    }
+}
+
+pub fn flush() {
+    match sink() {
+        Sink::Line => {
+            let _ = std::io::stdout().flush();
+        }
+        Sink::Block(m) => {
+            let _ = m.lock().unwrap_or_else(|e| e.into_inner()).flush();
+        }
+    }
+}

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -60,7 +60,7 @@ pub(crate) fn note_window_effect() {
 macro_rules! qprintln {
     ($($t:tt)*) => {
         if !crate::prim::quiet_engine() {
-            println!($($t)*)
+            crate::out::writeln_fmt(format_args!($($t)*))
         } else {
             crate::prim::note_window_effect()
         }
@@ -1542,10 +1542,10 @@ pub(crate) fn bram_warn_hook(block: usize, addr: u64) {
         return;
     }
     if let Some((name, bits)) = BRAM_WARN_NAMES.lock().unwrap().get(&block) {
-        println!(
+        crate::out::writeln_fmt(format_args!(
             "Warning: BRAM '{name}' -- Write collision at address {}",
             addr_dump_val(addr, *bits)
-        );
+        ));
     }
 }
 

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -727,8 +727,7 @@ pub fn try_boot(so: &str, max_cycles: u64, plusargs: &[String]) -> Option<i32> {
         }
         // teardown parity with run_and_release: flush stdout, leak the
         // arena (the caller exits), exit code = fataled only
-        use std::io::Write;
-        let _ = std::io::stdout().flush();
+        crate::out::flush();
         std::mem::forget(arena);
         Some(if rc.fe.fataled { 1 } else { 0 })
     }

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -1068,7 +1068,7 @@ fn main() -> ExitCode {
             ) {
                 Ok(code) => {
                     use std::io::Write;
-                    let _ = std::io::stdout().flush();
+                    trs_interp::stdout_flush();
                     let _ = std::io::stderr().flush();
                     // bypass atexit teardown: JIT body workers may still
                     // be inside LLVM and would stall process exit
@@ -1448,6 +1448,10 @@ fn run_script(
     formats: Option<(bool, bool)>,
     script: &str,
 ) -> ExitCode {
+    // script-tier command responses print through std stdout between
+    // sim advances — pin the sim's stdout sink to the same LineWriter
+    // so the two cannot reorder (out.rs)
+    trs_interp::stdout_force_line();
     let mut interp = match trs_interp::load_file(path, plusargs, binds, vcd) {
         Ok(i) => i,
         Err(e) => {


### PR DESCRIPTION
## What

Batch stdout is now block-buffered when fd 1 is not a terminal, matching the reference C engines' stdio contract (Bluesim/Verilator inherit block buffering from libc when piped; Rust's std stdout is unconditionally a LineWriter, costing one `write(2)` per `$display` line on piped runs — TrafficBRAM pays ~3,600 of them, SparseRF ~5,600).

New `trs-interp/src/out.rs`: a process-level stdout sink — std stdout (line-buffered) on a tty, a 64KiB `BufWriter` over raw fd 1 otherwise. Every stdout writer in the runtime routes through it: `write_display`, the `$fwrite` stdout slot, `qprintln!` (mem-file loader messages, prim warnings), the BRAM write-collision warning, and `Output error:` reporting.

## Flush points (the ordering contract)

- `$fflush` — explicit user flush (foreign.rs)
- BDPI phase 0 — user C code writes through libc's own buffers, so ours flushes before every BDPI call (`bdpi.rs`, `jit_stdio_cb`)
- run teardown — the batch exit path leaves via `libc::_exit` (which skips atexit), so the pre-`_exit` flush is explicit; RunCore's teardown mirrors it
- `atexit` — registered on block-mode init, covering every `exit(3)` path (`process::exit(86)` selfcheck bails included)

Panics and signals lose buffered output, exactly like C block buffering.

## The two-buffers-one-fd hazard

Two tiers share fd 1 with a foreign writer and must NOT block-buffer independently:

- `libtrs_capi.so` is dlopened into bluetcl, whose own stdio interleaves with sim output — `bk_init` pins line mode before any write.
- the in-process script tier (`trs run -c/-f`) prints command responses through std stdout between sim advances — `run_script` pins line mode.

`TRS_STDOUT_LINE` (any value) forces line mode as a user escape hatch.

## Witnesses

- FloatTest bench artifact: 345 stdout writes → **1** in block mode; output byte-identical across line / block / RunCore boots.
- Regress battery 22/22, classic and `TRS_RUNCORE=1`.
- Dual full-corpus seals at this head: **1003 PASS / 0 DIFF** twice (witnessed `TRS_RUNCORE_CHECK=1 TRS_SELFCHECK=1`, and driver-armed `TRS_RUNCORE=1`), engines 998 aot + 5 interp — byte parity holds with buffering in play, loader diagnostics and warning text included.

## Stamp (min-of-N interleaved, same host, trs legs byte-verified vs the Bluesim oracle)

| design | trs (ms) | verilator | bluesim | vs previous stamp |
|---|---|---|---|---|
| TrafficBRAM | 29.98 | 29.92 | 95.2 | trs −3.3ms: the −3.6ms Verilator gap is now a 0.06ms dead heat |
| SparseRF | 5.56 | — | 57.0 | trs −3.4ms (38% faster; 5.6k output lines) |
| Mesa | 36.89 | — | 67.3 | trs −1.9ms |
| CFL | 6.82 | 5.25 | 56.0 | gap −2.2 → −1.57 |
| Dividers | 2.14 | 2.89 | 48.8 | win widens |
| FloatTest | 52.74 | 45.39 | 91.5 | unchanged (345 lines — output cost was never its gap) |
| BRAM0Test / Sudoku / DFT64v1 / DFT64v5 / Long | 7.66 / 139.4 / 8.85 / 9.11 / 1049 | 4.72 / 376.3 / 12.29 / 14.82 / 16314 | 51.6 / 309.2 / 55.9 / 62.1 / 5144 | within noise; wins hold |

Verilator scoreboard 5W/3L/1T (was 5W/4L); Bluesim 11/11. The output-volume prediction registered before the stamp hit on all seven ranges; TrafficBRAM's remaining 0.06ms is the guarded-FIFO bounce rung's target.