### PR TITLE
trs: compiled auto-fire — always_enabled top methods inline at their cut anchors (all-AOT corpus)

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -217,6 +217,21 @@ pub struct PlanEnv<'a> {
     pub d: &'a Design,
     pub insts: &'a HashMap<usize, InstEnv>,
 }
+/// One auto-fired always_enabled top method, compiled as an appended
+/// pseudo-spec.  NEVER serialized: Emit and Load both derive the same
+/// list from the design's autofire config (interface order), so
+/// PlanB's wire layout is untouched.
+#[derive(Clone)]
+pub struct AfSpec {
+    /// method index in the TOP module's method list
+    pub method_idx: usize,
+    /// method name — EN_<m>/RDY_<m> sibling lookups
+    pub method: StrId,
+    /// constant argument values in method-arg order:
+    /// (width, limbs normalized to ceil(width/64) words)
+    pub argv: Vec<(u32, Vec<u64>)>,
+}
+
 /// One rule to compile.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct RuleSpec {
@@ -246,6 +261,12 @@ pub struct RuleSpec {
     /// index (callers use e.g. global_rule_ordinal << 16 so one shared
     /// callback can resolve the rule and the statement)
     pub token_base: u64,
+    /// Some = auto-fire pseudo-spec: `rule_idx` is a synthetic unique
+    /// key (never index rules with it) and the exec section inlines
+    /// the method body instead.  serde(skip): PlanB only ever carries
+    /// rule specs, and both sides re-derive pseudo-specs identically.
+    #[serde(skip)]
+    pub autofire: Option<AfSpec>,
 }
 
 /// One compiled foreign call site: everything the interpreter needs

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -3543,10 +3543,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         // other rules' fire signals read their (already computed) slots;
         // this rule's own CF/WF must expand its cone instead — the sched
         // fn is what computes those slots
