### PR TITLE
bench: main.v-equivalent Verilator driver — Mesa joins the timed pool (trs wins by 26%)

### DIFF
--- a/src/trs/tools/bench.py
+++ b/src/trs/tools/bench.py
@@ -92,37 +92,54 @@ POOL = [
          character="RegFile range traffic",
          no_verilator="RegFile over a 42-bit index elaborates to a "
                       "2^42-entry Verilog array"),
-    # packet-processing app (mesa)
+    # packet-processing app (mesa).  The old "non-terminating" skip
+    # was the driver's fault twice over: no timeInc (Mesa's testbench
+    # terminates on a $time bound, so it free-ran at $time==0) and an
+    # eval_initial stack overflow on the 2^21-entry $readmemh
+    # memories.  Its output legitimately differs from Bluesim's
+    # (backend time semantics + loader warnings), so the verilator
+    # leg compares against the suite's committed Verilog golden.
     dict(name="Mesa", dir="testsuite/bsc.bsv_examples/mesa/spiless-tx-bsv",
          src="TestMesa.bsv", top="sysTestMesa", cycles=None,
          character="app-scale packet pipeline",
-         no_verilator="non-terminating under the generic C++ driver "
-                      "(packet input side free-runs; same Verilog "
-                      "passes the suite under iverilog with bsc's "
-                      "main.v) — under investigation"),
+         vl_expected="sysTestMesa.v.out.expected"),
 ]
 
 VL_MAIN = r"""
-// generic Verilator driver for a closed bsc top (CLK/RST_N only) —
-// replaces main.v so no --timing is needed
+// main.v-equivalent Verilator driver for a closed bsc top (CLK/RST_N
+// only) — replaces main.v so no --timing is needed, but reproduces its
+// exact protocol: ONE posedge under asserted reset at t=1, deassert at
+// t=2 between edges, negedges at 5+10k, posedges at 10k.  Simulation
+// time advances with the clock (a driver that never calls timeInc
+// leaves $time stuck at 0 — Mesa's testbench terminates on a time
+// bound and free-ran under the old driver).
 #include "V%TOP%.h"
 #include "verilated.h"
+#include <sys/resource.h>
 int main(int argc, char** argv) {
-    Verilated::commandArgs(argc, argv);
-    V%TOP%* top = new V%TOP%;
-    vluint64_t half = 0;
-    top->RST_N = 0;
-    top->CLK = 0;
-    top->eval();
-    while (!Verilated::gotFinish()) {
-        ++half;
-        if (half == 4) top->RST_N = 1;   // 2 full cycles of reset
-        top->CLK = !top->CLK;
-        top->eval();
-        if (half > 8000000000ULL) break; // 4G-cycle safety cap
+    // Verilator's eval_initial overflows the default stack on
+    // $readmemh-scale memories (Mesa: 2^21-entry RegFiles) — raise to
+    // the hard limit before the first eval
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_STACK, &rl) == 0 && rl.rlim_cur != rl.rlim_max) {
+        rl.rlim_cur = rl.rlim_max;
+        setrlimit(RLIMIT_STACK, &rl);
+    }
+    VerilatedContext* ctx = new VerilatedContext;
+    ctx->commandArgs(argc, argv);
+    V%TOP%* top = new V%TOP%{ctx};
+    top->RST_N = 0; top->CLK = 0; top->eval();      // t=0: reset asserted
+    ctx->timeInc(1); top->CLK = 1; top->eval();     // t=1: posedge under reset
+    ctx->timeInc(1); top->RST_N = 1; top->eval();   // t=2: deassert
+    ctx->timeInc(3); top->CLK = 0; top->eval();     // t=5: first negedge
+    while (!ctx->gotFinish()) {
+        ctx->timeInc(5); top->CLK = 1; top->eval(); // 10k: posedge
+        if (ctx->time() > 40000000000ULL) break;    // 4G-cycle safety cap
+        ctx->timeInc(5); top->CLK = 0; top->eval(); // 5+10k: negedge
     }
     top->final();
     delete top;
+    delete ctx;
     return 0;
 }
 """
@@ -335,13 +352,28 @@ def bench_one(d, legs, runs, work):
     # $random designs are exempt on the verilator leg (Verilator's RNG
     # is not glibc's, so the operand stream legitimately differs).
     def norm(t):
