### PR TITLE
trs: display-bounce allocation burn-down — TrafficBRAM flips to a 20% Verilator win

### DIFF
--- a/src/trs/crates/trs-interp/src/format.rs
+++ b/src/trs/crates/trs-interp/src/format.rs
@@ -426,32 +426,27 @@ fn format_str(
             zero_pad = true;
             cs.next();
         }
-        let mut wdigits = String::new();
-        while let Some(d) = cs.peek() {
-            if d.is_ascii_digit() {
-                wdigits.push(*d);
-                cs.next();
-            } else {
-                break;
-            }
+        // digits accumulate directly (a String here was a per-spec
+        // allocation on the hot $display path)
+        while let Some(d) = cs.peek().and_then(|d| d.to_digit(10)) {
+            width = Some(
+                width
+                    .unwrap_or(0)
+                    .saturating_mul(10)
+                    .saturating_add(d as usize),
+            );
+            cs.next();
         }
-        if !wdigits.is_empty() {
-            width = Some(wdigits.parse().unwrap());
-        }
-        // optional .precision (real formats)
+        // optional .precision (real formats); no digits parses as 0
         let mut prec: Option<usize> = None;
         if cs.peek() == Some(&'.') {
             cs.next();
-            let mut pdigits = String::new();
-            while let Some(d) = cs.peek() {
-                if d.is_ascii_digit() {
-                    pdigits.push(*d);
-                    cs.next();
-                } else {
-                    break;
-                }
+            let mut p = 0usize;
+            while let Some(d) = cs.peek().and_then(|d| d.to_digit(10)) {
+                p = p.saturating_mul(10).saturating_add(d as usize);
+                cs.next();
             }
-            prec = Some(pdigits.parse().unwrap_or(0));
+            prec = Some(p);
         }
         let spec = cs.next().unwrap_or('%');
         // "%0d" means minimal width (the 0 is a width of zero), while a

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -115,13 +115,12 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         // the logical count walked past the allocation)
         let words = ((w.max(1) as usize) + 63) / 64;
         // TRUE logical width: a zero-width prim arg must reach the prim
-        // as the interp's width-0 Value (both constructors mask)
-        argv.push(if (1..=64).contains(&w) {
-            Value::from_u64(w, *args.add(off))
-        } else {
-            let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
-            Value::from_limbs64(w, limbs)
-        });
+        // as the interp's width-0 Value (from_limb_slice masks and keeps
+        // single-limb values off the heap)
+        argv.push(Value::from_limb_slice(
+            w,
+            std::slice::from_raw_parts(args.add(off), words),
+        ));
         off += words;
     }
     crate::prim::FROM_COMPILED.with(|c| c.set(token));
@@ -520,11 +519,12 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
             FArgSpec::Num { width, signed } => {
                 let w = width;
                 let words = ((w.max(1) as usize) + 63) / 64;
-                let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
                 // the TRUE width, zero included: the formatter must see
                 // the interp's width-0 Value for zero-width args, not a
-                // width-1 impostor (from_limbs64 masks the buffer word)
-                argv.push(Arg::Val(Value::from_limbs64(w, limbs), signed));
+                // width-1 impostor (from_limb_slice masks the buffer
+                // word and keeps single-limb values off the heap)
+                let limbs = std::slice::from_raw_parts(args.add(off), words);
+                argv.push(Arg::Val(Value::from_limb_slice(w, limbs), signed));
                 off += words;
             }
             FArgSpec::Real => {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -204,6 +204,9 @@ pub struct Interp {
     /// string id -> Arc'd text for Arg::Str: interned once, cloned as
     /// a refcount bump on every later call
     arg_strs: HashMap<u32, std::sync::Arc<str>>,
+    /// dense Arc cache for design-table string ids (the hot format
+    /// strings on the foreign bounce path); dyn ids stay on arg_strs
+    arg_strs_vec: Vec<Option<std::sync::Arc<str>>>,
     /// Emit requests stash the serialized PlanA here for the meta
     /// object (prime derives it; the aot_emit call site reads it)
     #[cfg(feature = "aot")]
@@ -803,6 +806,7 @@ impl Interp {
             fname_buf: String::new(),
             loc_buf: String::new(),
             arg_strs: HashMap::new(),
+            arg_strs_vec: Vec::new(),
             #[cfg(feature = "aot")]
             plan_a_bytes: None,
             trace_wf: std::env::var_os("TRS_TRACE_WF").is_some(),
@@ -1785,6 +1789,21 @@ impl Interp {
     /// per-event-tax audit: an Arc clone per call replaces a String
     /// alloc per call on the $display path).
     pub(crate) fn arg_str(&mut self, id: u32) -> std::sync::Arc<str> {
+        // design-table ids take a dense index (no per-call hashing);
+        // dyn ids (appended past the table) stay on the map
+        let n = self.d.strings.len();
+        if (id as usize) < n {
+            if self.arg_strs_vec.is_empty() {
+                self.arg_strs_vec = vec![None; n];
+            }
+            if let Some(a) = &self.arg_strs_vec[id as usize] {
+                return a.clone();
+            }
+            let a: std::sync::Arc<str> =
+                std::sync::Arc::from(self.d.strings[id as usize].as_str());
+            self.arg_strs_vec[id as usize] = Some(a.clone());
+            return a;
+        }
         if let Some(a) = self.arg_strs.get(&id) {
             return a.clone();
         }

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -311,6 +311,14 @@ struct RunCore {
     /// (post-attach, slots are the single source of truth — the
     /// restored prim is indistinguishable from a classic-boot one)
     prims: HashMap<usize, Box<dyn Prim>>,
+    /// per-boot scratch reused across foreign bounces (jit_foreign_cb's
+    /// buffer discipline): the argv spine, task name, and %m location
+    foreign_argv: Vec<Arg>,
+    fname_buf: String,
+    loc_buf: String,
+    /// dense Arc cache for design-table string ids (the hot format
+    /// strings); dyn ids stay on the arg_strs map
+    arg_strs_vec: Vec<Option<std::sync::Arc<str>>>,
 }
 
 impl RunCore {
@@ -323,6 +331,21 @@ impl RunCore {
         }
     }
     fn arg_str(&mut self, id: u32) -> std::sync::Arc<str> {
+        // design-table ids take a dense index (no per-call hashing);
+        // dyn ids (appended past the table) stay on the map
+        let n = self.strings.len();
+        if (id as usize) < n {
+            if self.arg_strs_vec.is_empty() {
+                self.arg_strs_vec = vec![None; n];
+            }
+            if let Some(a) = &self.arg_strs_vec[id as usize] {
+                return a.clone();
+            }
+            let a: std::sync::Arc<str> =
+                std::sync::Arc::from(self.strings[id as usize].as_str());
+            self.arg_strs_vec[id as usize] = Some(a.clone());
+            return a;
+        }
         if let Some(a) = self.arg_strs.get(&id) {
             return a.clone();
         }
@@ -346,23 +369,31 @@ unsafe extern "C" fn runcore_foreign_cb(
     let ordinal = (token >> 17) as usize;
     let is_exec = token & TOKEN_KIND_EXEC != 0;
     let local = (token & 0xffff) as usize;
+    // take the protos table for the marshal walk (rc.arg_str needs
+    // &mut rc) — a Vec move, not a copy; restored before dispatch
+    let protos = std::mem::take(&mut rc.protos);
     let fs = if is_exec {
-        &rc.protos[ordinal].exec_foreign[local]
+        &protos[ordinal].exec_foreign[local]
     } else {
-        &rc.protos[ordinal].sched_foreign[local]
+        &protos[ordinal].sched_foreign[local]
     };
     let (inst, func, ret_width) = (fs.inst, fs.func, fs.ret_width);
-    let specs = fs.args.clone();
-    let mut argv: Vec<Arg> = Vec::with_capacity(specs.len());
+    // per-boot scratch (jit_foreign_cb's buffer discipline): the argv
+    // spine survives across bounces, single-limb Values stay inline
+    let mut argv = std::mem::take(&mut rc.foreign_argv);
+    argv.clear();
+    argv.reserve(fs.args.len());
     let mut off = 0usize;
-    for a in &specs {
+    for a in &fs.args {
         match *a {
             FArgSpec::Str(sid) => argv.push(Arg::Str(rc.arg_str(sid))),
             FArgSpec::Num { width, signed } => {
                 let words = ((width.max(1) as usize) + 63) / 64;
-                let limbs =
-                    std::slice::from_raw_parts(args.add(off), words).to_vec();
-                argv.push(Arg::Val(Value::from_limbs64(width, limbs), signed));
+                let limbs = std::slice::from_raw_parts(args.add(off), words);
+                argv.push(Arg::Val(
+                    Value::from_limb_slice(width, limbs),
+                    signed,
+                ));
                 off += words;
             }
             FArgSpec::Real => {
@@ -376,6 +407,7 @@ unsafe extern "C" fn runcore_foreign_cb(
             }
         }
     }
+    rc.protos = protos;
     if func == trs_codegen::abi::STRING_CONCAT_FUNC {
         let mut text = String::new();
         for a in &argv {
@@ -386,29 +418,34 @@ unsafe extern "C" fn runcore_foreign_cb(
         let id = rc.strings.len() + rc.dyn_strs.len();
         rc.dyn_strs.push(text);
         *out = id as u64;
+        argv.clear();
+        rc.foreign_argv = argv;
         return 0;
     }
-    let name = rc.s(func).to_string();
+    let mut name = std::mem::take(&mut rc.fname_buf);
+    name.clear();
+    name.push_str(rc.s(func));
+    let mut loc = std::mem::take(&mut rc.loc_buf);
+    loc.clear();
+    loc.push_str("top");
     let p = &rc.paths[inst];
-    let loc = if p.is_empty() {
-        "top".to_string()
-    } else {
-        format!("top.{p}")
-    };
+    if !p.is_empty() {
+        loc.push('.');
+        loc.push_str(p);
+    }
     if ret_width == 0 {
         if !rc.fe.action(&name, &argv, rc.now, &loc) {
-            if name == "srand" {
-                let seed = match argv.first() {
-                    Some(Arg::Val(v, _)) => v.as_u64() as u32,
-                    _ => 0,
-                };
-                rc.rng.srandom(seed);
-                return 0;
+            if name != "srand" {
+                panic!(
+                    "trs runcore: action task {name:?} reached the boot \
+                     (eligibility-gate bug)"
+                );
             }
-            panic!(
-                "trs runcore: action task {name:?} reached the boot \
-                 (eligibility-gate bug)"
-            );
+            let seed = match argv.first() {
+                Some(Arg::Val(v, _)) => v.as_u64() as u32,
+                _ => 0,
+            };
+            rc.rng.srandom(seed);
         }
     } else {
         let v = match rc.fe.value(&name, &argv, ret_width, rc.now, &loc) {
@@ -427,6 +464,12 @@ unsafe extern "C" fn runcore_foreign_cb(
             *d = v.limbs64().get(i).copied().unwrap_or(0);
         }
     }
+    // return the scratch (a re-entered task took fresh empties via
+    // mem::take, so this only upgrades capacity back)
+    argv.clear();
+    rc.foreign_argv = argv;
+    rc.fname_buf = name;
+    rc.loc_buf = loc;
     0
 }
 
@@ -457,12 +500,10 @@ unsafe extern "C" fn runcore_prim_cb(
     let mut off = 0usize;
     for &w in &pc.arg_widths {
         let words = ((w.max(1) as usize) + 63) / 64;
-        argv.push(if (1..=64).contains(&w) {
-            Value::from_u64(w, *args.add(off))
-        } else {
-            let limbs = std::slice::from_raw_parts(args.add(off), words).to_vec();
-            Value::from_limbs64(w, limbs)
-        });
+        argv.push(Value::from_limb_slice(
+            w,
+            std::slice::from_raw_parts(args.add(off), words),
+        ));
         off += words;
     }
     let Some(p) = rc.prims.get_mut(&pc.inst) else {
@@ -676,6 +717,10 @@ pub fn try_boot(so: &str, max_cycles: u64, plusargs: &[String]) -> Option<i32> {
             rng: crate::GlibcRandom::new(),
             now: 0,
             prims,
+            foreign_argv: Vec::new(),
+            fname_buf: String::new(),
+            loc_buf: String::new(),
+            arg_strs_vec: Vec::new(),
         };
         rc.fe.plusargs = plusargs.to_vec();
         // mem-file overlay (docs/RUNCORE.md, overlay rung): rewrite

--- a/src/trs/crates/trs-interp/src/value.rs
+++ b/src/trs/crates/trs-interp/src/value.rs
@@ -127,6 +127,27 @@ impl Value {
         &self.limbs
     }
 
+    /// Build from a little-endian 64-bit limb slice without forcing a
+    /// heap Vec: the single-limb case (the callback marshal fast path)
+    /// stays inline.  Pad/truncate + mask semantics identical to
+    /// from_limbs64.
+    pub fn from_limb_slice(width: u32, limbs: &[u64]) -> Value {
+        let n = nlimbs(width).max(1);
+        let mut v = if n == 1 {
+            Value {
+                width,
+                limbs: Limbs::S([limbs.first().copied().unwrap_or(0)]),
+            }
+        } else {
+            let mut l = vec![0u64; n];
+            let k = limbs.len().min(n);
+            l[..k].copy_from_slice(&limbs[..k]);
+            Value { width, limbs: Limbs::W(l) }
+        };
+        v.mask();
+        v
+    }
+
     /// Build from little-endian 64-bit limbs, padding/truncating to the
     /// width's limb count and masking (JIT arena interchange).
     pub fn from_limbs64(width: u32, limbs: Vec<u64>) -> Value {


### PR DESCRIPTION
## What

The bench pool's remaining Verilator deficits turn out to be **foreign-bounce shaped, not prim-bounce shaped**: TrafficBRAM runs **zero** `jit_prim_cb` calls (the guarded-FIFO fast-path inline landed with the arena rungs) but **64,335** `jit_foreign_cb` calls — its testbench prints each vector element with its own `$write("%3d ", v[i])` — costing ~13ms of a 30ms run. Callgrind put the per-call tax in heap and hash churn, not in formatting:

- **`Value::from_limb_slice`** — marshal numeric args from the raw word run without the intermediate `Vec` that `from_limbs64` forced (`Limbs` already stores single-limb values inline; the Vec was allocated, copied out of, and freed once per numeric argument). All four callback marshal loops use it (jit/runcore × foreign/prim).
- **`runcore_foreign_cb` adopts `jit_foreign_cb`'s buffer discipline** — no more per-call `fs.args.clone()` (the protos table is `mem::take`n for the marshal walk — a Vec move, restored before dispatch), reused argv spine, reused task-name and %m-location buffers.
- **Dense `arg_str` caches** (Interp and RunCore) — design-table string ids index a Vec, killing the per-call sip hashing of the format-string id; dyn ids stay on the map.
- **`format_str` width/precision digits accumulate directly** instead of through a fresh `String` per `%`-spec (one alloc+free per formatted value); overflow saturates where `parse().unwrap()` would have panicked.

## Measured

TrafficBRAM: **212.2M → 190.2M Ir (−10.4%)**, **29.98 → 23.7ms** — the post-#146 Verilator dead heat (29.98 vs 29.92) flips to a **20% win** (23.7 vs 29.7, min-of-N interleaved, byte-verified vs the Bluesim oracle). Full-pool stamp: Verilator scoreboard 6W/3L (was 5W/3L/1T), Bluesim 11/11. Designs with few large `$display` calls (SparseRF, Mesa, FloatTest) are flat, as expected once counted by calls rather than lines — their remaining gaps are FP-path/boxed-prim shaped, not bounce shaped.

Ledgered next: `trs_bram_tick` inline (12.7% of the TrafficBRAM run is the per-port tick's indirect call + arg unpack).

## Witnesses

- Output byte-identical on the bench artifacts (classic and `TRS_RUNCORE=1`).
- Regress battery 22/22, classic and `TRS_RUNCORE=1`.
- Dual full-corpus seals at this head: **1003 PASS / 0 DIFF** twice (witnessed `TRS_RUNCORE_CHECK=1 TRS_SELFCHECK=1`, and driver-armed `TRS_RUNCORE=1`), engines 998 aot + 5 interp, zero mismatch, zero panics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_