-        let own = f.inst == self.spec.inst && {
-            let r = self.rule();
-            n == r.can_fire || n == r.will_fire
-        };
+        // auto-fire pseudo-specs have no rule (synthetic rule_idx) and
+        // no own CF/WF — every fire signal reads its computed slot
+        let own = f.inst == self.spec.inst
+            && self.spec.autofire.is_none()
+            && {
+                let r = self.rule();
+                n == r.can_fire || n == r.will_fire
+            };
         if !own {
             if let Some(&slot) = ie.cfwf_slot.get(&n) {
                 edge_ssa_count(0, 1);
@@ -4024,6 +4028,11 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     /// is at the section's top level, so recording it in the edge
     /// cache is dominance-safe.
     fn sched_section(&mut self, f: &mut Frame<'ctx>) -> Result<(), Ineligible> {
+        if self.spec.autofire.is_some() {
+            // auto-fire pseudo-spec: nothing to latch — the method
+            // executes unconditionally at its Exec anchor
+            return Ok(());
+        }
         let r = self.rule().clone();
         // EFFECTFUL eager defs latch FIRST, in list order — the
         // interpreter evaluates REntry::eager into the latch before
@@ -4148,6 +4157,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         func: FunctionValue<'ctx>,
         stop_bb: inkwell::basic_block::BasicBlock<'ctx>,
     ) -> Result<(), Ineligible> {
+        if let Some(af) = self.spec.autofire.clone() {
+            return self.autofire_section(f, func, stop_bb, &af);
+        }
         let r = self.rule().clone();
         let body_bb = self.ctx.append_basic_block(func, "body");
         let cont_bb = self.ctx.append_basic_block(func, "cont");
@@ -4175,6 +4187,98 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         self.stmts(f, func, &r.body, stop_bb)?;
         self.builder.build_unconditional_branch(cont_bb).unwrap();
         self.builder.position_at_end(cont_bb);
+        Ok(())
+    }
+
+    /// Auto-fired always_enabled top method (pseudo-spec): the body
+    /// inlines at its Exec anchor with EN latched, constant argument
+    /// values (the baked bindings), and the sibling RDY_<m> wrap — the
+    /// compiled twin of the interpreter's call_action at the cut.
+    /// always_fire on the pseudo-spec skipped the WF gate; only RDY
+    /// gates the body (the C++ check_rdy wrapper), absent = ready.
+    fn autofire_section(
+        &mut self,
+        f: &mut Frame<'ctx>,
+        func: FunctionValue<'ctx>,
+        stop_bb: inkwell::basic_block::BasicBlock<'ctx>,
+        af: &crate::abi::AfSpec,
+    ) -> Result<(), Ineligible> {
+        let ie = self.ie(f.inst)?;
+        let mir = ie.mir;
+        let m = &self.env.d.modules[mir].methods[af.method_idx];
+        if !matches!(m.kind, trs_ir::MethodKind::Action) {
+            return nope("auto-fire on a non-Action method");
+        }
+        if !m.always_enabled || m.args.len() != af.argv.len() {
+            return nope("auto-fire spec out of step with the method");
+        }
+        let (margs, body, mname) = (m.args.clone(), m.body.clone(), m.name);
+        // sibling RDY_<m> lookup — same rule as the interp's
+        // always_en_rdy and the parent-call inline: no RDY method
+        // exported = constant ready
+        let rdy = {
+            let rdy_name =
+                format!("RDY_{}", self.env.d.strings[mname as usize]);
+            self.env
+                .d
+                .strings
+                .iter()
+                .position(|x| x == &rdy_name)
+                .and_then(|id| {
+                    self.env.d.modules[mir]
+                        .methods
+                        .iter()
+                        .enumerate()
+                        .find(|(_, mm)| mm.name == id as StrId)
+                        .map(|(mi, mm)| (mi, mm.result.clone()))
+                })
+        };
+        let en_slot = {
+            let en_name =
+                format!("EN_{}", self.env.d.strings[mname as usize]);
+            self.env
+                .d
+                .strings
+                .iter()
+                .position(|x| x == &en_name)
+                .and_then(|id| ie.en_slot.get(&(id as StrId)).copied())
+        };
+        // callee frame on the top itself, args bound to the baked
+        // constants (limbs pre-normalized to ceil(width/64) words)
+        let mut cf = self.child_frame(f, f.inst, Some(af.method_idx))?;
+        for (pa, (_, limbs)) in margs.iter().zip(&af.argv) {
+            let v = self
+                .ity(pa.width.max(1))
+                .const_int_arbitrary_precision(limbs);
+            cf.args.insert(pa.name, (v, pa.width));
+        }
+        if let Some(slot) = en_slot {
+            let one = self.ctx.i64_type().const_int(1, false);
+            self.store_word(&cf, slot, one);
+        }
+        let rec_argv: Vec<_> = margs
+            .iter()
+            .filter_map(|pa| cf.args.get(&pa.name).copied())
+            .collect();
+        self.rec_meth_call(&cf, f.inst, mname, &rec_argv)?;
+        let sk_bb = self.ctx.append_basic_block(func, "afsk");
+        match rdy {
+            Some((mi_r, Some(res))) => {
+                let mut rf = self.child_frame(f, f.inst, Some(mi_r))?;
+                let r = self.expr(&mut rf, &res)?;
+                let rz = self.nonzero(r, 1);
+                let bd_bb = self.ctx.append_basic_block(func, "afrdy");
+                self.builder
+                    .build_conditional_branch(rz, bd_bb, sk_bb)
+                    .unwrap();
+                self.builder.position_at_end(bd_bb);
+            }
+            Some((_, None)) => return nope("RDY method without result"),
+            None => {}
+        }
+        self.stmts(&mut cf, func, &body, stop_bb)?;
+        self.builder.build_unconditional_branch(sk_bb).unwrap();
+        self.builder.position_at_end(sk_bb);
         Ok(())
     }
 

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1950,6 +1950,13 @@ impl Interp {
         if rcomps.iter().any(|rc| !rc.alts.is_empty()) {
             ineligible(&mut r_reason, "dynamic scheduling (alts)");
         }
+        // auto-fire designs (compiled via pseudo-specs) stay RunCore-
+        // ineligible v1: the boot's baked plan replay knows nothing of
+        // the per-edge anchor invocations, and such designs usually
+        // carry bindings anyway (which the boot hook already refuses)
+        if !self.autofire.is_empty() {
+            ineligible(&mut r_reason, "top always_enabled autofire");
+        }
         // the boot parser caps LOADS rows (hostile-file bound): refuse
         // HERE, where a reason can be recorded, rather than bake a
         // sidecar every boot silently rejects (review finding)
@@ -3329,12 +3336,25 @@ impl Interp {
             write_memo: HashMap::new(),
         };
 
+        // one body resolver for rule specs AND auto-fire pseudo-specs
+        // (whose synthetic rule_idx must never index rules): the
+        // method body is the section body, so its cones and write
+        // sets analyze exactly like a rule's
+        let spec_body = |o: usize| -> Vec<Stmt> {
+            let sp = &specs[o];
+            let mir = inst_envs[&sp.inst].mir;
+            match &sp.autofire {
+                Some(af) => {
+                    self.d.modules[mir].methods[af.method_idx].body.clone()
+                }
+                None => self.d.modules[mir].rules[sp.rule_idx].body.to_vec(),
+            }
+        };
         // per-ordinal exec write sets (all rules, once)
         let mut exec_writes: Vec<Vec<usize>> = Vec::with_capacity(specs_lite.len());
         let mut write_sets: Vec<HashSet<usize>> = Vec::with_capacity(specs_lite.len());
-        for &(inst, ridx) in specs_lite {
-            let mir = inst_envs[&inst].mir;
-            let body = self.d.modules[mir].rules[ridx].body.clone();
+        for (o, &(inst, _ridx)) in specs_lite.iter().enumerate() {
+            let body = spec_body(o);
             let mut w = HashSet::new();
             stmt_writes(&mut cx, inst, &body, &mut w);
             let mut v: Vec<usize> = w.iter().copied().collect();
@@ -3379,9 +3399,8 @@ impl Interp {
                     if !is_exec {
                         return None;
                     }
-                    let (inst, ridx) = specs_lite[o];
-                    let mir = inst_envs[&inst].mir;
-                    let body = self.d.modules[mir].rules[ridx].body.clone();
+                    let (inst, _ridx) = specs_lite[o];
+                    let body = spec_body(o);
                     let mut c = Cone::default();
                     for st in body.iter() {
                         walk_stmt_defs(&mut cx, inst, st, &mut c);
@@ -3711,9 +3730,8 @@ impl Interp {
         }
         for &o in &outlined_execs {
             export_slots.insert(specs[o].wf_slot);
-            let (inst, ridx) = specs_lite[o];
-            let mir = inst_envs[&inst].mir;
-            let body = self.d.modules[mir].rules[ridx].body.clone();
+            let (inst, _ridx) = specs_lite[o];
+            let body = spec_body(o);
             let mut c = Cone::default();
             for st in body.iter() {
                 walk_stmt_defs(&mut cx, inst, st, &mut c);
@@ -3868,14 +3886,22 @@ impl Interp {
             }
             return None;
         }
-        // batch auto-fire of always_enabled top methods runs on the
-        // interpreted entries loop: compiled call sites exist only
-        // for parent-fused method calls, and the auto-fire positions
-        // (segment cuts) are not in the compiled node stream — the
-        // documented v1 engine contract for such designs is interp
-        // (the regress battery and the sweep's engine column assert
-        // this reason)
-        if !self.autofire.is_empty() {
+        // batch auto-fire of always_enabled top methods compiles ONLY
+        // as edge-SSA artifact emission — pseudo exec sections at the
+        // methods' cut anchors in the node stream — or a Load of such
+        // an artifact.  The in-process JIT tier, TRS_EDGE_SSA=0, and
+        // traced plans keep the documented interp fallback (their
+        // node streams carry no anchors), mirroring the
+        // dynamic-scheduling gate below.
+        let edge_ssa_on = std::env::var("TRS_EDGE_SSA").as_deref() != Ok("0");
+        let have_af = !self.autofire.is_empty();
+        let af_compiled = have_af
+            && match &request {
+                JitRequest::Emit { .. } => edge_ssa_on && !self.vcd_trace,
+                JitRequest::Load { .. } => true,
+                JitRequest::Run => false,
+            };
+        if have_af && !af_compiled {
             if trace {
                 eprintln!("trs jit: off (top always_enabled autofire)");
             }
@@ -3893,7 +3919,6 @@ impl Interp {
         // recording.  The alternative cap bounds edge-fn growth
         // (bodies multiply per alternative).
         let have_alts = rcomps.iter().any(|rc| !rc.alts.is_empty());
-        let edge_ssa_on = std::env::var("TRS_EDGE_SSA").as_deref() != Ok("0");
         let alts_capped = rcomps.iter().all(|rc| rc.alts.len() <= 16);
         let alts_compiled = have_alts
             && alts_capped
@@ -4833,7 +4858,69 @@ impl Interp {
                 shared: ri.shared.clone(),
                 label: format!("i{}_{}", ri.inst, ri.ordinal),
                 token_base: (ri.ordinal as u64) << 17,
+                autofire: None,
             });
+        }
+        // auto-fired always_enabled top methods: appended PSEUDO-SPECS,
+        // one per method in interface order — deterministic, so Emit
+        // and Load derive identical ordinals/tokens and PlanB never
+        // needs to carry them (its always_fire vec grows matching
+        // trailing `true`s, read back only for rule ordinals).
+        // always_fire skips the WF gate; the exec section inlines the
+        // method body at its anchor (lower.rs autofire_section); the
+        // synthetic rule_idx keys the dedup classes uniquely and must
+        // never index rules (every consumer branches on autofire).
+        let n_rule_specs = specs.len();
+        if af_compiled {
+            let top_inst = 0usize;
+            let tmir = self.mods[self.module_of(top_inst)].ir;
+            for (afi, (mname, argv)) in
+                self.autofire.clone().iter().enumerate()
+            {
+                let Some(mi) = self.d.modules[tmir]
+                    .methods
+                    .iter()
+                    .position(|m| m.name == *mname)
+                else {
+                    if trace {
+                        eprintln!("trs jit: off (autofire method missing)");
+                    }
+                    return None;
+                };
+                let m = &self.d.modules[tmir].methods[mi];
+                if m.args.len() != argv.len() {
+                    if trace {
+                        eprintln!("trs jit: off (autofire argv mismatch)");
+                    }
+                    return None;
+                }
+                let mut av: Vec<(u32, Vec<u64>)> = Vec::new();
+                for (pa, v) in m.args.iter().zip(argv) {
+                    let words = (pa.width.max(1) as usize).div_ceil(64);
+                    let mut limbs = v.limbs64().to_vec();
+                    limbs.resize(words, 0);
+                    av.push((pa.width, limbs));
+                }
+                let o = specs.len();
+                specs.push(RuleSpec {
+                    always_fire: true,
+                    inst: top_inst,
+                    rule_idx: usize::MAX - afi,
+                    inhibit_slots: Vec::new(),
+                    cf_slot: 0,
+                    wf_slot: 0,
+                    eager: Vec::new(),
+                    shared: Vec::new(),
+                    label: format!("af{afi}_{o}"),
+                    token_base: (o as u64) << 17,
+                    autofire: Some(trs_codegen::abi::AfSpec {
+                        method_idx: mi,
+                        method: *mname,
+                        argv: av,
+                    }),
+                });
+                sched_parts.push((0, vec![Vec::new(); rcomps.len()]));
+            }
         }
         // edge-SSA shareability analysis (task #24 M1,
         // TRS_EDGE_SSA_STATS=1): for every def consumed by 2+ exec
@@ -5056,9 +5143,20 @@ impl Interp {
 
         let comp_nodes: Vec<Option<Vec<JitNode>>> = rcomps
             .iter()
-            .map(|rc| {
+            .enumerate()
+            .map(|(rci, rc)| {
                 let mut nodes = Vec::new();
-                for en in &rc.entries {
+                // auto-fire anchors (interp parity): Exec cuts that
+                // precede every node-bearing top segment fire before
+                // the walk; the rest after their entry's nodes
+                let af_node =
+                    |mi: &usize| JitNode::Exec((n_rule_specs + *mi) as u32);
+                if af_compiled {
+                    if let Some(idxs) = self.autofire_pre.get(&rci) {
+                        nodes.extend(idxs.iter().map(af_node));
+                    }
+                }
+                for (ei, en) in rc.entries.iter().enumerate() {
                     for &node in &en.nodes {
                         let (r, is_sched) = match node {
                             SchedNode::Sched(r) => (r, true),
@@ -5083,6 +5181,11 @@ impl Interp {
                         } else {
                             JitNode::Exec(ord)
                         });
+                    }
+                    if af_compiled {
+                        if let Some(idxs) = self.autofire_at.get(&(rci, ei)) {
+                            nodes.extend(idxs.iter().map(af_node));
+                        }
                     }
                 }
                 Some(nodes)

--- a/src/trs/crates/trs-interp/src/topbind.rs
+++ b/src/trs/crates/trs-interp/src/topbind.rs
@@ -27,10 +27,14 @@
 //!   always_enabled implies RDY constant true: asserted at arm time
 //!   (a sibling RDY_<m> method must be absent or a non-zero
 //!   constant), and call_action's check_rdy still guards each fire.
-//! - Auto-fire designs run INTERPRETED: the jit plan declines with
-//!   "top always_enabled autofire" (the sweep's why= column).
-//!   Binding-only designs compile normally (params fold into
-//!   port_consts / wide_consts).
+//! - Auto-fire designs COMPILE as edge-SSA artifacts: the jit plan
+//!   appends one pseudo-spec per method (always_fire, method body
+//!   inlined at its anchor — see lower.rs autofire_section) and the
+//!   node stream carries the anchors.  The in-process JIT tier,
+//!   TRS_EDGE_SSA=0, and traced plans still decline with "top
+//!   always_enabled autofire" (the sweep's why= column for those
+//!   modes).  Binding-only designs compile normally (params fold
+//!   into port_consts / wide_consts).
 //! - Refused loudly: ActionValue or enabled_when_ready methods,
 //!   zero-width/non-Bit arguments (also refused by bsc), input clocks
 //!   or resets beyond the defaults on a top with bindable arguments,

--- a/src/trs/tests/regress/run.sh
+++ b/src/trs/tests/regress/run.sh
@@ -205,9 +205,9 @@ check_topparam
 # EBSimEnablePragma (G0062); trs batch mode auto-fires them per cycle
 # at their schedule position (tick's state mutation is read by the
 # rule BEFORE the methods' Exec cut, so position is observable in the
-# values), with setStep's argument constant-bound.  The documented v1
-# engine contract is INTERPRETED with the specific decline reason —
-# asserted here in both spellings (the link note and the traced why).
+# values), with setStep's argument constant-bound.  The engine
+# contract is COMPILED (pseudo exec sections at the cut anchors);
+# `trs run` on the .bir still exercises the interp path above.
 check_topae() {
     name=TopAlwaysEn; top=sysTopAlwaysEn
     cp "$SRC/$name.bsv" .
@@ -224,9 +224,10 @@ check_topae() {
     if [ "$gotrc" != 0 ] || ! cmp -s "$SRC/$name.expected" got.out; then
         echo "FAIL $name (run stdout, rc=$gotrc)"; diff "$SRC/$name.expected" got.out | head -3; fail=1; return
     fi
-    TRS_JIT_TRACE=1 "$TRS" link "$top.bir" +setStep.v=2 -o aeart >aelink.out 2>&1 || { echo "FAIL $name (trs link)"; fail=1; return; }
-    grep -q "run interpreted" aelink.out || { echo "FAIL $name (expected interpreted artifact)"; fail=1; return; }
-    grep -q "top always_enabled autofire" aelink.out || { echo "FAIL $name (expected the autofire decline reason)"; fail=1; return; }
+    # compiled auto-fire: the artifact's edge fns carry the method
+    # bodies at their cut anchors, so the link must COMPILE —
+    # TRS_REQUIRE_AOT trips (rc 86) if the engine silently falls back
+    TRS_REQUIRE_AOT=1 "$TRS" link "$top.bir" +setStep.v=2 -o aeart >aelink.out 2>&1 || { echo "FAIL $name (trs link, compiled)"; fail=1; return; }
     TRS="$TRS" ./aeart > gota.out 2>&1; gotrc=$?
     if [ "$gotrc" != 0 ] || ! cmp -s "$SRC/$name.expected" gota.out; then
         echo "FAIL $name (artifact stdout, rc=$gotrc)"; diff "$SRC/$name.expected" gota.out | head -3; fail=1; return

--- a/testsuite/bsc.trs/toplift/sysTopAlwaysEn.trsonly.expected
+++ b/testsuite/bsc.trs/toplift/sysTopAlwaysEn.trsonly.expected
@@ -1,5 +1,4 @@
 # trs-only golden-compared sweep design (see sysTopParam.trsonly.expected).
 refuse=G0062
 bind=setStep.v=2
-engine=interp
-why=top_always_enabled_autofire
+engine=aot


### PR DESCRIPTION
Closes the corpus's LAST interpreter exception: `sysTopAlwaysEn` (`why=top_always_enabled_autofire`) now compiles, and the engine census reads **1003 aot + 0 interp** — every design that runs, runs compiled.

## Mechanism

- **Pseudo-specs** (`jit_plan`): one appended spec per auto-fired method, in interface order — deterministic, so Emit and Load derive identical ordinals and tokens, and **PlanB never carries them** (its `always_fire` vec grows matching trailing `true`s, read back only for rule ordinals; wire layout untouched, no version bump). The synthetic `rule_idx` (`usize::MAX - i`) keys the dedup classes uniquely and must never index rules: every consumer branches on `spec.autofire` first — and bring-up caught the one miss (the def path's own-CF/WF check) as a loud panic at link, exactly the designed failure mode.
- **Anchors in the node stream** (interp parity): `autofire_pre` methods before the walk, `autofire_at` methods after their entry's nodes.
- **`autofire_section`** (lower.rs) — the compiled twin of the interpreter's `call_action` at the cut: EN latched first, argument values baked as constants (the bound `+NAME=value` identity is already in `bir_hash`'s salt), the sibling `RDY_<m>` result cone gates the body (no RDY method = constant ready), body statements inline with rule-body `$finish` semantics. `always_fire` on the pseudo-spec skips the WF gate; `sched_section` is a no-op.
- **Plan analysis**: `edge_ssa_plan` resolves pseudo sections by their METHOD body (one `spec_body` resolver for both kinds), so cones, write sets, sharing legality and hoists treat them exactly like rules.
- **Mode gate** mirrors compiled-alts (#151): edge-SSA Emit (untraced) and Loads compile; the in-process JIT tier, `TRS_EDGE_SSA=0`, and traced plans keep the documented interp fallback. RunCore sidecar eligibility refuses auto-fire designs (v1) — they boot classic.

## Gates flipped with the feature, same diff

- `sysTopAlwaysEn.trsonly.expected`: `engine=aot` — the sweep's engine tripwire now trips on a silent fallback.
- Battery `check_topae`: links under `TRS_REQUIRE_AOT=1` (rc 86 on fallback).

## Witnesses

- The compiled artifact byte-matches the hand-derived golden AND its interp run — and the golden's values (`count = 0,1,3,5,7,9` under tick-then-setStep cut order) encode the anchor POSITION, so correct placement is witnessed, not just execution.
- Battery 22/22 classic and 22/22 `TRS_RUNCORE=1`.
- Dual full-corpus seals at this head: **1003 PASS / 0 DIFF** twice (witnessed `TRS_RUNCORE_CHECK=1 TRS_SELFCHECK=1`, and driver-armed `TRS_RUNCORE=1`), engines **1003 aot + 0 interp**, zero mismatch, zero panics.

Stacked on #151 (`trs/32-alts`). Together they close Ravi's "close the interpreter exceptions" ask.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_