### PR TITLE
trs link: bind intra-artifact calls locally — FloatTest flips to a Verilator win

### DIFF
--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1172,8 +1172,15 @@ fn aot_emit(
         // .so at the final path (it would dlopen-fail or worse on the
         // next run before the gates can judge it)
         let so_tmp = so.with_extension("so.tmp");
+        // -Bsymbolic-functions: the artifact calls its OWN exec/sched
+        // fns, but their symbols must stay dynamically exported (the
+        // table-less loader path dlsyms them) — without local binding
+        // every intra-.so call pays a PLT stub + GOT load (FloatTest:
+        // 415 call sites, 5.5M indirect branches/run).  Function-only
+        // binding keeps the callback DATA globals (trs_cb_*) on their
+        // normal GOT path, which the loader writes through dlsym.
         let st = std::process::Command::new(cc_tool())
-            .args(["-shared", "-o"])
+            .args(["-shared", "-Wl,-Bsymbolic-functions", "-o"])
             .arg(&so_tmp)
             .args([&f, &mf])
             .status()
@@ -1356,10 +1363,11 @@ fn aot_emit(
     let mf = tmp.join("meta.o");
     std::fs::write(&mf, meta).map_err(|e| EmitFail::Infra(e.to_string()))?;
     files.push(mf);
-    // temp+rename, same discipline as the single-object emit
+    // temp+rename, same discipline as the single-object emit; local
+    // function binding for the same reason (see the one-module link)
     let so_tmp = so.with_extension("so.tmp");
     let st = std::process::Command::new("cc")
-        .args(["-shared", "-o"])
+        .args(["-shared", "-Wl,-Bsymbolic-functions", "-o"])
         .arg(&so_tmp)
         .args(&files)
         .status()


### PR DESCRIPTION
## What

One linker flag, diagnosed by the FloatTest profile: the artifact .so calls its **own** exec/sched functions, but their symbols must stay dynamically exported (the table-less loader path dlsyms them) — so every intra-.so call paid a PLT stub, a GOT load, and an indirect jump. FloatTest carried **415 such call sites → 5.52M indirect branches per run** (96.6% mispredicted under a last-target model), plus the GOT data traffic.

`-Wl,-Bsymbolic-functions` on both .so links (one-module and chunked) binds those calls at link time: all 415 PLT calls become direct near calls (verified by disassembly — zero `@plt` exec calls remain). Function-only binding keeps the callback **data** globals (`trs_cb_*`) on their normal GOT path, which the loader writes through dlsym; the dynamic symbol table is untouched, so the per-symbol loader and RunCore's dlsyms are unaffected. The capi .so has linked with `-Bsymbolic` since the export-perf rung — this extends the discipline to the artifacts.

## Measured (FloatTest, cachegrind + branch-sim, identical workloads)

| metric | before | after | Verilator |
|---|---|---|---|
| indirect branches | 5.52M | **0.20M** | 0.24M |
| mispredicts | 5.60M | **0.26M** | 0.42M |
| D1 misses | 1.13M | 0.69M | 0.02M |
| wall (min-of-N) | 52.68ms | **40.95ms** | 44.58ms |

## Stamp (full pool, min-of-N interleaved, trs legs byte-verified vs the Bluesim oracle)

**FloatTest flips to an 8% Verilator win** (40.95 vs 44.58 — it was −7.8ms two rungs ago). Scoreboard: **7W/2L vs Verilator** (Dividers, TrafficBRAM, FloatTest, Sudoku, DFT64v1, DFT64v5, Long), **11/11 vs Bluesim**. Remaining deficits: CFL −1.7ms and BRAM0Test −2.7ms — both RunCore-booted small designs whose residue is per-cycle/bram-tick shaped, not call-shaped (CFL was flat under this change, exactly as its profile predicts).

## Witnesses

- Output byte-identical on the bench artifacts (classic and `TRS_RUNCORE=1`).
- Regress battery 22/22, classic and `TRS_RUNCORE=1`.
- Dual full-corpus seals at this head with **every design relinked under the flag**: **1003 PASS / 0 DIFF** twice (witnessed `TRS_RUNCORE_CHECK=1 TRS_SELFCHECK=1`, and driver-armed `TRS_RUNCORE=1`), engines 998 aot + 5 interp, zero mismatch, zero panics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_