+        # Verilator prints its $readmem short-file warnings on stdout
+        # (iverilog goldens carry none) — normalized with the trailer
         return "\n".join(
             l for l in t.strip().splitlines()
             if not re.match(r"^- .*Verilog \$finish", l)
+            and not l.startswith("%Warning:")
         ).strip()
     outs = {k: norm(v) for k, v in outputs.items()}
     if d.get("random") or d.get("vl_out_exempt"):
         outs.pop("verilator", None)
+    # a design whose Verilog-backend output legitimately differs from
+    # Bluesim's (time semantics, loader warnings) compares its
+    # verilator leg against the suite's committed Verilog golden
+    # instead of the bluesim leg
+    if d.get("vl_expected") and "verilator" in outs:
+        vl = outs.pop("verilator")
+        try:
+            gold = norm(open(os.path.join(src_dir, d["vl_expected"])).read())
+        except OSError:
+            gold = None
+        if gold is None or vl != gold:
+            res["output_mismatch"] = {"verilator_vs_golden": vl[-200:]}
     # Verilator's $finish sets a flag but finishes evaluating the
     # instant, so sibling always-blocks may print same-instant lines
     # that abort-immediately semantics (Bluesim, trs) never reach: the


### PR DESCRIPTION
## What

Mesa's Verilator leg was skipped as "non-terminating under the generic C++ driver — under investigation." The investigation is done: the driver was at fault twice over.

1. **It never advanced simulation time.** The driver toggled CLK without calling `timeInc`, so `$time` stayed 0 forever — and Mesa's testbench terminates on a `$time` bound, so it free-ran printing `Cycle: N Tick: 0` indefinitely.
2. **A plain segfault before any output on this Verilator (5.020):** `eval_initial` overflows the default 8MB stack initializing Mesa's 2²¹-entry `$readmemh` memories.

The driver now reproduces bsc's `main.v` protocol exactly — one posedge under asserted reset at t=1, deassert at t=2, negedges at 5+10k, posedges at 10k, time advancing with the clock — and raises `RLIMIT_STACK` to the hard limit before the first eval. Under it Mesa runs to its `$finish` at cycle 1000 with output **byte-identical to the suite's committed Verilog golden** (`sysTestMesa.v.out.expected`).

Backend outputs legitimately differ for Mesa (time semantics: Verilog samples ticks at 5+10k, Bluesim at 10+10k; plus Bluesim's mem-file gap warnings), so a new `vl_expected` knob compares the verilator leg against the committed Verilog golden instead of the bluesim leg. `norm()` also strips Verilator's stdout `$readmem` warnings alongside the `$finish` trailer. SparseRF stays verilator-exempt (its RegFile over a 42-bit index elaborates to a 2⁴²-entry Verilog array — structural, not a harness gap).

## Witnesses

- Mesa through the harness itself: verilator + bluesim legs, outputs-ok (golden-compared).
- Controls under the new driver: FloatTest and TrafficBRAM re-run, outputs-ok (their prefix compare vs Bluesim unchanged — they don't sample `$time`).
- Harness-only change: no simulator code touched; corpus seals unaffected by construction.

## Stamp (full pool, min-of-N interleaved, same host)

| design | trs | verilator | bluesim |
|---|---|---|---|
| **Mesa (new column)** | **40.76** | 55.39 | 67.47 | 
| FloatTest | 41.54 | 44.26 | 91.9 |
| TrafficBRAM | 23.74 | 29.26 | 94.0 |
| Dividers / Sudoku / DFT64v1 / DFT64v5 / Long | 2.21 / 132.3 / 9.18 / 9.75 / 956 | 3.06 / 373.7 / 12.28 / 14.94 / 16353 | — |
| CFL / BRAM0Test | 7.2 / 7.39 | 5.43 / 4.59 | — |

**Mesa is a 26% trs win. Scoreboard: 8W/2L across the 10 timed Verilator legs; 11/11 vs Bluesim.** Side finding: the long-parked "vl-output DIFF" question dissolves — with the `$finish` trailer normalized, every timed design's Verilator output is byte-identical to Bluesim's (CFL extends it by one same-instant line after `$finish`, the documented Verilator finish semantics the harness's prefix rule accepts; DFT64 stays `$random`-exempt).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_