### PR TITLE
trs: compiled dynamic scheduling — per-alternative edge bodies behind a guard dispatch

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -562,6 +562,19 @@ pub struct EdgeSsaPlan {
     /// the registered value (arena words [base, base+w) -> [base+w,
     /// base+2w)); the boxed per-port history only feeds VCD
     pub creg_copies: Vec<Vec<(u32, u32)>>,
+    /// per composition: compiled dynamic-scheduling alternatives in
+    /// guard-evaluation order (first matching guard wins; none -> the
+    /// composition's own base row).  Empty everywhere = no dispatch.
+    pub alt_rows: Vec<Vec<AltRow>>,
+    /// per ROW, per spec ordinal: sched-section overrides for the
+    /// order-derived RuleSpec fields (inhibitors, owned-earlier
+    /// shares).  Base rows carry empty maps — a RuleSpec bakes the
+    /// BASE interleaving's values and is correct there.
+    pub sched_over: Vec<HashMap<usize, SchedOver>>,
+    /// per exec ordinal: the outlined-call node (class-rep symbol +
+    /// region/token bases).  Variant rows have no FusedComp node
+    /// stream to index by section, so outlined execs resolve here.
+    pub ord_fnodes: HashMap<usize, FusedNode>,
     /// per composition: packed trs_bram_tick argument triples of
     /// ungated BRAM port ticks — the edge fn calls the helper through
     /// the trs_bram_tick_cb pointer-global (filled at artifact load)
@@ -881,6 +894,32 @@ unsafe fn mask_top(p: *mut u64, width: u32, words: usize) {
 }
 
 /// One node of a fused per-composition edge function.
+/// One compiled dynamic-scheduling alternative of a composition: the
+/// edge fn's prologue evaluates `guard` against pre-edge state
+/// (registers only, by the SchedAlt exporter contract) and branches to
+/// the alternative's body — the compiled twin of the interpreter's
+/// per-edge selection.
+#[derive(Clone)]
+pub struct AltRow {
+    /// row index into EdgeSsaPlan::nodes/hoists (variant rows are
+    /// appended after the per-composition base rows)
+    pub row: usize,
+    /// instance the guard expression is scoped to
+    pub guard_inst: usize,
+    /// the guard, first-match-wins in declaration order
+    pub guard: trs_ir::Expr,
+}
+
+/// Order-derived RuleSpec overrides for a sched section emitted inside
+/// an alternative's body: ME inhibitors follow the interleaving, and
+/// owned-earlier share claims only hold for defs whose owner entry
+/// runs earlier in THIS interleaving.
+#[derive(Clone)]
+pub struct SchedOver {
+    pub inhibit_slots: Vec<u32>,
+    pub shared: Vec<StrId>,
+}
+
 pub enum FusedNode {
     /// sched fn: baked address (JIT) or symbol (AOT)
     Sched(HelperRef),

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -1210,267 +1210,390 @@ fn lower_edge_ssa<'ctx>(
             b.build_store(gep(en), i64t.const_zero()).unwrap();
         }
 
-        let mut edge_ctx = EdgeCtx {
-            exports: plan.export_slots.clone(),
-            ..Default::default()
-        };
         section_sizes.push(Vec::new());
-        // checkpoint for exact per-section attribution: new blocks
-        // PLUS growth of the carried-over insert block (straight-line
-        // sections often append no block at all — block-count deltas
-        // alone attribute their code to the next block creator)
-        let mut blocks_seen = func.count_basic_blocks() as usize;
-        let mut carry = entry;
-        let mut carry_insns = count_block(entry);
-        let mut cur = entry;
-        for (s, &(is_exec, o)) in plan.nodes[k].iter().enumerate() {
-            let spec = &specs[o];
-            let mut lc = Lower {
-                env,
-                ctx,
-                module,
-                builder: ctx.create_builder(),
-                cbs,
-                spec,
-                token_kind: if is_exec { TOKEN_KIND_EXEC } else { 0 },
-                outlined,
-                helper_self: None,
-                dedup: None,
-                foreign_stmts: Vec::new(),
-                prim_calls: Vec::new(),
-                edge: Some(std::mem::take(&mut edge_ctx)),
-            };
-            lc.builder.position_at_end(cur);
-            // hoist prelude: shared pure defs whose first consumer is
-            // this section, computed unconditionally on the spine (so
-            // the values dominate every later section)
-            for &(hi, hd) in &plan.hoists[k][s] {
-                let mut hf = Frame {
+        // dynamic-scheduling dispatch (compiled alts): evaluate the
+        // guards in declaration order against pre-edge state — pure
+        // register/const cones by the SchedAlt exporter contract —
+        // and branch to the first match's body; none matching walks
+        // the base row.  Interp parity: Value::as_bool is "nonzero",
+        // so the taken test is a plain != 0 on the guard value.
+        let alt_refs: &[crate::abi::AltRow] =
+            plan.alt_rows.get(k).map(|v| &v[..]).unwrap_or(&[]);
+        let mut bodies = Vec::new();
+        if alt_refs.is_empty() {
+            bodies.push((k, entry));
+        } else {
+            let gspec = specs.first().ok_or_else(|| {
+                Ineligible("alts plan without specs".into())
+            })?;
+            let mut chk = entry;
+            for (vi, ar) in alt_refs.iter().enumerate() {
+                let body_bb =
+                    ctx.append_basic_block(func, &format!("alt{vi}"));
+                let next_bb =
+                    ctx.append_basic_block(func, &format!("chk{vi}"));
+                // the guard Lower never reaches spec-derived state
+                // (pure cone, no tokens/foreign) — any spec anchors it
+                let mut lcg = Lower {
+                    env,
+                    ctx,
+                    module,
+                    builder: ctx.create_builder(),
+                    cbs,
+                    spec: gspec,
+                    token_kind: 0,
+                    // no helper memoization on the guard path: a
+                    // memo filled at this extra pre-edge evaluation
+                    // point would serve stale values to the body's
+                    // own cone reads later in the instant
+                    outlined: None,
+                    helper_self: None,
+                    dedup: None,
+                    foreign_stmts: Vec::new(),
+                    prim_calls: Vec::new(),
+                    edge: None,
+                };
+                lcg.builder.position_at_end(chk);
+                let mut gf = Frame {
                     arena,
                     envp: Some(envp),
-                    inst: hi,
+                    inst: ar.guard_inst,
                     method_idx: None,
                     args: HashMap::new(),
                     ssa: HashMap::new(),
                     expanding: Vec::new(),
                     thunks: HashMap::new(),
                     av_widths: HashMap::new(),
-            dead_defs: Default::default(),
+                    dead_defs: Default::default(),
                     tasks: HashMap::new(),
                     av_slots: HashMap::new(),
                     av_args: HashMap::new(),
-                    is_exec: true,
+                    is_exec: false,
                     depth: 0,
                 };
-                let v = lc.def(&mut hf, hd)?;
-                lc.edge.as_mut().unwrap().shared.insert((hi, hd), v);
-            }
-            let mut f = Frame {
-                arena,
-                envp: Some(envp),
-                inst: spec.inst,
-                method_idx: None,
-                args: HashMap::new(),
-                ssa: HashMap::new(),
-                expanding: Vec::new(),
-                thunks: HashMap::new(),
-                av_widths: HashMap::new(),
-            dead_defs: Default::default(),
-                tasks: HashMap::new(),
-                av_slots: HashMap::new(),
-                av_args: HashMap::new(),
-                is_exec,
-                depth: 0,
-            };
-            if is_exec {
-                // PRE-evict (review-fleet critical finding): a rule
-                // whose own actions invalidate a shared def must not
-                // consume the pre-body value — tsort body-position
-                // semantics.  The plan already refuses to HOIST at
-                // self-killing sections; this refuses CONSUMPTION of
-                // earlier anchors too.
+                let gv = lcg.expr(&mut gf, &ar.guard)?;
+                // SchedAlt contract: the guard cone is pure (register
+                // and const reads only).  A callback emitted here
+                // would carry gspec's tokens — wrong rule, wrong
+                // proto — so refuse LOUDLY instead of miswiring.
+                if !lcg.foreign_stmts.is_empty() || !lcg.prim_calls.is_empty()
                 {
+                    return Err(Ineligible(
+                        "alts guard cone is not pure (callback emitted)"
+                            .into(),
+                    ));
+                }
+                let nz = lcg
+                    .builder
+                    .build_int_compare(
+                        IntPredicate::NE,
+                        gv,
+                        gv.get_type().const_zero(),
+                        "g",
+                    )
+                    .unwrap();
+                lcg.builder
+                    .build_conditional_branch(nz, body_bb, next_bb)
+                    .unwrap();
+                bodies.push((ar.row, body_bb));
+                chk = next_bb;
+            }
+            bodies.push((k, chk));
+        }
+        for (row, start) in bodies {
+            let mut edge_ctx = EdgeCtx {
+                exports: plan.export_slots.clone(),
+                ..Default::default()
+            };
+            // checkpoint for exact per-section attribution: new blocks
+            // PLUS growth of the carried-over insert block (straight-line
+            // sections often append no block at all — block-count deltas
+            // alone attribute their code to the next block creator)
+            let mut blocks_seen = func.count_basic_blocks() as usize;
+            let mut carry = start;
+            let mut carry_insns = count_block(start);
+            let mut cur = start;
+            for (s, &(is_exec, o)) in plan.nodes[row].iter().enumerate() {
+                let base_spec = &specs[o];
+                // order-derived sched overrides (variant rows only):
+                // ME inhibitors and owned-earlier share claims follow
+                // the selected interleaving, not the base order
+                let spec_owned: RuleSpec;
+                let spec: &RuleSpec = match plan
+                    .sched_over
+                    .get(row)
+                    .and_then(|m| m.get(&o))
+                {
+                    Some(ov) if !is_exec => {
+                        spec_owned = RuleSpec {
+                            inhibit_slots: ov.inhibit_slots.clone(),
+                            shared: ov.shared.clone(),
+                            ..base_spec.clone()
+                        };
+                        &spec_owned
+                    }
+                    _ => base_spec,
+                };
+                let mut lc = Lower {
+                    env,
+                    ctx,
+                    module,
+                    builder: ctx.create_builder(),
+                    cbs,
+                    spec,
+                    token_kind: if is_exec { TOKEN_KIND_EXEC } else { 0 },
+                    outlined,
+                    helper_self: None,
+                    dedup: None,
+                    foreign_stmts: Vec::new(),
+                    prim_calls: Vec::new(),
+                    edge: Some(std::mem::take(&mut edge_ctx)),
+                };
+                lc.builder.position_at_end(cur);
+                // hoist prelude: shared pure defs whose first consumer is
+                // this section, computed unconditionally on the spine (so
+                // the values dominate every later section)
+                for &(hi, hd) in &plan.hoists[row][s] {
+                    let mut hf = Frame {
+                        arena,
+                        envp: Some(envp),
+                        inst: hi,
+                        method_idx: None,
+                        args: HashMap::new(),
+                        ssa: HashMap::new(),
+                        expanding: Vec::new(),
+                        thunks: HashMap::new(),
+                        av_widths: HashMap::new(),
+                dead_defs: Default::default(),
+                        tasks: HashMap::new(),
+                        av_slots: HashMap::new(),
+                        av_args: HashMap::new(),
+                        is_exec: true,
+                        depth: 0,
+                    };
+                    let v = lc.def(&mut hf, hd)?;
+                    lc.edge.as_mut().unwrap().shared.insert((hi, hd), v);
+                }
+                let mut f = Frame {
+                    arena,
+                    envp: Some(envp),
+                    inst: spec.inst,
+                    method_idx: None,
+                    args: HashMap::new(),
+                    ssa: HashMap::new(),
+                    expanding: Vec::new(),
+                    thunks: HashMap::new(),
+                    av_widths: HashMap::new(),
+                dead_defs: Default::default(),
+                    tasks: HashMap::new(),
+                    av_slots: HashMap::new(),
+                    av_args: HashMap::new(),
+                    is_exec,
+                    depth: 0,
+                };
+                if is_exec {
+                    // PRE-evict (review-fleet critical finding): a rule
+                    // whose own actions invalidate a shared def must not
+                    // consume the pre-body value — tsort body-position
+                    // semantics.  The plan already refuses to HOIST at
+                    // self-killing sections; this refuses CONSUMPTION of
+                    // earlier anchors too.
+                    {
+                        let ws = &writes[o];
+                        lc.edge.as_mut().unwrap().shared.retain(|key, _| {
+                            plan.def_reads
+                                .get(key)
+                                .is_some_and(|rs| rs.iter().all(|gi| !ws.contains(gi)))
+                        });
+                    }
+                    if plan.outlined_execs.contains(&o) {
+                        // outline dial: call the standalone class body (it
+                        // gates itself on the stored WF slot; stores are
+                        // all kept) — bounds the mega-function while the
+                        // body keeps its per-module-type dedup
+                        // variant rows have no FusedComp stream: the
+                        // outlined call resolves per ordinal instead
+                        let fnode = if row == k {
+                            &fused[k].nodes[s]
+                        } else {
+                            plan.ord_fnodes.get(&o).ok_or_else(|| {
+                                Ineligible(
+                                    "variant outlined exec without ord node"
+                                        .into(),
+                                )
+                            })?
+                        };
+                        let FusedNode::Exec(href, base, tok) = fnode else {
+                            return Err(Ineligible(
+                                "outlined exec node mismatch".into(),
+                            ));
+                        };
+                        let exec_ty = i32t.fn_type(
+                            &[ptrt.into(), ptrt.into(), i64t.into(), i64t.into()],
+                            false,
+                        );
+                        let args: Vec<inkwell::values::BasicMetadataValueEnum> = vec![
+                            arena.into(),
+                            envp.into(),
+                            i64t.const_int(*base, false).into(),
+                            i64t.const_int(*tok, false).into(),
+                        ];
+                        let cs = match href {
+                            HelperRef::Sym(name) => {
+                                let cf = module.get_function(name).unwrap_or_else(|| {
+                                    module.add_function(name, exec_ty, None)
+                                });
+                                lc.builder.build_call(cf, &args, "oe").unwrap()
+                            }
+                            HelperRef::Addr(a) => {
+                                let fp = i64t
+                                    .const_int(*a as u64, false)
+                                    .const_to_pointer(ptrt);
+                                lc.builder
+                                    .build_indirect_call(exec_ty, fp, &args, "oe")
+                                    .unwrap()
+                            }
+                        };
+                        let inkwell::values::ValueKind::Basic(rv) = cs.try_as_basic_value()
+                        else {
+                            return Err(Ineligible("outlined exec returned void".into()));
+                        };
+                        let stop = lc
+                            .builder
+                            .build_int_compare(
+                                IntPredicate::NE,
+                                rv.into_int_value(),
+                                i32t.const_zero(),
+                                "st",
+                            )
+                            .unwrap();
+                        let cont = ctx.append_basic_block(func, "oc");
+                        lc.builder
+                            .build_conditional_branch(stop, stop_bb, cont)
+                            .unwrap();
+                        lc.builder.position_at_end(cont);
+                    } else {
+                        lc.exec_section(&mut f, func, stop_bb)?;
+                    }
+                    // evict shares whose cone the body may have invalidated
                     let ws = &writes[o];
                     lc.edge.as_mut().unwrap().shared.retain(|key, _| {
                         plan.def_reads
                             .get(key)
                             .is_some_and(|rs| rs.iter().all(|gi| !ws.contains(gi)))
                     });
+                } else {
+                    lc.sched_section(&mut f)?;
                 }
-                if plan.outlined_execs.contains(&o) {
-                    // outline dial: call the standalone class body (it
-                    // gates itself on the stored WF slot; stores are
-                    // all kept) — bounds the mega-function while the
-                    // body keeps its per-module-type dedup
-                    let FusedNode::Exec(href, base, tok) = &fused[k].nodes[s] else {
-                        return Err(Ineligible(
-                            "outlined exec node mismatch".into(),
-                        ));
+                cur = lc.builder.get_insert_block().unwrap();
+                edge_ctx = lc.edge.take().unwrap();
+                let (nb, new_insns) = count_new(func, blocks_seen);
+                let carry_now = count_block(carry);
+                let insns = new_insns + carry_now.saturating_sub(carry_insns);
+                blocks_seen = nb;
+                carry = cur;
+                carry_insns = count_block(cur);
+                if is_exec && !plan.outlined_execs.contains(&o) {
+                    section_sizes[k].push((o, insns));
+                }
+            }
+            let bend = ctx.create_builder();
+            bend.position_at_end(cur);
+            // compiled wire ticks: end-of-edge valid-bit clears
+            if let Some(clears) = plan.wire_clears.get(row) {
+                for &slot in clears {
+                    let gepw = unsafe {
+                        bend.build_gep(
+                            i64t,
+                            arena,
+                            &[i64t.const_int(slot as u64, false)],
+                            "wc",
+                        )
+                        .unwrap()
                     };
-                    let exec_ty = i32t.fn_type(
-                        &[ptrt.into(), ptrt.into(), i64t.into(), i64t.into()],
+                    bend.build_store(gepw, i64t.const_zero()).unwrap();
+                }
+            }
+            // compiled CReg ticks: copy the live value into the registered
+            // value (the whole untraced semantics of CReg::tick)
+            if let Some(copies) = plan.creg_copies.get(row) {
+                for &(base, words) in copies {
+                    for i in 0..words {
+                        let s = unsafe {
+                            bend.build_gep(
+                                i64t,
+                                arena,
+                                &[i64t.const_int((base + i) as u64, false)],
+                                "cs",
+                            )
+                            .unwrap()
+                        };
+                        let v = bend.build_load(i64t, s, "cv").unwrap();
+                        let d = unsafe {
+                            bend.build_gep(
+                                i64t,
+                                arena,
+                                &[i64t
+                                    .const_int((base + words + i) as u64, false)],
+                                "cd",
+                            )
+                            .unwrap()
+                        };
+                        bend.build_store(d, v).unwrap();
+                    }
+                }
+            }
+            // compiled BRAM ticks: one helper call per port tick, through
+            // the trs_bram_tick_cb pointer-global (filled at load).  Call
+            // order preserves the rc.ticks walk — the cross-port bypass
+            // reads the other port's just-latched written_at.
+            if let Some(ticks) = plan.bram_ticks.get(row) {
+                if !ticks.is_empty() {
+                    // external declaration: the meta object owns the single
+                    // definition (loader fills it after dlopen)
+                    let cbg = module
+                        .get_global("trs_bram_tick_cb")
+                        .unwrap_or_else(|| {
+                            module.add_global(i64t, None, "trs_bram_tick_cb")
+                        });
+                    let fp64 = bend
+                        .build_load(i64t, cbg.as_pointer_value(), "btc")
+                        .unwrap()
+                        .into_int_value();
+                    let fp =
+                        bend.build_int_to_ptr(fp64, ptrt, "btp").unwrap();
+                    let tick_ty = ctx.void_type().fn_type(
+                        &[
+                            ptrt.into(),
+                            i64t.into(),
+                            i64t.into(),
+                            i64t.into(),
+                            i64t.into(),
+                        ],
                         false,
                     );
-                    let args: Vec<inkwell::values::BasicMetadataValueEnum> = vec![
-                        arena.into(),
-                        envp.into(),
-                        i64t.const_int(*base, false).into(),
-                        i64t.const_int(*tok, false).into(),
-                    ];
-                    let cs = match href {
-                        HelperRef::Sym(name) => {
-                            let cf = module.get_function(name).unwrap_or_else(|| {
-                                module.add_function(name, exec_ty, None)
-                            });
-                            lc.builder.build_call(cf, &args, "oe").unwrap()
-                        }
-                        HelperRef::Addr(a) => {
-                            let fp = i64t
-                                .const_int(*a as u64, false)
-                                .const_to_pointer(ptrt);
-                            lc.builder
-                                .build_indirect_call(exec_ty, fp, &args, "oe")
-                                .unwrap()
-                        }
-                    };
-                    let inkwell::values::ValueKind::Basic(rv) = cs.try_as_basic_value()
-                    else {
-                        return Err(Ineligible("outlined exec returned void".into()));
-                    };
-                    let stop = lc
-                        .builder
-                        .build_int_compare(
-                            IntPredicate::NE,
-                            rv.into_int_value(),
-                            i32t.const_zero(),
-                            "st",
+                    for a in ticks {
+                        bend.build_indirect_call(
+                            tick_ty,
+                            fp,
+                            &[
+                                arena.into(),
+                                now.into(),
+                                i64t.const_int(a[0], false).into(),
+                                i64t.const_int(a[1], false).into(),
+                                i64t.const_int(a[2], false).into(),
+                            ],
+                            "bt",
                         )
                         .unwrap();
-                    let cont = ctx.append_basic_block(func, "oc");
-                    lc.builder
-                        .build_conditional_branch(stop, stop_bb, cont)
-                        .unwrap();
-                    lc.builder.position_at_end(cont);
-                } else {
-                    lc.exec_section(&mut f, func, stop_bb)?;
-                }
-                // evict shares whose cone the body may have invalidated
-                let ws = &writes[o];
-                lc.edge.as_mut().unwrap().shared.retain(|key, _| {
-                    plan.def_reads
-                        .get(key)
-                        .is_some_and(|rs| rs.iter().all(|gi| !ws.contains(gi)))
-                });
-            } else {
-                lc.sched_section(&mut f)?;
-            }
-            cur = lc.builder.get_insert_block().unwrap();
-            edge_ctx = lc.edge.take().unwrap();
-            let (nb, new_insns) = count_new(func, blocks_seen);
-            let carry_now = count_block(carry);
-            let insns = new_insns + carry_now.saturating_sub(carry_insns);
-            blocks_seen = nb;
-            carry = cur;
-            carry_insns = count_block(cur);
-            if is_exec && !plan.outlined_execs.contains(&o) {
-                section_sizes[k].push((o, insns));
-            }
-        }
-        let bend = ctx.create_builder();
-        bend.position_at_end(cur);
-        // compiled wire ticks: end-of-edge valid-bit clears
-        if let Some(clears) = plan.wire_clears.get(k) {
-            for &slot in clears {
-                let gepw = unsafe {
-                    bend.build_gep(
-                        i64t,
-                        arena,
-                        &[i64t.const_int(slot as u64, false)],
-                        "wc",
-                    )
-                    .unwrap()
-                };
-                bend.build_store(gepw, i64t.const_zero()).unwrap();
-            }
-        }
-        // compiled CReg ticks: copy the live value into the registered
-        // value (the whole untraced semantics of CReg::tick)
-        if let Some(copies) = plan.creg_copies.get(k) {
-            for &(base, words) in copies {
-                for i in 0..words {
-                    let s = unsafe {
-                        bend.build_gep(
-                            i64t,
-                            arena,
-                            &[i64t.const_int((base + i) as u64, false)],
-                            "cs",
-                        )
-                        .unwrap()
-                    };
-                    let v = bend.build_load(i64t, s, "cv").unwrap();
-                    let d = unsafe {
-                        bend.build_gep(
-                            i64t,
-                            arena,
-                            &[i64t
-                                .const_int((base + words + i) as u64, false)],
-                            "cd",
-                        )
-                        .unwrap()
-                    };
-                    bend.build_store(d, v).unwrap();
+                    }
                 }
             }
+            bend.build_return(Some(&i32t.const_int(0, false))).unwrap();
         }
-        // compiled BRAM ticks: one helper call per port tick, through
-        // the trs_bram_tick_cb pointer-global (filled at load).  Call
-        // order preserves the rc.ticks walk — the cross-port bypass
-        // reads the other port's just-latched written_at.
-        if let Some(ticks) = plan.bram_ticks.get(k) {
-            if !ticks.is_empty() {
-                // external declaration: the meta object owns the single
-                // definition (loader fills it after dlopen)
-                let cbg = module
-                    .get_global("trs_bram_tick_cb")
-                    .unwrap_or_else(|| {
-                        module.add_global(i64t, None, "trs_bram_tick_cb")
-                    });
-                let fp64 = bend
-                    .build_load(i64t, cbg.as_pointer_value(), "btc")
-                    .unwrap()
-                    .into_int_value();
-                let fp =
-                    bend.build_int_to_ptr(fp64, ptrt, "btp").unwrap();
-                let tick_ty = ctx.void_type().fn_type(
-                    &[
-                        ptrt.into(),
-                        i64t.into(),
-                        i64t.into(),
-                        i64t.into(),
-                        i64t.into(),
-                    ],
-                    false,
-                );
-                for a in ticks {
-                    bend.build_indirect_call(
-                        tick_ty,
-                        fp,
-                        &[
-                            arena.into(),
-                            now.into(),
-                            i64t.const_int(a[0], false).into(),
-                            i64t.const_int(a[1], false).into(),
-                            i64t.const_int(a[2], false).into(),
-                        ],
-                        "bt",
-                    )
-                    .unwrap();
-                }
-            }
-        }
-        bend.build_return(Some(&i32t.const_int(0, false))).unwrap();
-        bend.position_at_end(stop_bb);
-        bend.build_return(Some(&i32t.const_int(1, false))).unwrap();
+        let bstop = ctx.create_builder();
+        bstop.position_at_end(stop_bb);
+        bstop.build_return(Some(&i32t.const_int(1, false))).unwrap();
     }
     Ok(())
 }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1942,11 +1942,11 @@ impl Interp {
             ineligible(&mut r_reason, "boxed prims (lazy Reflect pending)");
         }
         // dynamic scheduling: alternative interleavings select per
-        // edge, so no single baked comp order (or window image taken
-        // under one order) is valid across selections.  Alts designs
-        // never reach the Emit stash today (the jit declines them and
-        // desc_finish only runs post-Emit), so this gate is explicit
-        // belt-and-braces against that ever changing.
+        // edge.  Compiled-alts artifacts DO reach Emit now (the edge
+        // fns carry the guard dispatch), so this gate is load-bearing:
+        // the RunCore boot replays baked plan state under one comp
+        // order, and no single baked window/plan order is valid
+        // across selections — alts designs boot classic (v1).
         if rcomps.iter().any(|rc| !rc.alts.is_empty()) {
             ineligible(&mut r_reason, "dynamic scheduling (alts)");
         }
@@ -3739,6 +3739,13 @@ impl Interp {
             wire_clears: Vec::new(),
             creg_copies: Vec::new(),
             bram_ticks: Vec::new(),
+            // dynamic-scheduling variants are the CALLER's to fill
+            // (jit_plan owns guard/inhibitor resolution); the plan
+            // tables above already cover any variant rows appended to
+            // `nodes` — this fn is row-uniform
+            alt_rows: Vec::new(),
+            sched_over: Vec::new(),
+            ord_fnodes: HashMap::new(),
             export_slots,
         }
     }
@@ -3874,6 +3881,33 @@ impl Interp {
             }
             return None;
         }
+        // dynamic-scheduling alternatives compile ONLY as edge-SSA
+        // artifact emission — per-alternative bodies behind a
+        // guard-dispatch prologue INSIDE each comp's edge fn — or a
+        // Load of such an artifact (the dispatch ships in the .so;
+        // the loader needs no variant plan).  Every other mode keeps
+        // the interp fallback: the in-process JIT tier and
+        // TRS_EDGE_SSA=0 emission drive standalone sched fns whose
+        // inhibitor slots bake the BASE order (wrong under a selected
+        // alternative), and traced plans would need per-variant
+        // recording.  The alternative cap bounds edge-fn growth
+        // (bodies multiply per alternative).
+        let have_alts = rcomps.iter().any(|rc| !rc.alts.is_empty());
+        let edge_ssa_on = std::env::var("TRS_EDGE_SSA").as_deref() != Ok("0");
+        let alts_capped = rcomps.iter().all(|rc| rc.alts.len() <= 16);
+        let alts_compiled = have_alts
+            && alts_capped
+            && match &request {
+                JitRequest::Emit { .. } => edge_ssa_on && !self.vcd_trace,
+                JitRequest::Load { .. } => true,
+                JitRequest::Run => false,
+            };
+        if have_alts && !alts_compiled {
+            if trace {
+                eprintln!("trs jit: off (dynamic schedule)");
+            }
+            return None;
+        }
 
         let mut sl = crate::startup::StartupLap::new();
         let mut nslots: u32 = 0;
@@ -3906,14 +3940,6 @@ impl Interp {
             // exactly like a cold exec cell — so they are SKIPPED here
             // (kept out of rule_ord and the node stream), not refused.
             // The central fast loop already bails on early comps.
-            // dynamic-scheduling alternatives select the interleaving
-            // per edge; compiled dispatch bakes one order (v1: interp)
-            if !rc.alts.is_empty() {
-                if trace {
-                    eprintln!("trs jit: off (dynamic schedule)");
-                }
-                return None;
-            }
             // eager defs owned by entries already walked in THIS comp,
             // per instance: later rules of the same instance may load
             // their slots instead of re-expanding the cone
@@ -3954,6 +3980,39 @@ impl Interp {
                         shared,
                     });
                     let _ = mir;
+                }
+            }
+            // alternative interleavings reference the same segment
+            // space as the base entries; a rule reachable ONLY
+            // through an alternative still needs an ordinal.  Its
+            // base-order share claims don't transfer, so it makes
+            // none (the sched section re-expands its cone) — the
+            // per-alternative override below never widens a claim.
+            for alt in &rc.alts {
+                for en in &alt.entries {
+                    for &node in &en.nodes {
+                        let SchedNode::Sched(r) = node else { continue };
+                        if rc.early.contains(&(en.inst, r))
+                            || rule_ord.contains_key(&(en.inst, r))
+                        {
+                            continue;
+                        }
+                        let module = self.module_of(en.inst);
+                        let Some(&ri) = self.mods[module].rules.get(&r)
+                        else {
+                            continue;
+                        };
+                        rule_ord.insert((en.inst, r), rules.len());
+                        rules.push(RuleInfo {
+                            inst: en.inst,
+                            rule_idx: ri,
+                            ordinal: rules.len(),
+                            cf_slot: 0,
+                            wf_slot: 0,
+                            eager: en.eager.clone(),
+                            shared: Vec::new(),
+                        });
+                    }
                 }
             }
         }
@@ -4685,6 +4744,12 @@ impl Interp {
         sl.lap("plan sigs (inst_sig hashing)");
         // one design-wide spec list (ordinal order)
         let mut specs = Vec::new();
+        // per ordinal: (ME-inhibitor slot count, per-comp base cross
+        // slots) — the compiled-alts variant builder recomposes
+        // inhibitors as ME + other comps' base cross + this comp's
+        // ALTERNATIVE cross (a union over interleavings would inhibit
+        // rules that do not precede the victim in the selected order)
+        let mut sched_parts: Vec<(usize, Vec<Vec<u32>>)> = Vec::new();
         for ri in &rules {
             let mir = inst_envs[&ri.inst].mir;
             let rr = &self.d.modules[mir].rules[ri.rule_idx];
@@ -4703,11 +4768,15 @@ impl Interp {
                     }
                 }
             }
+            let me_len = inhibit_slots.len();
+            let mut cross_by_comp: Vec<Vec<u32>> =
+                Vec::with_capacity(rcomps.len());
             for rc in rcomps {
+                let mut cv = Vec::new();
                 if let Some(cs) = rc.cross.get(&(ri.inst, rr.name)) {
                     for (oi, ocf) in cs {
                         match inst_envs.get(oi).and_then(|e| e.cfwf_slot.get(ocf)) {
-                            Some(&s) => inhibit_slots.push(s),
+                            Some(&s) => cv.push(s),
                             None => {
                                 if trace {
                                     eprintln!(
@@ -4719,7 +4788,10 @@ impl Interp {
                         }
                     }
                 }
+                inhibit_slots.extend(cv.iter().copied());
+                cross_by_comp.push(cv);
             }
+            sched_parts.push((me_len, cross_by_comp));
             // always-fire detection (task #23): the WILL_FIRE def
             // resolves (through Def aliases) to a constant-true value.
             // Only WF is the truth: bsc bakes preemption/urgency gating
@@ -5175,7 +5247,7 @@ impl Interp {
             // legality tables the edge emitter consumes
             // DEFAULT ON for AOT links (the specialized fast compile);
             // TRS_EDGE_SSA=0 restores the classic emission
-            let nodes_for_plan: Vec<Vec<(bool, usize)>> = comp_nodes
+            let mut nodes_for_plan: Vec<Vec<(bool, usize)>> = comp_nodes
                 .iter()
                 .map(|ns| {
                     ns.as_ref()
@@ -5190,6 +5262,142 @@ impl Interp {
                         .unwrap_or_default()
                 })
                 .collect();
+            // compiled dynamic-scheduling variants (Emit only — a Load
+            // runs the dispatch already baked into the artifact): one
+            // appended plan row per (composition, alternative), plus
+            // the order-derived sched overrides for that row.  Guard
+            // evaluation order = declaration order (interp parity:
+            // first match wins, none matching walks the base row).
+            struct AltVar {
+                comp: usize,
+                guard_inst: usize,
+                guard: trs_ir::Expr,
+                nodes: Vec<(bool, usize)>,
+                over: HashMap<usize, trs_codegen::abi::SchedOver>,
+            }
+            let mut alt_vars: Vec<AltVar> = Vec::new();
+            if alts_compiled {
+                for (k, rc) in rcomps.iter().enumerate() {
+                    for alt in &rc.alts {
+                        let mut vnodes: Vec<(bool, usize)> = Vec::new();
+                        // owned-earlier eager defs per instance in
+                        // THIS interleaving: base share claims only
+                        // survive where the owner still runs earlier
+                        let mut owned: HashMap<
+                            usize,
+                            std::collections::HashSet<StrId>,
+                        > = HashMap::new();
+                        let mut over: HashMap<
+                            usize,
+                            trs_codegen::abi::SchedOver,
+                        > = HashMap::new();
+                        for en in &alt.entries {
+                            for &node in &en.nodes {
+                                let (r, is_sched) = match node {
+                                    SchedNode::Sched(r) => (r, true),
+                                    SchedNode::Exec(r) => (r, false),
+                                };
+                                if rc.early.contains(&(en.inst, r)) {
+                                    continue;
+                                }
+                                let Some(&o) = rule_ord.get(&(en.inst, r))
+                                else {
+                                    continue;
+                                };
+                                vnodes.push((!is_sched, o));
+                                if !is_sched {
+                                    continue;
+                                }
+                                // inhibitors: ME + the OTHER comps'
+                                // base cross + this alternative's own
+                                // cross (never the base order's)
+                                let (me_len, ref cbc) = sched_parts[o];
+                                let mut inh: Vec<u32> =
+                                    specs[o].inhibit_slots[..me_len].to_vec();
+                                for (j, cv) in cbc.iter().enumerate() {
+                                    if j != k {
+                                        inh.extend(cv.iter().copied());
+                                    }
+                                }
+                                if let Some(cs) = alt.cross.get(&(en.inst, r)) {
+                                    for (oi, ocf) in cs {
+                                        match inst_envs
+                                            .get(oi)
+                                            .and_then(|e| e.cfwf_slot.get(ocf))
+                                        {
+                                            Some(&s) => inh.push(s),
+                                            None => {
+                                                if trace {
+                                                    eprintln!(
+                                                        "trs jit: off (unslotted \
+                                                         alt cross inhibitor)"
+                                                    );
+                                                }
+                                                return None;
+                                            }
+                                        }
+                                    }
+                                }
+                                let shared: Vec<StrId> = specs[o]
+                                    .shared
+                                    .iter()
+                                    .filter(|d| {
+                                        owned
+                                            .get(&en.inst)
+                                            .is_some_and(|s| s.contains(d))
+                                    })
+                                    .copied()
+                                    .collect();
+                                over.insert(
+                                    o,
+                                    trs_codegen::abi::SchedOver {
+                                        inhibit_slots: inh,
+                                        shared,
+                                    },
+                                );
+                                owned
+                                    .entry(en.inst)
+                                    .or_default()
+                                    .extend(en.eager.iter().copied());
+                            }
+                        }
+                        alt_vars.push(AltVar {
+                            comp: k,
+                            guard_inst: alt.guard_inst,
+                            guard: alt.guard.clone(),
+                            nodes: vnodes,
+                            over,
+                        });
+                    }
+                }
+            }
+            let base_rows = nodes_for_plan.len();
+            let mut alt_row_refs: Vec<Vec<trs_codegen::abi::AltRow>> =
+                vec![Vec::new(); base_rows];
+            let mut sched_over_rows: Vec<
+                HashMap<usize, trs_codegen::abi::SchedOver>,
+            > = vec![HashMap::new(); base_rows];
+            // per appended row: its composition (tick-table inheritance)
+            let mut alt_row_comp: Vec<usize> = Vec::new();
+            for av in alt_vars {
+                let row = nodes_for_plan.len();
+                nodes_for_plan.push(av.nodes);
+                sched_over_rows.push(av.over);
+                alt_row_comp.push(av.comp);
+                alt_row_refs[av.comp].push(trs_codegen::abi::AltRow {
+                    row,
+                    guard_inst: av.guard_inst,
+                    guard: av.guard,
+                });
+            }
+            // exec class representatives, for the variant rows'
+            // outlined-call nodes (FusedComp streams cover base rows)
+            let mut rep_of: Vec<usize> = (0..specs.len()).collect();
+            for (rep, members) in &classes {
+                for &m in members {
+                    rep_of[m] = *rep;
+                }
+            }
             let mk_edge_plan = |forced: &std::collections::HashSet<usize>| {
                 (std::env::var("TRS_EDGE_SSA").as_deref() != Ok("0")).then(|| {
                     let mut plan = self.edge_ssa_plan(
@@ -5209,6 +5417,43 @@ impl Interp {
                         plan.wire_clears = cov.wire_clears;
                         plan.creg_copies = cov.creg_copies;
                         plan.bram_ticks = cov.bram_ticks;
+                    }
+                    if !alt_row_comp.is_empty() {
+                        plan.alt_rows = alt_row_refs.clone();
+                        plan.sched_over = sched_over_rows.clone();
+                        // variant rows resolve outlined execs per
+                        // ordinal (no FusedComp stream to index)
+                        for (o, sp) in specs.iter().enumerate() {
+                            plan.ord_fnodes.insert(
+                                o,
+                                trs_codegen::abi::FusedNode::Exec(
+                                    trs_codegen::abi::HelperRef::Sym(
+                                        format!(
+                                            "exec_{}",
+                                            specs[rep_of[o]].label
+                                        ),
+                                    ),
+                                    inst_envs[&sp.inst].region.0 as u64,
+                                    sp.token_base,
+                                ),
+                            );
+                        }
+                        // variant rows inherit their composition's
+                        // tick tables (ticks are per comp, not per
+                        // interleaving); rows were appended in
+                        // alt_row_comp order.  Length guard: traced
+                        // plans leave the tables empty (and decline
+                        // alts anyway) — never mis-index rows.
+                        if plan.wire_clears.len() == base_rows {
+                            for &c in &alt_row_comp {
+                                let wc = plan.wire_clears[c].clone();
+                                let cc = plan.creg_copies[c].clone();
+                                let bt = plan.bram_ticks[c].clone();
+                                plan.wire_clears.push(wc);
+                                plan.creg_copies.push(cc);
+                                plan.bram_ticks.push(bt);
+                            }
+                        }
                     }
                     plan
                 })

--- a/src/trs/tests/regress/run.sh
+++ b/src/trs/tests/regress/run.sh
@@ -273,10 +273,10 @@ check_dyn() { # name top errtag
     $BSC -sim -sched-dynamic -bir -trs -e "$top" -o dyn.exe >/dev/null 2>&1 || { echo "FAIL $name (bsc -trs link)"; fail=1; return; }
     "$TRS" run "$top.bir" > got.out 2>&1 || { echo "FAIL $name (trs run)"; fail=1; return; }
     if ! cmp -s "$SRC/$name.expected" got.out; then echo "FAIL $name (run stdout)"; diff "$SRC/$name.expected" got.out | head -3; fail=1; return; fi
-    "$TRS" link "$top.bir" -o dynart >dynlink.out 2>&1 || { echo "FAIL $name (trs link)"; fail=1; return; }
-    # the compiled engine does not execute dynamic schedules yet; a
-    # compiled artifact here would mean the jit gate silently vanished
-    grep -q "run interpreted" dynlink.out || { echo "FAIL $name (expected interpreted artifact)"; fail=1; return; }
+    # compiled alts: the artifact's edge fns carry the per-edge guard
+    # dispatch, so the link must COMPILE — TRS_REQUIRE_AOT trips (rc 86)
+    # if the engine silently falls back to interp again
+    TRS_REQUIRE_AOT=1 "$TRS" link "$top.bir" -o dynart >dynlink.out 2>&1 || { echo "FAIL $name (trs link, compiled)"; fail=1; return; }
     TRS="$TRS" ./dynart > gota.out 2>&1 || { echo "FAIL $name (art run)"; fail=1; return; }
     if ! cmp -s "$SRC/$name.expected" gota.out; then echo "FAIL $name (art stdout)"; diff "$SRC/$name.expected" gota.out | head -3; fail=1; return; fi
     echo "PASS $name"

--- a/testsuite/bsc.trs/dynsched/sysDynSched.trsonly.expected
+++ b/testsuite/bsc.trs/dynsched/sysDynSched.trsonly.expected
@@ -1,4 +1,3 @@
 flags=-sched-dynamic
 refuse=S0015
-engine=interp
-why=dynamic_schedule
+engine=aot

--- a/testsuite/bsc.trs/dynsched/sysDynSchedBoth.trsonly.expected
+++ b/testsuite/bsc.trs/dynsched/sysDynSchedBoth.trsonly.expected
@@ -1,4 +1,3 @@
 flags=-sched-dynamic
 refuse=S0015
-engine=interp
-why=dynamic_schedule
+engine=aot

--- a/testsuite/bsc.trs/dynsched/sysDynSchedLoop.trsonly.expected
+++ b/testsuite/bsc.trs/dynsched/sysDynSchedLoop.trsonly.expected
@@ -1,4 +1,3 @@
 flags=-sched-dynamic
 refuse=S0015
-engine=interp
-why=dynamic_schedule
+engine=aot

--- a/testsuite/bsc.trs/dynsched/sysDynSchedSelf.trsonly.expected
+++ b/testsuite/bsc.trs/dynsched/sysDynSchedSelf.trsonly.expected
@@ -1,4 +1,3 @@
 flags=-sched-dynamic
 refuse=S0015
-engine=interp
-why=dynamic_schedule
+engine=aot


### PR DESCRIPTION
Closes 4 of the corpus's 5 interpreter exceptions: the `bsc.trs/dynsched` family (`why=dynamic_schedule`) now compiles — every guarded alternative interleaving gets its own fused body inside the composition's edge function, behind a compiled guard-dispatch prologue. `sysTopAlwaysEn` (autofire) is the one remaining interp design, queued as its own rung.

## Mechanism

- **Plan side** (`jit_plan`): one appended plan row per (composition, alternative). `edge_ssa_plan` is row-uniform, so node streams, hoists, sharing legality, and export elision compute for variant rows exactly as for base rows. Variant rows inherit their composition's tick tables; `ord_fnodes` carries per-ordinal outlined-call nodes because variant rows have no `FusedComp` stream to index by section.
- **Order-derived spec overrides** (`SchedOver`): a `RuleSpec` bakes the BASE interleaving's values. Per variant row, ME inhibitors recompose as ME + the *other* compositions' base cross + *this alternative's* cross — a union over interleavings would inhibit rules that do not precede the victim in the selected order. Owned-earlier share claims are filtered to defs whose owner entry still runs earlier in the alternative (a base-order claim could otherwise load a slot the alternative has not stored yet).
- **Emission** (`lower_edge_ssa`): the edge fn's prologue evaluates the guards in declaration order against pre-edge state and branches to the first match's body; none matching walks the base row — exact interp parity (`Value::as_bool` = nonzero). Guard lowering is hardened: it refuses loudly if the cone emits any callback (it would be mis-tokened against an arbitrary spec), and skips helper memoization (an extra pre-edge evaluation point would serve stale per-instant memo values to the body's own cone reads).
- **Mode gate**: compiled only for edge-SSA emission (untraced, alternatives capped at 16) and Loads of such artifacts. The in-process JIT tier, `TRS_EDGE_SSA=0`, and traced plans keep the documented interp fallback — their standalone sched fns bake base-order inhibitors.
- **RunCore**: alts designs now *reach* Emit, so the sidecar eligibility refusal is load-bearing rather than belt-and-braces — they boot classic (v1), documented at the gate.

## Gates flipped with the feature, same diff

- `testsuite/bsc.trs/dynsched/*.trsonly.expected`: `engine=aot` (the sweep's engine tripwire now trips on a silent fallback *to* interp).
- Battery `check_dyn`: links under `TRS_REQUIRE_AOT=1` (rc 86 on fallback).

## Witnesses

- All 4 compiled artifacts byte-match their hand-derived goldens AND their interp runs (the goldens are RWire-order-sensitive: a wrong interleaving on a `put` cycle drops the `r: acc <=` line).
- `edge_c0` disassembly on `sysDynSched`: guard cone (register load, `and $1` / `cmp $9`) at fn top, conditional branch into two full interleaving bodies (distinct callback token sequences), converging on the shared tick-clear tail.
- Battery 22/22 classic and 22/22 `TRS_RUNCORE=1`.
- Dual full-corpus seals at this head: **1003 PASS / 0 DIFF** twice (witnessed `TRS_RUNCORE_CHECK=1 TRS_SELFCHECK=1`, and driver-armed `TRS_RUNCORE=1`), engines **1002 aot + 1 interp** — the one interp row is exactly `sysTopAlwaysEn`, by contract; zero mismatch, zero panics.

Stacked on #150 (`trs/31-bootalloc`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_