### PR TITLE
trs: activity gating (opt-in after a measured null) + the dispatcher structure — outlined sched sections, size dial, group guards, O1 tier (rung 35)

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -216,6 +216,12 @@ pub struct PlanEnv<'a> {
     pub now_slot: u32,
     pub d: &'a Design,
     pub insts: &'a HashMap<usize, InstEnv>,
+    /// activity gating: the shared did-a-watched-write-change scratch
+    /// slot.  Some = arena-inline prim WRITE sites emit accurate marks
+    /// (regs/ConfigRegs compare old vs new; wires/FIFOs mark on the
+    /// taken path), which each exec call site consumes into the dirty
+    /// bitmaps.  None = ungated emission, no marking code.
+    pub gate_scratch: Option<u32>,
 }
 /// One auto-fired always_enabled top method, compiled as an appended
 /// pseudo-spec.  NEVER serialized: Emit and Load both derive the same
@@ -637,10 +643,13 @@ pub struct GateLayout {
     pub lastwf_base: u32,
     /// dirty words per bitmap (state bits + rule bits)
     pub words: u32,
-    /// last-WF words (ceil(n_rules/64))
+    /// last-WF words (ceil(n_rules/64)); allocated but unused since
+    /// the v1.5 scratch scheme (kept for geometry stability)
     pub lastwf_words: u32,
     /// first rule bit index (= number of state bits)
     pub rule_bit_base: u32,
+    /// the shared write-mark scratch word (see PlanEnv::gate_scratch)
+    pub scratch: u32,
 }
 
 /// Pack one BRAM port tick into trs_bram_tick's (a0, a1, a2) args.

--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -572,6 +572,20 @@ pub struct EdgeSsaPlan {
     /// stability contract; defs ABSENT from this table must never be
     /// cached across sections (conservative)
     pub def_reads: HashMap<(usize, StrId), Vec<usize>>,
+    /// sched sections lower as OUTLINED per-section functions behind a
+    /// test-and-call dispatcher in the edge fn (the structure dial):
+    /// cross-section values travel through their CF/WF/eager slots
+    /// (export_slots is widened to all of them; hoists are empty —
+    /// spine SSA cannot dominate another function's body).  Engaged
+    /// when the measured edge fn exceeds TRS_JIT_SCHED_OUTLINE_BUDGET
+    /// with no exec victims left (the Toooba link shape: one
+    /// monolithic edge fn wedges LLVM's early-cse<memssa>, whose
+    /// dominated-use rewrites are superlinear in function size), or
+    /// via TRS_JIT_OUTLINE=1.  NOT implied by gating: outlining
+    /// measured 0.68x of the inline shape on Flute (lost cross-section
+    /// SSA sharing), so it stays a link-scaling dial.  Combined with
+    /// gating, a skipped section's call is never even fetched.
+    pub outline_sched: bool,
     /// per composition, per section index: shared PURE defs to hoist
     /// (computed unconditionally before the section — first-consumer
     /// position; pure = no warning-emitting or callback reads, so the

--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -515,7 +515,7 @@ pub const STRING_CONCAT_FUNC: StrId = u32::MAX - 1;
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 22;
+pub const AOT_LAYOUT_REV: u64 = 23; // 23: activity-gating dirty words
 /// How a caller reaches an outlined def-piece helper: a baked address
 /// (JIT: the helper engine compiled first) or a named symbol (AOT: ld
 /// resolves it inside the artifact .so).
@@ -600,6 +600,47 @@ pub struct EdgeSsaPlan {
     /// ungated BRAM port ticks — the edge fn calls the helper through
     /// the trs_bram_tick_cb pointer-global (filled at artifact load)
     pub bram_ticks: Vec<Vec<[u64; 3]>>,
+    /// activity gating (single-composition designs): dirty-bitmap
+    /// geometry in the arena, None = gating not armed for this
+    /// artifact.  Bits [0, n_state_bits) are written prim instances;
+    /// bits [n_state_bits, n_state_bits + n_rules) are RULE bits (a
+    /// recomputed sched section sets its own bit for same-edge
+    /// CF-chain propagation; rule bits never survive the edge roll —
+    /// the epilogue writes only state bits into `next`).
+    pub gate: Option<GateLayout>,
+    /// per spec ordinal: the sched section's sensitivity mask as
+    /// (dirty word index, bit mask) pairs over the CURRENT dirty
+    /// words; None = ungateable (effectful/ported/boxed cone, or the
+    /// cone analysis declined) — the section always runs
+    pub gate_masks: Vec<Option<Vec<(u32, u64)>>>,
+    /// per spec ordinal: state bits its body may write (transitive,
+    /// conservative) — ORed into the NEXT-edge dirty words by the
+    /// edge epilogue when WF or last-edge WF is set (covers value
+    /// changes AND wire/bypass revert-to-default on the fire edge)
+    pub dirty_sync: Vec<Vec<(u32, u64)>>,
+    /// per spec ordinal: the same-cycle-visible subset (wires, CReg,
+    /// loopy/bypass FIFOs) — ORed into the CURRENT dirty words right
+    /// after the exec section when WF is set, so later-in-edge
+    /// readers see the write
+    pub dirty_bypass: Vec<Vec<(u32, u64)>>,
+}
+
+/// Arena geometry of the activity-gating dirty bitmaps.  Three
+/// consecutive regions: CURRENT dirty words (what sched guards test),
+/// NEXT dirty words (accumulates this edge's writes; rolled into
+/// CURRENT at the next edge's start), and last-WF bit words (one bit
+/// per spec ordinal, maintained by the epilogue).
+#[derive(Clone, Copy, Debug)]
+pub struct GateLayout {
+    pub cur_base: u32,
+    pub next_base: u32,
+    pub lastwf_base: u32,
+    /// dirty words per bitmap (state bits + rule bits)
+    pub words: u32,
+    /// last-WF words (ceil(n_rules/64))
+    pub lastwf_words: u32,
+    /// first rule bit index (= number of state bits)
+    pub rule_bit_base: u32,
 }
 
 /// Pack one BRAM port tick into trs_bram_tick's (a0, a1, a2) args.

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -198,6 +198,26 @@ const IR_PASS_WIDTH_CAP: u32 = 4096;
 /// Max integer bit-width appearing as an instruction result type.
 /// Wide values only exist by being ASSEMBLED (zext/shl/or chains from
 /// arena slots), so result types are a complete witness.
+/// Largest single function in the module, in IR instructions — the
+/// O1 size tier's measurement (see run_ir_passes).
+fn module_max_fn_insns(module: &Module) -> u64 {
+    let mut max = 0u64;
+    let mut f = module.get_first_function();
+    while let Some(func) = f {
+        let mut insns = 0u64;
+        for bb in func.get_basic_blocks() {
+            let mut ins = bb.get_first_instruction();
+            while let Some(i) = ins {
+                insns += 1;
+                ins = i.get_next_instruction();
+            }
+        }
+        max = max.max(insns);
+        f = func.get_next_function();
+    }
+    max
+}
+
 fn module_max_int_width(module: &Module) -> u32 {
     let mut w = 0;
     let mut f = module.get_first_function();
@@ -301,9 +321,12 @@ impl IrTally {
 /// that retired the old O1 shape tier was FALSIFIED at Toooba scale:
 /// early-cse<memssa>'s dominated-use rewrites are superlinear in
 /// FUNCTION size (the monolithic edge fn wedged >39min, DNF).  The
-/// replacements are structural — the dispatcher outlines sched
-/// sections into bounded functions (EdgeSsaPlan::outline_sched), and
-/// the per-function insn backstop below optnones any straggler.
+/// replacements: the dispatcher outlines sched sections into bounded
+/// functions (EdgeSsaPlan::outline_sched), and the O1 size tier below
+/// is REINSTATED for stragglers — default<O1> runs EarlyCSE WITHOUT
+/// MemorySSA (no dominated-use rewriting) and measured 1.78s runtime
+/// vs O3's 1.83s / O0's 2.74s on the opt ladder, so the tier costs ~3%
+/// on the module it demotes instead of optnone's 1.5x.
 /// instcombine must be spelled no-verify-fixpoint: the textual pass
 /// defaults to max-iterations=1 and ABORTS on non-convergence.
 const AOT_PIPELINE: &str = "cgscc(inline),function(early-cse<memssa>,\
@@ -331,7 +354,38 @@ fn run_ir_passes(
             if width > IR_PASS_WIDTH_CAP {
                 return Ok(());
             }
-            AOT_PIPELINE.to_string()
+            // O1 size tier (the DEFAULT pipeline only — explicit
+            // TRS_JIT_OPT / TRS_JIT_PIPELINE still force): a function
+            // over the budget is pathological (one giant cone the
+            // dispatcher could not split), and feeding it to
+            // early-cse<memssa> risks the measured superlinear wedge.
+            // default<O1>'s EarlyCSE runs without MemorySSA and stays
+            // near-linear; the demoted module keeps ~O3-class runtime
+            // (opt-ladder: O1 1.78s vs O3 1.83s vs O0 2.74s).
+            // TRS_JIT_FN_INSN_BUDGET overrides the threshold; 0
+            // disables the tier.
+            let fn_budget: u64 =
+                std::env::var("TRS_JIT_FN_INSN_BUDGET")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(2_000_000);
+            let max_fn = if fn_budget > 0 {
+                module_max_fn_insns(module)
+            } else {
+                0
+            };
+            if fn_budget > 0 && max_fn > fn_budget {
+                if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                    eprintln!(
+                        "trs jit: a function measures {max_fn} insns \
+                         (budget {fn_budget}) — module drops to the \
+                         default<O1> size tier"
+                    );
+                }
+                "default<O1>".to_string()
+            } else {
+                AOT_PIPELINE.to_string()
+            }
         }
         Err(_) => return Ok(()),
     };
@@ -345,53 +399,6 @@ fn run_ir_passes(
     // (miscompile bisection — e.g. "default<O1>,gvn")
     let pipeline =
         std::env::var("TRS_JIT_PIPELINE").unwrap_or(pipeline);
-    // per-function insn backstop: a function over budget here is
-    // pathological (one giant cone the dispatcher could not split) —
-    // mark it optnone (+noinline, which optnone requires) so it
-    // codegens at O0 instead of feeding a superlinear function pass
-    // (early-cse<memssa> wedged >39min on a Toooba-scale monolith).
-    // TRS_JIT_FN_INSN_BUDGET overrides; 0 disables.
-    let fn_budget: u64 = std::env::var("TRS_JIT_FN_INSN_BUDGET")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(2_000_000);
-    if fn_budget > 0 {
-        let mctx = module.get_context();
-        let kind = |n: &str| {
-            inkwell::attributes::Attribute::get_named_enum_kind_id(n)
-        };
-        let mut fo = module.get_first_function();
-        while let Some(func) = fo {
-            if func.count_basic_blocks() > 0 {
-                let mut insns = 0u64;
-                for bb in func.get_basic_blocks() {
-                    let mut ins = bb.get_first_instruction();
-                    while let Some(i) = ins {
-                        insns += 1;
-                        ins = i.get_next_instruction();
-                    }
-                }
-                if insns > fn_budget {
-                    func.add_attribute(
-                        inkwell::attributes::AttributeLoc::Function,
-                        mctx.create_enum_attribute(kind("noinline"), 0),
-                    );
-                    func.add_attribute(
-                        inkwell::attributes::AttributeLoc::Function,
-                        mctx.create_enum_attribute(kind("optnone"), 0),
-                    );
-                    if std::env::var_os("TRS_JIT_TRACE").is_some() {
-                        eprintln!(
-                            "trs jit: {} over the fn insn budget \
-                             ({insns} > {fn_budget}) — optnone backstop",
-                            func.get_name().to_string_lossy()
-                        );
-                    }
-                }
-            }
-            fo = func.get_next_function();
-        }
-    }
     module.run_passes(&pipeline, &tm, opts).map_err(|e| {
         // LOUD on stderr, not just the Ineligible fallback chain: a
         // rejected pipeline string (an LLVM upgrade renaming a pass in

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -297,8 +297,13 @@ impl IrTally {
 /// Measured against default<O3> on the five witness shapes (all
 /// byte-exact): links 13.7->10.6s (FloatTest), 27.4->23.0
 /// (BRAM0Test), ties on the rest — and RUNTIME improves too
-/// (FloatTest 70.7->63.1ms); the giant-function O1 shape tier this
-/// replaces is obsolete (this list has no superlinear-in-size pass).
+/// (FloatTest 70.7->63.1ms).  The "no superlinear-in-size pass" claim
+/// that retired the old O1 shape tier was FALSIFIED at Toooba scale:
+/// early-cse<memssa>'s dominated-use rewrites are superlinear in
+/// FUNCTION size (the monolithic edge fn wedged >39min, DNF).  The
+/// replacements are structural — the dispatcher outlines sched
+/// sections into bounded functions (EdgeSsaPlan::outline_sched), and
+/// the per-function insn backstop below optnones any straggler.
 /// instcombine must be spelled no-verify-fixpoint: the textual pass
 /// defaults to max-iterations=1 and ABORTS on non-convergence.
 const AOT_PIPELINE: &str = "cgscc(inline),function(early-cse<memssa>,\
@@ -340,6 +345,53 @@ fn run_ir_passes(
     // (miscompile bisection — e.g. "default<O1>,gvn")
     let pipeline =
         std::env::var("TRS_JIT_PIPELINE").unwrap_or(pipeline);
+    // per-function insn backstop: a function over budget here is
+    // pathological (one giant cone the dispatcher could not split) —
+    // mark it optnone (+noinline, which optnone requires) so it
+    // codegens at O0 instead of feeding a superlinear function pass
+    // (early-cse<memssa> wedged >39min on a Toooba-scale monolith).
+    // TRS_JIT_FN_INSN_BUDGET overrides; 0 disables.
+    let fn_budget: u64 = std::env::var("TRS_JIT_FN_INSN_BUDGET")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000_000);
+    if fn_budget > 0 {
+        let mctx = module.get_context();
+        let kind = |n: &str| {
+            inkwell::attributes::Attribute::get_named_enum_kind_id(n)
+        };
+        let mut fo = module.get_first_function();
+        while let Some(func) = fo {
+            if func.count_basic_blocks() > 0 {
+                let mut insns = 0u64;
+                for bb in func.get_basic_blocks() {
+                    let mut ins = bb.get_first_instruction();
+                    while let Some(i) = ins {
+                        insns += 1;
+                        ins = i.get_next_instruction();
+                    }
+                }
+                if insns > fn_budget {
+                    func.add_attribute(
+                        inkwell::attributes::AttributeLoc::Function,
+                        mctx.create_enum_attribute(kind("noinline"), 0),
+                    );
+                    func.add_attribute(
+                        inkwell::attributes::AttributeLoc::Function,
+                        mctx.create_enum_attribute(kind("optnone"), 0),
+                    );
+                    if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                        eprintln!(
+                            "trs jit: {} over the fn insn budget \
+                             ({insns} > {fn_budget}) — optnone backstop",
+                            func.get_name().to_string_lossy()
+                        );
+                    }
+                }
+            }
+            fo = func.get_next_function();
+        }
+    }
     module.run_passes(&pipeline, &tm, opts).map_err(|e| {
         // LOUD on stderr, not just the Ineligible fallback chain: a
         // rejected pipeline string (an LLVM upgrade renaming a pass in
@@ -741,7 +793,11 @@ fn lower_helpers<'ctx>(
 /// on an over-budget module).
 pub enum DesignObject {
     Object(Vec<u8>),
-    EdgeOverBudget(Vec<Vec<(usize, u64)>>),
+    /// (per-comp inlined section sizes, largest measured edge-fn size
+    /// in IR instructions) — the caller replans on the sizes and uses
+    /// the edge measurement to decide between accepting the inline
+    /// monolith and outlining the sched sections (see outline_sched)
+    EdgeOverBudget(Vec<Vec<(usize, u64)>>, u64),
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -848,10 +904,13 @@ pub fn compile_design_object(
     // measured edge budget: hand the per-section sizes back for a
     // replan instead of feeding a giant function to the pass pipeline.
     // The judgement is the FULL edge-fn size (sched sections and call
-    // preludes included — only exec sections are outlining candidates,
-    // so the caller may find no victims and accept the remainder).
+    // preludes included); the max measurement rides along so the
+    // caller can decide between accepting the inline remainder (the
+    // common CPU-core shape — cross-section SSA sharing is worth 1.4x
+    // wall on Flute) and outlining the sched sections (the
+    // Toooba-scale link fix).
     if edge_insn_budget > 0 {
-        let mut over = false;
+        let mut max_insns = 0u64;
         for k in 0..fused.len() {
             if let Some(f) = module.get_function(&format!("edge_c{k}")) {
                 let mut insns = 0u64;
@@ -862,14 +921,17 @@ pub fn compile_design_object(
                         ins = i.get_next_instruction();
                     }
                 }
-                if insns > edge_insn_budget {
-                    over = true;
-                    break;
+                if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                    eprintln!("trs jit: edge_c{k} measured {insns} insns");
                 }
+                max_insns = max_insns.max(insns);
             }
         }
-        if over {
-            return Ok(DesignObject::EdgeOverBudget(section_sizes));
+        if max_insns > edge_insn_budget {
+            return Ok(DesignObject::EdgeOverBudget(
+                section_sizes,
+                max_insns,
+            ));
         }
     }
     // ordinal-indexed fn tables: without them the loader dlsyms ~one
@@ -1138,6 +1200,35 @@ fn lower_fused<'ctx>(
     syms
 }
 
+/// Activity-gating dirty test at the builder's position: OR of
+/// (CURRENT dirty word & mask word) over the mask pairs, compared
+/// against zero — i1 "some input moved since this cone last ran".
+fn gate_test<'ctx>(
+    b: &Builder<'ctx>,
+    i64t: inkwell::types::IntType<'ctx>,
+    arena: PointerValue<'ctx>,
+    g: &crate::abi::GateLayout,
+    mask: &[(u32, u64)],
+) -> IntValue<'ctx> {
+    let mut acc = i64t.const_zero();
+    for &(w, m) in mask {
+        let p = unsafe {
+            b.build_gep(
+                i64t,
+                arena,
+                &[i64t.const_int((g.cur_base + w) as u64, false)],
+                "gw",
+            )
+            .unwrap()
+        };
+        let v = b.build_load(i64t, p, "gv").unwrap().into_int_value();
+        let a = b.build_and(v, i64t.const_int(m, false), "ga").unwrap();
+        acc = b.build_or(acc, a, "go").unwrap();
+    }
+    b.build_int_compare(IntPredicate::NE, acc, i64t.const_zero(), "gd")
+        .unwrap()
+}
+
 /// Whole-edge SSA emission (task #24 M2): one edge_c<k> per
 /// composition with every sched/exec section lowered INLINE, sharing
 /// an EdgeCtx value cache across sections — latched CF/WF/eager values
@@ -1146,6 +1237,15 @@ fn lower_fused<'ctx>(
 /// and signature as lower_fused, so the loader and runtime are
 /// untouched.  Every existing slot STORE is preserved (interp/debug
 /// contract).
+///
+/// Under `plan.outline_sched` (the dispatcher structure) sched
+/// sections are NOT inlined: each lowers into its own bounded internal
+/// noinline function and the edge fn becomes a test-and-call
+/// dispatcher over them — the link-scaling shape (LLVM's function
+/// passes stay linear per function); combined with gating, a skipped
+/// section's code is never even fetched.  With gating armed (either
+/// structure), maximal runs of consecutive gated sections sit behind
+/// an outer union-mask group guard.
 #[allow(clippy::too_many_arguments)]
 fn lower_edge_ssa<'ctx>(
     env: &PlanEnv,
@@ -1202,6 +1302,7 @@ fn lower_edge_ssa<'ctx>(
         let gg = module.add_global(i64t.array_type(3), None, "trs_gate_geom");
         gg.set_initializer(&arr);
     }
+    let exports_rc = std::rc::Rc::new(plan.export_slots.clone());
     for (k, comp) in fused.iter().enumerate() {
         let sym = format!("edge_c{k}");
         let fnty = i32t.fn_type(&[ptrt.into(), ptrt.into(), i64t.into()], false);
@@ -1331,7 +1432,7 @@ fn lower_edge_ssa<'ctx>(
         }
         for (row, start) in bodies {
             let mut edge_ctx = EdgeCtx {
-                exports: plan.export_slots.clone(),
+                exports: exports_rc.clone(),
                 ..Default::default()
             };
             // checkpoint for exact per-section attribution: new blocks
@@ -1342,6 +1443,67 @@ fn lower_edge_ssa<'ctx>(
             let mut carry = start;
             let mut carry_insns = count_block(start);
             let mut cur = start;
+            // guard grouping (gating armed): a maximal run of
+            // consecutive gated sched sections gets ONE outer test on
+            // the union of its masks — union clean means every member
+            // is clean (members' inputs are all in the union, and CUR
+            // only changes at exec consume sites, which break runs), so
+            // the whole run of calls is skipped on one branch.  Inner
+            // per-section tests still discriminate when the union is
+            // dirty.  run_end: run head index -> last member index.
+            let mut run_end: HashMap<usize, usize> = HashMap::new();
+            if plan.gate.is_some() {
+                let ns = &plan.nodes[row];
+                let gated = |s: usize| {
+                    let (ie, oo) = ns[s];
+                    !ie && specs[oo].autofire.is_none()
+                        && plan
+                            .gate_masks
+                            .get(oo)
+                            .and_then(|m| m.as_ref())
+                            .is_some_and(|m| !m.is_empty())
+                };
+                let mut s = 0;
+                while s < ns.len() {
+                    if gated(s) {
+                        let mut e = s;
+                        while e + 1 < ns.len() && gated(e + 1) {
+                            e += 1;
+                        }
+                        if e > s {
+                            run_end.insert(s, e);
+                        }
+                        s = e + 1;
+                    } else {
+                        s += 1;
+                    }
+                }
+            }
+            if std::env::var_os("TRS_JIT_TRACE").is_some()
+                && !run_end.is_empty()
+            {
+                let members: usize =
+                    run_end.iter().map(|(&s0, &e)| e - s0 + 1).sum();
+                let gated_total = plan.nodes[row]
+                    .iter()
+                    .filter(|&&(ie, oo)| {
+                        !ie && plan
+                            .gate_masks
+                            .get(oo)
+                            .and_then(|m| m.as_ref())
+                            .is_some_and(|m| !m.is_empty())
+                    })
+                    .count();
+                eprintln!(
+                    "trs jit: edge_c{k} row {row}: {} group guards \
+                     cover {members} of {gated_total} gated sections",
+                    run_end.len()
+                );
+            }
+            let mut run_close: Option<(
+                usize,
+                inkwell::basic_block::BasicBlock<'ctx>,
+            )> = None;
             for (s, &(is_exec, o)) in plan.nodes[row].iter().enumerate() {
                 let base_spec = &specs[o];
                 // order-derived sched overrides (variant rows only):
@@ -1512,6 +1674,36 @@ fn lower_edge_ssa<'ctx>(
                             .is_some_and(|rs| rs.iter().all(|gi| !ws.contains(gi)))
                     });
                 } else {
+                    // outer group guard at a run head: one union test
+                    // covers every gated call in the run (see run_end)
+                    if let Some(&re) = run_end.get(&s) {
+                        let g = plan.gate.as_ref().unwrap();
+                        let mut union: Vec<(u32, u64)> = Vec::new();
+                        for si in s..=re {
+                            let (_, oo) = plan.nodes[row][si];
+                            for &(w, m) in
+                                plan.gate_masks[oo].as_ref().unwrap()
+                            {
+                                match union
+                                    .iter_mut()
+                                    .find(|(uw, _)| *uw == w)
+                                {
+                                    Some((_, um)) => *um |= m,
+                                    None => union.push((w, m)),
+                                }
+                            }
+                        }
+                        union.sort_unstable_by_key(|&(w, _)| w);
+                        let dirty =
+                            gate_test(&lc.builder, i64t, arena, g, &union);
+                        let orun = ctx.append_basic_block(func, "orun");
+                        let ocont = ctx.append_basic_block(func, "ocont");
+                        lc.builder
+                            .build_conditional_branch(dirty, orun, ocont)
+                            .unwrap();
+                        lc.builder.position_at_end(orun);
+                        run_close = Some((re, ocont));
+                    }
                     // activity gating: pure sched cones sit behind a
                     // dirty test — (mask AND current-dirty) == 0 means
                     // no input moved since this section last ran, so
@@ -1524,67 +1716,157 @@ fn lower_edge_ssa<'ctx>(
                         .and_then(|_| plan.gate_masks.get(o))
                         .and_then(|m| m.as_ref())
                         .filter(|m| !m.is_empty());
-                    match gm {
-                        Some(mask) => {
-                            let g = plan.gate.as_ref().unwrap();
-                            let mut acc = i64t.const_zero();
-                            for &(w, m) in mask {
-                                let p = unsafe {
-                                    lc.builder
-                                        .build_gep(
-                                            i64t,
-                                            arena,
-                                            &[i64t.const_int(
-                                                (g.cur_base + w) as u64,
-                                                false,
-                                            )],
-                                            "gw",
-                                        )
-                                        .unwrap()
-                                };
-                                let v = lc
-                                    .builder
-                                    .build_load(i64t, p, "gv")
+                    if plan.outline_sched && spec.autofire.is_none() {
+                        // dispatcher structure: the sched body lives in
+                        // its own bounded function (internal + noinline
+                        // — function passes stay linear per function,
+                        // and the inliner must not rebuild the
+                        // monolith); the edge fn tests and calls.
+                        // Cross-section values travel through their
+                        // CF/WF/eager slots: the plan widened the
+                        // export keep-set and emptied the hoist tables,
+                        // and gate_no_latch keeps this section's SSA
+                        // out of any cross-function cache — the same
+                        // slot fallbacks a skipped gated section
+                        // relies on (def()'s existing lattice, the one
+                        // standalone sched fns lower with).
+                        let gname = format!("gsec{k}_r{row}_s{s}");
+                        let gty = ctx
+                            .void_type()
+                            .fn_type(&[ptrt.into(), ptrt.into()], false);
+                        let gfunc = module.add_function(&gname, gty, None);
+                        gfunc.set_linkage(
+                            inkwell::module::Linkage::Internal,
+                        );
+                        gfunc.add_attribute(
+                            inkwell::attributes::AttributeLoc::Function,
+                            ctx.create_enum_attribute(
+                                inkwell::attributes::Attribute::get_named_enum_kind_id(
+                                    "noinline",
+                                ),
+                                0,
+                            ),
+                        );
+                        {
+                            let mut lo = Lower {
+                                env,
+                                ctx,
+                                module,
+                                builder: ctx.create_builder(),
+                                cbs,
+                                spec,
+                                token_kind: 0,
+                                outlined,
+                                helper_self: None,
+                                dedup: None,
+                                foreign_stmts: Vec::new(),
+                                prim_calls: Vec::new(),
+                                edge: Some(EdgeCtx {
+                                    exports: exports_rc.clone(),
+                                    gate_no_latch: true,
+                                    ..Default::default()
+                                }),
+                            };
+                            let gentry =
+                                ctx.append_basic_block(gfunc, "entry");
+                            lo.builder.position_at_end(gentry);
+                            let mut gf = Frame {
+                                arena: gfunc
+                                    .get_nth_param(0)
                                     .unwrap()
-                                    .into_int_value();
-                                let a = lc
-                                    .builder
-                                    .build_and(
-                                        v,
-                                        i64t.const_int(m, false),
-                                        "ga",
+                                    .into_pointer_value(),
+                                envp: Some(
+                                    gfunc
+                                        .get_nth_param(1)
+                                        .unwrap()
+                                        .into_pointer_value(),
+                                ),
+                                inst: spec.inst,
+                                method_idx: None,
+                                args: HashMap::new(),
+                                ssa: HashMap::new(),
+                                expanding: Vec::new(),
+                                thunks: HashMap::new(),
+                                av_widths: HashMap::new(),
+                                dead_defs: Default::default(),
+                                tasks: HashMap::new(),
+                                av_slots: HashMap::new(),
+                                av_args: HashMap::new(),
+                                is_exec: false,
+                                depth: 0,
+                            };
+                            lo.sched_section(&mut gf)?;
+                            lo.builder.build_return(None).unwrap();
+                        }
+                        let cargs: [inkwell::values::BasicMetadataValueEnum;
+                            2] = [arena.into(), envp.into()];
+                        match gm {
+                            Some(mask) => {
+                                let g = plan.gate.as_ref().unwrap();
+                                let dirty = gate_test(
+                                    &lc.builder,
+                                    i64t,
+                                    arena,
+                                    g,
+                                    mask,
+                                );
+                                let run_bb =
+                                    ctx.append_basic_block(func, "grun");
+                                let cont_bb =
+                                    ctx.append_basic_block(func, "gcont");
+                                lc.builder
+                                    .build_conditional_branch(
+                                        dirty, run_bb, cont_bb,
                                     )
                                     .unwrap();
-                                acc = lc.builder.build_or(acc, a, "go").unwrap();
+                                lc.builder.position_at_end(run_bb);
+                                lc.builder
+                                    .build_call(gfunc, &cargs, "")
+                                    .unwrap();
+                                lc.builder
+                                    .build_unconditional_branch(cont_bb)
+                                    .unwrap();
+                                lc.builder.position_at_end(cont_bb);
                             }
-                            let dirty = lc
-                                .builder
-                                .build_int_compare(
-                                    IntPredicate::NE,
-                                    acc,
-                                    i64t.const_zero(),
-                                    "gd",
-                                )
-                                .unwrap();
-                            let run_bb =
-                                ctx.append_basic_block(func, "grun");
-                            let cont_bb =
-                                ctx.append_basic_block(func, "gcont");
-                            lc.builder
-                                .build_conditional_branch(
-                                    dirty, run_bb, cont_bb,
-                                )
-                                .unwrap();
-                            lc.builder.position_at_end(run_bb);
-                            lc.edge.as_mut().unwrap().gate_no_latch = true;
-                            lc.sched_section(&mut f)?;
-                            lc.edge.as_mut().unwrap().gate_no_latch = false;
-                            lc.builder
-                                .build_unconditional_branch(cont_bb)
-                                .unwrap();
-                            lc.builder.position_at_end(cont_bb);
+                            None => {
+                                lc.builder
+                                    .build_call(gfunc, &cargs, "")
+                                    .unwrap();
+                            }
                         }
-                        None => lc.sched_section(&mut f)?,
+                    } else {
+                        match gm {
+                            Some(mask) => {
+                                let g = plan.gate.as_ref().unwrap();
+                                let dirty = gate_test(
+                                    &lc.builder,
+                                    i64t,
+                                    arena,
+                                    g,
+                                    mask,
+                                );
+                                let run_bb =
+                                    ctx.append_basic_block(func, "grun");
+                                let cont_bb =
+                                    ctx.append_basic_block(func, "gcont");
+                                lc.builder
+                                    .build_conditional_branch(
+                                        dirty, run_bb, cont_bb,
+                                    )
+                                    .unwrap();
+                                lc.builder.position_at_end(run_bb);
+                                lc.edge.as_mut().unwrap().gate_no_latch =
+                                    true;
+                                lc.sched_section(&mut f)?;
+                                lc.edge.as_mut().unwrap().gate_no_latch =
+                                    false;
+                                lc.builder
+                                    .build_unconditional_branch(cont_bb)
+                                    .unwrap();
+                                lc.builder.position_at_end(cont_bb);
+                            }
+                            None => lc.sched_section(&mut f)?,
+                        }
                     }
                 }
                 // activity gating, consume the write-mark scratch: a
@@ -1668,6 +1950,17 @@ fn lower_edge_ssa<'ctx>(
                         lc.builder
                             .build_store(gp(g.scratch), i64t.const_zero())
                             .unwrap();
+                    }
+                }
+                // close an outer group guard at its run's last member:
+                // the dirty path rejoins the skip path's continuation
+                if let Some((re, ocont)) = run_close {
+                    if re == s {
+                        lc.builder
+                            .build_unconditional_branch(ocont)
+                            .unwrap();
+                        lc.builder.position_at_end(ocont);
+                        run_close = None;
                     }
                 }
                 cur = lc.builder.get_insert_block().unwrap();
@@ -1833,7 +2126,9 @@ struct EdgeCtx<'ctx> {
     /// Everything else is dead weight in the specialized compile
     /// (Ravi: speed first — the slot-level debug contract is not part
     /// of the edge-SSA artifact surface).
-    exports: std::collections::HashSet<u32>,
+    /// (Rc: under sched outlining every section's fresh EdgeCtx shares
+    /// the one keep-set — the clone is a pointer bump, not a rebuild)
+    exports: std::rc::Rc<std::collections::HashSet<u32>>,
     /// position-latched values: CF/WF and eager defs at their compute
     /// position — what the arena slots hold.  NEVER evicted (eviction
     /// would change latched semantics, not just performance).

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -1234,6 +1234,9 @@ fn lower_edge_ssa<'ctx>(
                 b.build_store(gep(g.next_base + i), i64t.const_zero())
                     .unwrap();
             }
+            // defensive: the write-mark scratch is consumed-and-cleared
+            // at every exec call site; a clean edge start costs one store
+            b.build_store(gep(g.scratch), i64t.const_zero()).unwrap();
         }
 
         section_sizes.push(Vec::new());
@@ -1584,80 +1587,87 @@ fn lower_edge_ssa<'ctx>(
                         None => lc.sched_section(&mut f)?,
                     }
                 }
-                // activity gating, same-cycle dirty: wires and bypass
-                // prims this body may write become visible to LATER
-                // readers this edge — OR the bypass mask into CURRENT
-                // when the rule fired (branchless: sign-extended WF)
+                // activity gating, consume the write-mark scratch: a
+                // watched write actually happened in this body (regs:
+                // value moved; wires/fifos/cregs: action taken) — OR
+                // the rule's write mask into NEXT (next-edge readers)
+                // and its same-cycle-visible subset into CURRENT
+                // (later-in-edge readers), then clear the scratch so
+                // the next body starts clean.
                 if is_exec && plan.gate.is_some() {
-                    if let Some(byp) =
-                        plan.dirty_bypass.get(o).filter(|b| !b.is_empty())
-                    {
-                        let g = plan.gate.as_ref().unwrap();
-                        let sel = if spec.autofire.is_some() {
-                            i64t.const_all_ones()
-                        } else {
-                            let wp = unsafe {
-                                lc.builder
-                                    .build_gep(
-                                        i64t,
-                                        arena,
-                                        &[i64t.const_int(
-                                            spec.wf_slot as u64,
-                                            false,
-                                        )],
-                                        "bw",
-                                    )
-                                    .unwrap()
-                            };
-                            let wf = lc
-                                .builder
-                                .build_load(i64t, wp, "bwv")
-                                .unwrap()
-                                .into_int_value();
-                            let nz = lc
-                                .builder
-                                .build_int_compare(
-                                    IntPredicate::NE,
-                                    wf,
-                                    i64t.const_zero(),
-                                    "bnz",
-                                )
-                                .unwrap();
-                            lc.builder
-                                .build_int_s_extend(nz, i64t, "bsel")
-                                .unwrap()
-                        };
-                        for &(w, m) in byp {
-                            let p = unsafe {
-                                lc.builder
-                                    .build_gep(
-                                        i64t,
-                                        arena,
-                                        &[i64t.const_int(
-                                            (g.cur_base + w) as u64,
-                                            false,
-                                        )],
-                                        "bc",
-                                    )
-                                    .unwrap()
-                            };
+                    let g = plan.gate.as_ref().unwrap();
+                    let gp = |slot: u32| unsafe {
+                        lc.builder
+                            .build_gep(
+                                i64t,
+                                arena,
+                                &[i64t.const_int(slot as u64, false)],
+                                "gs",
+                            )
+                            .unwrap()
+                    };
+                    let sync =
+                        plan.dirty_sync.get(o).map(|v| &v[..]).unwrap_or(&[]);
+                    if !sync.is_empty() {
+                        let s = lc
+                            .builder
+                            .build_load(i64t, gp(g.scratch), "gsv")
+                            .unwrap()
+                            .into_int_value();
+                        let nz = lc
+                            .builder
+                            .build_int_compare(
+                                IntPredicate::NE,
+                                s,
+                                i64t.const_zero(),
+                                "gsn",
+                            )
+                            .unwrap();
+                        let do_bb = ctx.append_basic_block(func, "gdo");
+                        let done_bb = ctx.append_basic_block(func, "gdn");
+                        lc.builder
+                            .build_conditional_branch(nz, do_bb, done_bb)
+                            .unwrap();
+                        lc.builder.position_at_end(do_bb);
+                        for &(w, m) in sync {
+                            let p = gp(g.next_base + w);
                             let old = lc
                                 .builder
-                                .build_load(i64t, p, "bo")
+                                .build_load(i64t, p, "gno")
                                 .unwrap()
                                 .into_int_value();
-                            let add = lc
+                            let nv = lc
                                 .builder
-                                .build_and(
-                                    i64t.const_int(m, false),
-                                    sel,
-                                    "bm",
-                                )
+                                .build_or(old, i64t.const_int(m, false), "gnn")
                                 .unwrap();
-                            let nv =
-                                lc.builder.build_or(old, add, "bn").unwrap();
                             lc.builder.build_store(p, nv).unwrap();
                         }
+                        if let Some(byp) = plan.dirty_bypass.get(o) {
+                            for &(w, m) in byp {
+                                let p = gp(g.cur_base + w);
+                                let old = lc
+                                    .builder
+                                    .build_load(i64t, p, "gco")
+                                    .unwrap()
+                                    .into_int_value();
+                                let nv = lc
+                                    .builder
+                                    .build_or(
+                                        old,
+                                        i64t.const_int(m, false),
+                                        "gcn",
+                                    )
+                                    .unwrap();
+                                lc.builder.build_store(p, nv).unwrap();
+                            }
+                        }
+                        lc.builder
+                            .build_unconditional_branch(done_bb)
+                            .unwrap();
+                        lc.builder.position_at_end(done_bb);
+                        lc.builder
+                            .build_store(gp(g.scratch), i64t.const_zero())
+                            .unwrap();
                     }
                 }
                 cur = lc.builder.get_insert_block().unwrap();
@@ -1762,119 +1772,6 @@ fn lower_edge_ssa<'ctx>(
                         )
                         .unwrap();
                     }
-                }
-            }
-            // activity gating, edge epilogue: a rule dirties its write
-            // set for the NEXT edge when it fired (values may have
-            // moved) OR when it fired LAST edge but not this one (its
-            // wires revert to defaults at the clear above — that
-            // transition is a change too).  Branchless per rule; the
-            // fresh WF bits become the new last-WF words.
-            if let Some(g) = &plan.gate {
-                let gepe = |slot: u32| unsafe {
-                    bend.build_gep(
-                        i64t,
-                        arena,
-                        &[i64t.const_int(slot as u64, false)],
-                        "ge",
-                    )
-                    .unwrap()
-                };
-                let old_lw: Vec<inkwell::values::IntValue> = (0..g
-                    .lastwf_words)
-                    .map(|i| {
-                        bend.build_load(i64t, gepe(g.lastwf_base + i), "lw")
-                            .unwrap()
-                            .into_int_value()
-                    })
-                    .collect();
-                let mut new_lw: Vec<inkwell::values::IntValue> =
-                    (0..g.lastwf_words).map(|_| i64t.const_zero()).collect();
-                for (o, sp) in specs.iter().enumerate() {
-                    let wf_nz = if sp.autofire.is_some() {
-                        bend.build_int_compare(
-                            IntPredicate::NE,
-                            i64t.const_int(1, false),
-                            i64t.const_zero(),
-                            "af",
-                        )
-                        .unwrap()
-                    } else {
-                        let wf = bend
-                            .build_load(i64t, gepe(sp.wf_slot), "ew")
-                            .unwrap()
-                            .into_int_value();
-                        bend.build_int_compare(
-                            IntPredicate::NE,
-                            wf,
-                            i64t.const_zero(),
-                            "en",
-                        )
-                        .unwrap()
-                    };
-                    let wf64 = bend
-                        .build_int_z_extend(wf_nz, i64t, "ez")
-                        .unwrap();
-                    let (lwi, lbit) = ((o / 64) as u32, (o % 64) as u64);
-                    new_lw[lwi as usize] = bend
-                        .build_or(
-                            new_lw[lwi as usize],
-                            bend.build_left_shift(
-                                wf64,
-                                i64t.const_int(lbit, false),
-                                "es",
-                            )
-                            .unwrap(),
-                            "eo",
-                        )
-                        .unwrap();
-                    let sync = &plan.dirty_sync[o];
-                    if sync.is_empty() {
-                        continue;
-                    }
-                    let old_bit = bend
-                        .build_and(
-                            bend.build_right_shift(
-                                old_lw[lwi as usize],
-                                i64t.const_int(lbit, false),
-                                false,
-                                "or",
-                            )
-                            .unwrap(),
-                            i64t.const_int(1, false),
-                            "ob",
-                        )
-                        .unwrap();
-                    let cond = bend
-                        .build_or(wf64, old_bit, "ec")
-                        .unwrap();
-                    let sel = bend
-                        .build_int_sub(
-                            i64t.const_zero(),
-                            // cond is 0/1: 0 - cond = 0 or all-ones
-                            cond,
-                            "esl",
-                        )
-                        .unwrap();
-                    for &(w, m) in sync {
-                        let p = gepe(g.next_base + w);
-                        let old = bend
-                            .build_load(i64t, p, "eno")
-                            .unwrap()
-                            .into_int_value();
-                        let add = bend
-                            .build_and(i64t.const_int(m, false), sel, "ena")
-                            .unwrap();
-                        let nv = bend.build_or(old, add, "enn").unwrap();
-                        bend.build_store(p, nv).unwrap();
-                    }
-                }
-                for i in 0..g.lastwf_words {
-                    bend.build_store(
-                        gepe(g.lastwf_base + i),
-                        new_lw[i as usize],
-                    )
-                    .unwrap();
                 }
             }
             bend.build_return(Some(&i32t.const_int(0, false))).unwrap();
@@ -5630,6 +5527,25 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         r.map(|_| stable)
     }
 
+    /// Activity gating: OR an i1 into the shared write-mark scratch
+    /// word.  Emitted at arena-inline prim WRITE sites (the only prims
+    /// gated cones can watch), with per-site accuracy: regs and
+    /// ConfigRegs pass old!=new, wires/FIFOs pass the taken condition.
+    /// The exec call site consumes the word into the dirty bitmaps.
+    fn gate_mark(&mut self, f: &mut Frame<'ctx>, changed: IntValue<'ctx>) {
+        let Some(slot) = self.env.gate_scratch else {
+            return;
+        };
+        let i64t = self.ctx.i64_type();
+        let old = self.load_word(f, slot);
+        let z = self
+            .builder
+            .build_int_z_extend(changed, i64t, "gmz")
+            .unwrap();
+        let nv = self.builder.build_or(old, z, "gmo").unwrap();
+        self.store_word(f, slot, nv);
+    }
+
     fn action(
         &mut self,
         f: &mut Frame<'ctx>,
@@ -5665,6 +5581,16 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         .unwrap()
                         .into_int_value();
                     self.store_val(f, base, rw, sel);
+                    // gating: value-accurate mark (sel==old covers
+                    // both "not fired" and "rewrote the same value" —
+                    // the fires != dirty distinction the census proved)
+                    if self.env.gate_scratch.is_some() {
+                        let ne = self
+                            .builder
+                            .build_int_compare(IntPredicate::NE, sel, old, "gne")
+                            .unwrap();
+                        self.gate_mark(f, ne);
+                    }
                     return Ok(());
                 }
                 if let Some(&(base, rw)) = ie.creg_slot.get(instance) {
@@ -5704,6 +5630,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     self.store_val(f, base, rw, old2);
                     self.store_val(f, base + words, rw, v);
                     self.store_word(f, base + 2 * words, now);
+                    // gating: taken path, value-accurate vs the live value
+                    if self.env.gate_scratch.is_some() {
+                        let ne = self
+                            .builder
+                            .build_int_compare(IntPredicate::NE, v, cur, "gcne")
+                            .unwrap();
+                        self.gate_mark(f, ne);
+                    }
                     self.builder.build_unconditional_branch(sk_bb).unwrap();
                     self.builder.position_at_end(sk_bb);
                     return Ok(());
@@ -5908,6 +5842,12 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         let sk_bb = self.ctx.append_basic_block(func, "fsk");
                         self.builder.build_conditional_branch(cz, go_bb, sk_bb).unwrap();
                         self.builder.position_at_end(go_bb);
+                        // gating: an executed enq/deq moves fifo state
+                        // (level, elements, bypass headers) — mark taken
+                        if self.env.gate_scratch.is_some() {
+                            let t = self.ctx.bool_type().const_int(1, false);
+                            self.gate_mark(f, t);
+                        }
                         let elems = self.load_word(f, base);
                         let saved = self.load_word(f, base + 1);
                         let other_at =
@@ -6133,6 +6073,11 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     } else {
                         None
                     };
+                    // gating: wire writes are fire-edge dirtiness —
+                    // condition-accurate (a same-value rewrite still
+                    // marks; the wire's revert-to-default transition is
+                    // covered because the mark propagates to NEXT)
+                    self.gate_mark(f, cz);
                     // branchless wset: valid |= cond; value = select
                     let ov = self.load_word(f, base);
                     let cz64 = self
@@ -6162,6 +6107,19 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     let sk_bb = self.ctx.append_basic_block(func, "psk");
                     self.builder.build_conditional_branch(cz, go_bb, sk_bb).unwrap();
                     self.builder.position_at_end(go_bb);
+                    // gating: a trampolined action on a prim whose
+                    // VALUE reads are arena-inline (a watched class —
+                    // e.g. fifo clear, size-0 fifos) mutates watched
+                    // state outside the inline arms above: mark taken
+                    if self.env.gate_scratch.is_some()
+                        && (ie.reg_slot.contains_key(instance)
+                            || ie.creg_slot.contains_key(instance)
+                            || ie.wire_slot.contains_key(instance)
+                            || ie.fifo_slot.contains_key(instance))
+                    {
+                        let t = self.ctx.bool_type().const_int(1, false);
+                        self.gate_mark(f, t);
+                    }
                     self.emit_prim_call(f, child, *method, args, 0, true)?;
                     self.builder.build_unconditional_branch(sk_bb).unwrap();
                     self.builder.position_at_end(sk_bb);

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -1190,6 +1190,18 @@ fn lower_edge_ssa<'ctx>(
         .iter()
         .map(|v| v.iter().copied().collect())
         .collect();
+    // activity gating: export the bitmap geometry — the slim RunCore
+    // boot saturates the bitmaps after mem-file overlays, and the
+    // symbol's presence marks a gated artifact for A/B introspection
+    if let Some(g) = &plan.gate {
+        let arr = i64t.const_array(&[
+            i64t.const_int(g.cur_base as u64, false),
+            i64t.const_int(g.next_base as u64, false),
+            i64t.const_int(g.words as u64, false),
+        ]);
+        let gg = module.add_global(i64t.array_type(3), None, "trs_gate_geom");
+        gg.set_initializer(&arr);
+    }
     for (k, comp) in fused.iter().enumerate() {
         let sym = format!("edge_c{k}");
         let fnty = i32t.fn_type(&[ptrt.into(), ptrt.into(), i64t.into()], false);
@@ -1208,6 +1220,20 @@ fn lower_edge_ssa<'ctx>(
         b.build_store(gep(comp.now_slot), now).unwrap();
         for &en in &comp.en_slots {
             b.build_store(gep(en), i64t.const_zero()).unwrap();
+        }
+        // activity gating: roll the dirty bitmaps — CURRENT = NEXT
+        // (last edge's writes), NEXT = 0.  Same-cycle writers (wires,
+        // bypass prims) OR into CURRENT mid-edge; the epilogue refills
+        // NEXT from WF | last-WF per rule.
+        if let Some(g) = &plan.gate {
+            for i in 0..g.words {
+                let n = b
+                    .build_load(i64t, gep(g.next_base + i), "gn")
+                    .unwrap();
+                b.build_store(gep(g.cur_base + i), n).unwrap();
+                b.build_store(gep(g.next_base + i), i64t.const_zero())
+                    .unwrap();
+            }
         }
 
         section_sizes.push(Vec::new());
@@ -1483,7 +1509,156 @@ fn lower_edge_ssa<'ctx>(
                             .is_some_and(|rs| rs.iter().all(|gi| !ws.contains(gi)))
                     });
                 } else {
-                    lc.sched_section(&mut f)?;
+                    // activity gating: pure sched cones sit behind a
+                    // dirty test — (mask AND current-dirty) == 0 means
+                    // no input moved since this section last ran, so
+                    // its CF/WF/eager slots already hold the values a
+                    // recompute would produce (determinism), and the
+                    // whole section is jumped over
+                    let gm = plan
+                        .gate
+                        .as_ref()
+                        .and_then(|_| plan.gate_masks.get(o))
+                        .and_then(|m| m.as_ref())
+                        .filter(|m| !m.is_empty());
+                    match gm {
+                        Some(mask) => {
+                            let g = plan.gate.as_ref().unwrap();
+                            let mut acc = i64t.const_zero();
+                            for &(w, m) in mask {
+                                let p = unsafe {
+                                    lc.builder
+                                        .build_gep(
+                                            i64t,
+                                            arena,
+                                            &[i64t.const_int(
+                                                (g.cur_base + w) as u64,
+                                                false,
+                                            )],
+                                            "gw",
+                                        )
+                                        .unwrap()
+                                };
+                                let v = lc
+                                    .builder
+                                    .build_load(i64t, p, "gv")
+                                    .unwrap()
+                                    .into_int_value();
+                                let a = lc
+                                    .builder
+                                    .build_and(
+                                        v,
+                                        i64t.const_int(m, false),
+                                        "ga",
+                                    )
+                                    .unwrap();
+                                acc = lc.builder.build_or(acc, a, "go").unwrap();
+                            }
+                            let dirty = lc
+                                .builder
+                                .build_int_compare(
+                                    IntPredicate::NE,
+                                    acc,
+                                    i64t.const_zero(),
+                                    "gd",
+                                )
+                                .unwrap();
+                            let run_bb =
+                                ctx.append_basic_block(func, "grun");
+                            let cont_bb =
+                                ctx.append_basic_block(func, "gcont");
+                            lc.builder
+                                .build_conditional_branch(
+                                    dirty, run_bb, cont_bb,
+                                )
+                                .unwrap();
+                            lc.builder.position_at_end(run_bb);
+                            lc.edge.as_mut().unwrap().gate_no_latch = true;
+                            lc.sched_section(&mut f)?;
+                            lc.edge.as_mut().unwrap().gate_no_latch = false;
+                            lc.builder
+                                .build_unconditional_branch(cont_bb)
+                                .unwrap();
+                            lc.builder.position_at_end(cont_bb);
+                        }
+                        None => lc.sched_section(&mut f)?,
+                    }
+                }
+                // activity gating, same-cycle dirty: wires and bypass
+                // prims this body may write become visible to LATER
+                // readers this edge — OR the bypass mask into CURRENT
+                // when the rule fired (branchless: sign-extended WF)
+                if is_exec && plan.gate.is_some() {
+                    if let Some(byp) =
+                        plan.dirty_bypass.get(o).filter(|b| !b.is_empty())
+                    {
+                        let g = plan.gate.as_ref().unwrap();
+                        let sel = if spec.autofire.is_some() {
+                            i64t.const_all_ones()
+                        } else {
+                            let wp = unsafe {
+                                lc.builder
+                                    .build_gep(
+                                        i64t,
+                                        arena,
+                                        &[i64t.const_int(
+                                            spec.wf_slot as u64,
+                                            false,
+                                        )],
+                                        "bw",
+                                    )
+                                    .unwrap()
+                            };
+                            let wf = lc
+                                .builder
+                                .build_load(i64t, wp, "bwv")
+                                .unwrap()
+                                .into_int_value();
+                            let nz = lc
+                                .builder
+                                .build_int_compare(
+                                    IntPredicate::NE,
+                                    wf,
+                                    i64t.const_zero(),
+                                    "bnz",
+                                )
+                                .unwrap();
+                            lc.builder
+                                .build_int_s_extend(nz, i64t, "bsel")
+                                .unwrap()
+                        };
+                        for &(w, m) in byp {
+                            let p = unsafe {
+                                lc.builder
+                                    .build_gep(
+                                        i64t,
+                                        arena,
+                                        &[i64t.const_int(
+                                            (g.cur_base + w) as u64,
+                                            false,
+                                        )],
+                                        "bc",
+                                    )
+                                    .unwrap()
+                            };
+                            let old = lc
+                                .builder
+                                .build_load(i64t, p, "bo")
+                                .unwrap()
+                                .into_int_value();
+                            let add = lc
+                                .builder
+                                .build_and(
+                                    i64t.const_int(m, false),
+                                    sel,
+                                    "bm",
+                                )
+                                .unwrap();
+                            let nv =
+                                lc.builder.build_or(old, add, "bn").unwrap();
+                            lc.builder.build_store(p, nv).unwrap();
+                        }
+                    }
                 }
                 cur = lc.builder.get_insert_block().unwrap();
                 edge_ctx = lc.edge.take().unwrap();
@@ -1589,6 +1764,119 @@ fn lower_edge_ssa<'ctx>(
                     }
                 }
             }
+            // activity gating, edge epilogue: a rule dirties its write
+            // set for the NEXT edge when it fired (values may have
+            // moved) OR when it fired LAST edge but not this one (its
+            // wires revert to defaults at the clear above — that
+            // transition is a change too).  Branchless per rule; the
+            // fresh WF bits become the new last-WF words.
+            if let Some(g) = &plan.gate {
+                let gepe = |slot: u32| unsafe {
+                    bend.build_gep(
+                        i64t,
+                        arena,
+                        &[i64t.const_int(slot as u64, false)],
+                        "ge",
+                    )
+                    .unwrap()
+                };
+                let old_lw: Vec<inkwell::values::IntValue> = (0..g
+                    .lastwf_words)
+                    .map(|i| {
+                        bend.build_load(i64t, gepe(g.lastwf_base + i), "lw")
+                            .unwrap()
+                            .into_int_value()
+                    })
+                    .collect();
+                let mut new_lw: Vec<inkwell::values::IntValue> =
+                    (0..g.lastwf_words).map(|_| i64t.const_zero()).collect();
+                for (o, sp) in specs.iter().enumerate() {
+                    let wf_nz = if sp.autofire.is_some() {
+                        bend.build_int_compare(
+                            IntPredicate::NE,
+                            i64t.const_int(1, false),
+                            i64t.const_zero(),
+                            "af",
+                        )
+                        .unwrap()
+                    } else {
+                        let wf = bend
+                            .build_load(i64t, gepe(sp.wf_slot), "ew")
+                            .unwrap()
+                            .into_int_value();
+                        bend.build_int_compare(
+                            IntPredicate::NE,
+                            wf,
+                            i64t.const_zero(),
+                            "en",
+                        )
+                        .unwrap()
+                    };
+                    let wf64 = bend
+                        .build_int_z_extend(wf_nz, i64t, "ez")
+                        .unwrap();
+                    let (lwi, lbit) = ((o / 64) as u32, (o % 64) as u64);
+                    new_lw[lwi as usize] = bend
+                        .build_or(
+                            new_lw[lwi as usize],
+                            bend.build_left_shift(
+                                wf64,
+                                i64t.const_int(lbit, false),
+                                "es",
+                            )
+                            .unwrap(),
+                            "eo",
+                        )
+                        .unwrap();
+                    let sync = &plan.dirty_sync[o];
+                    if sync.is_empty() {
+                        continue;
+                    }
+                    let old_bit = bend
+                        .build_and(
+                            bend.build_right_shift(
+                                old_lw[lwi as usize],
+                                i64t.const_int(lbit, false),
+                                false,
+                                "or",
+                            )
+                            .unwrap(),
+                            i64t.const_int(1, false),
+                            "ob",
+                        )
+                        .unwrap();
+                    let cond = bend
+                        .build_or(wf64, old_bit, "ec")
+                        .unwrap();
+                    let sel = bend
+                        .build_int_sub(
+                            i64t.const_zero(),
+                            // cond is 0/1: 0 - cond = 0 or all-ones
+                            cond,
+                            "esl",
+                        )
+                        .unwrap();
+                    for &(w, m) in sync {
+                        let p = gepe(g.next_base + w);
+                        let old = bend
+                            .build_load(i64t, p, "eno")
+                            .unwrap()
+                            .into_int_value();
+                        let add = bend
+                            .build_and(i64t.const_int(m, false), sel, "ena")
+                            .unwrap();
+                        let nv = bend.build_or(old, add, "enn").unwrap();
+                        bend.build_store(p, nv).unwrap();
+                    }
+                }
+                for i in 0..g.lastwf_words {
+                    bend.build_store(
+                        gepe(g.lastwf_base + i),
+                        new_lw[i as usize],
+                    )
+                    .unwrap();
+                }
+            }
             bend.build_return(Some(&i32t.const_int(0, false))).unwrap();
         }
         let bstop = ctx.create_builder();
@@ -1657,6 +1945,12 @@ struct EdgeCtx<'ctx> {
     /// the driver); the driver evicts after any exec section whose
     /// write-set intersects the def's unstable-read set.
     shared: HashMap<(usize, StrId), IntValue<'ctx>>,
+    /// activity gating: the CURRENT section body sits behind a dirty
+    /// test and may be SKIPPED at runtime — its SSA values do not
+    /// dominate later sections, so it must not publish position-
+    /// latched values (readers fall back to slot loads, which a
+    /// skipped section leaves holding last edge's — correct — values)
+    gate_no_latch: bool,
 }
 
 struct Lower<'a, 'ctx> {
@@ -4087,7 +4381,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         // (what the slots hold); later sections read them in place of
         // slot loads.  Never evicted — eviction would change latched
         // semantics, not just performance.
-        if self.edge.is_some() {
+        if self.edge.is_some() && !self.edge.as_ref().unwrap().gate_no_latch {
             let inst = self.spec.inst;
             let e = self.edge.as_mut().unwrap();
             e.latched.insert((inst, r.can_fire), cf);

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -5972,8 +5972,8 @@ impl Interp {
                         // link outright (>39min DNF).  Already
                         // outlined and still over, or the round cap:
                         // accept — every remaining function is bounded
-                        // and the per-function insn backstop in
-                        // run_ir_passes covers stragglers.
+                        // and run_ir_passes's O1 size tier covers
+                        // stragglers.
                         if victims.is_empty() {
                             let sched_budget: u64 = std::env::var(
                                 "TRS_JIT_SCHED_OUTLINE_BUDGET",

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -3859,6 +3859,37 @@ impl Interp {
                     .collect();
                 gate_masks.push(Some(pairs(&bits)));
             }
+            // SABOTAGE WITNESS (validation hook, not a product knob):
+            // clear ONE dirty-sync bit that some gated cone actually
+            // watches — a deliberately incomplete dirty model.  The
+            // corpus/battery must classify the affected design DIFF;
+            // if it does not, the tripwire is not trustworthy.
+            if std::env::var_os("TRS_GATING_SABOTAGE").is_some() {
+                'sab: for o in 0..dirty_sync.len() {
+                    for pi in 0..dirty_sync[o].len() {
+                        let (w, m) = dirty_sync[o][pi];
+                        let watched: u64 = gate_masks
+                            .iter()
+                            .flatten()
+                            .flat_map(|gm| gm.iter())
+                            .filter(|&&(gw, _)| gw == w)
+                            .map(|&(_, gm)| gm)
+                            .fold(0, |a, b| a | b);
+                        let hit = m & watched;
+                        if hit != 0 {
+                            let bit = hit.trailing_zeros();
+                            dirty_sync[o][pi].1 &= !(1u64 << bit);
+                            eprintln!(
+                                "trs gating SABOTAGE: dropped dirty bit \
+                                 {} (word {w}) from ordinal {o}'s sync \
+                                 mask — expect byte DIFFs",
+                                w * 64 + bit
+                            );
+                            break 'sab;
+                        }
+                    }
+                }
+            }
         }
 
         // export keep-set (specialized compile: slot stores survive

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -977,9 +977,12 @@ enum EmitFail {
     Ineligible(String),
     Infra(String),
     /// an edge fn exceeded the instruction budget: the MEASURED
-    /// oversized inlined sections (ordinals) — the caller extends the
-    /// plan's outlined set and re-emits (see EDGE_INSN_BUDGET)
-    EdgeOverBudget(std::collections::HashSet<usize>),
+    /// oversized inlined sections (ordinals) plus the largest measured
+    /// edge-fn size — the caller extends the plan's outlined set and
+    /// re-emits (see EDGE_INSN_BUDGET), or, when no exec victims
+    /// remain, decides by size between the inline monolith and the
+    /// sched-outline dispatcher
+    EdgeOverBudget(std::collections::HashSet<usize>, u64),
 }
 
 #[cfg(feature = "jit")]
@@ -1109,7 +1112,10 @@ fn aot_emit(
         .map_err(|e| EmitFail::Ineligible(format!("design object: {e}")))?
         {
             trs_codegen::lower::DesignObject::Object(o) => o,
-            trs_codegen::lower::DesignObject::EdgeOverBudget(sizes) => {
+            trs_codegen::lower::DesignObject::EdgeOverBudget(
+                sizes,
+                edge_insns,
+            ) => {
                 // pick MEASURED victims: per over-budget comp, largest
                 // inlined sections first until the comp fits
                 let mut victims: std::collections::HashSet<usize> =
@@ -1130,7 +1136,7 @@ fn aot_emit(
                         total -= i;
                     }
                 }
-                return Err(EmitFail::EdgeOverBudget(victims));
+                return Err(EmitFail::EdgeOverBudget(victims, edge_insns));
             }
         };
         if std::env::var_os("TRS_JIT_TIME").is_some() {
@@ -2974,6 +2980,10 @@ impl Interp {
         // replan pass): joined into outlined_execs before any sharing/
         // hoist/elision table is computed, so the plan stays coherent
         forced_outline: &std::collections::HashSet<usize>,
+        // sched sections forced OUTLINED by the measured edge budget
+        // (the replan pass found the remaining mass is sched code, the
+        // shape with no exec victims left) — see EdgeSsaPlan::outline_sched
+        forced_outline_sched: bool,
         // activity-gating dirty-region geometry (allocated by
         // jit_plan for every request kind); None = the caller forbids
         // gating for this plan (stats runs, traced artifacts)
@@ -3761,6 +3771,29 @@ impl Interp {
             && nodes.len() == 1
             && !self.vcd_trace
             && std::env::var("TRS_GATING").as_deref() == Ok("1");
+        // dispatcher structure: outline sched sections when the budget
+        // replan demands it (sched mass over the SCHED_OUTLINE
+        // threshold with no exec victims left — the Toooba link
+        // shape), or forced for witnesses.  NOT tied to gating: the
+        // Flute A/B measured outlining at 0.68x of the inline shape
+        // (lost cross-section SSA sharing + 372 calls/edge), so gating
+        // keeps its measured inline form unless the size dial rules
+        // inline out.  Traced plans keep the inline shape too.
+        let outline_sched = !self.vcd_trace
+            && (forced_outline_sched
+                || std::env::var("TRS_JIT_OUTLINE").as_deref() == Ok("1"));
+        // outlined sections cannot consume spine SSA: a hoisted def
+        // computed in the dispatcher does not dominate (or even reach)
+        // another function's body — sections recompute pure shared
+        // cones locally and reload slot-carried defs (def()'s existing
+        // fallbacks, the same lattice standalone sched fns lower with)
+        if outline_sched {
+            for comp in hoists.iter_mut() {
+                for q in comp.iter_mut() {
+                    q.clear();
+                }
+            }
+        }
         let mut gate_masks: Vec<Option<Vec<(u32, u64)>>> = Vec::new();
         let mut dirty_sync: Vec<Vec<(u32, u64)>> = Vec::new();
         let mut dirty_bypass: Vec<Vec<(u32, u64)>> = Vec::new();
@@ -3972,7 +4005,7 @@ impl Interp {
         // edge-cache miss — the miss is NEW: ungated edges always
         // insert into the cache).  The epilogue and exec-site bypass
         // ORs also load every WF slot.  Same keep-set as has_early.
-        if gating_on {
+        if gating_on || outline_sched {
             for e in inst_envs.values() {
                 export_slots.extend(e.cfwf_slot.values().copied());
                 export_slots.extend(e.eager_slot.values().map(|&(b, _)| b));
@@ -4026,6 +4059,7 @@ impl Interp {
             sched_over: Vec::new(),
             ord_fnodes: HashMap::new(),
             export_slots,
+            outline_sched,
             gate: gating_on.then_some(gate).flatten(),
             gate_masks,
             dirty_sync,
@@ -5224,7 +5258,7 @@ impl Interp {
                 .collect();
             let _ = self.edge_ssa_plan(
                 &inst_envs, &nodes, &specs, has_early, true,
-                &Default::default(), None,
+                &Default::default(), false, None,
             );
         }
         // sharing census (TRS_JIT_SHARE_STATS=1): how many defs are
@@ -5790,7 +5824,8 @@ impl Interp {
                     rep_of[m] = *rep;
                 }
             }
-            let mk_edge_plan = |forced: &std::collections::HashSet<usize>| {
+            let mk_edge_plan = |forced: &std::collections::HashSet<usize>,
+                                outline_sched: bool| {
                 (std::env::var("TRS_EDGE_SSA").as_deref() != Ok("0")).then(|| {
                     let mut plan = self.edge_ssa_plan(
                         &inst_envs,
@@ -5799,6 +5834,7 @@ impl Interp {
                         has_early,
                         false,
                         forced,
+                        outline_sched,
                         Some(gate_layout),
                     );
                     // traced artifacts keep wire ticks boxed: the tick
@@ -5884,8 +5920,9 @@ impl Interp {
             // over budget: iterate (the forced set only grows, so this
             // terminates), with a round cap as the safety valve
             let mut rounds = 0u32;
+            let mut outline_sched = false;
             let result = loop {
-                let edge_plan = mk_edge_plan(&forced);
+                let edge_plan = mk_edge_plan(&forced, outline_sched);
                 match aot_emit(
                     &self.d,
                     &inst_envs,
@@ -5911,19 +5948,57 @@ impl Interp {
                     &bdpi_names,
                     budget_now,
                 ) {
-                    Err(EmitFail::EdgeOverBudget(victims)) => {
+                    Err(EmitFail::EdgeOverBudget(victims, edge_insns)) => {
                         if std::env::var_os("TRS_JIT_TRACE").is_some() {
                             eprintln!(
-                                "trs jit: edge over budget — replanning \
-                                 with {} measured sections outlined",
+                                "trs jit: edge over budget ({edge_insns} \
+                                 insns) — replanning with {} measured \
+                                 sections outlined",
                                 victims.len()
                             );
                         }
                         rounds += 1;
-                        // no exec sections left to outline (the
-                        // remainder is sched code) or the round cap:
-                        // accept — the O1 size tier is the backstop
-                        if victims.is_empty() || rounds >= 4 {
+                        // no exec sections left to outline: the
+                        // remainder is sched code.  Below the sched-
+                        // outline threshold, ACCEPT the inline
+                        // monolith — cross-section SSA sharing is
+                        // worth 1.4x wall on Flute (measured: outlined
+                        // 34.7s vs inline 23.7s busy), and the
+                        // pipeline handles Flute-scale functions
+                        // (~250k insns) fine.  Above it, outline the
+                        // sched sections (the dispatcher structure) —
+                        // the Toooba-scale shape where early-cse's
+                        // superlinear dominated-use rewrites wedge the
+                        // link outright (>39min DNF).  Already
+                        // outlined and still over, or the round cap:
+                        // accept — every remaining function is bounded
+                        // and the per-function insn backstop in
+                        // run_ir_passes covers stragglers.
+                        if victims.is_empty() {
+                            let sched_budget: u64 = std::env::var(
+                                "TRS_JIT_SCHED_OUTLINE_BUDGET",
+                            )
+                            .ok()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(1_000_000);
+                            if outline_sched
+                                || sched_budget == 0
+                                || edge_insns < sched_budget
+                            {
+                                budget_now = 0;
+                            } else {
+                                outline_sched = true;
+                                if std::env::var_os("TRS_JIT_TRACE")
+                                    .is_some()
+                                {
+                                    eprintln!(
+                                        "trs jit: sched mass over budget \
+                                         — outlining sched sections"
+                                    );
+                                }
+                            }
+                        }
+                        if rounds >= 5 {
                             budget_now = 0;
                         }
                         forced.extend(victims);
@@ -6074,7 +6149,7 @@ impl Interp {
                 Err(EmitFail::Ineligible(e)) => crate::AotEmit::Ineligible(e),
                 Err(EmitFail::Infra(e)) => crate::AotEmit::Failed(e),
                 // the unbounded second pass cannot report over-budget
-                Err(EmitFail::EdgeOverBudget(_)) => unreachable!(),
+                Err(EmitFail::EdgeOverBudget(..)) => unreachable!(),
             });
             return None;
         }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -3748,10 +3748,19 @@ impl Interp {
         // bitmaps on reset activity, clocks/params are domain-constant.
         // Masks use Cone.reads_all (a stability contract bounds INTRA-
         // edge movement; gating asks about CROSS-edge movement).
+        // OPT-IN (TRS_GATING=1): the Flute A/B measured the honest
+        // null — on an ACTIVE CPU core the Ir-dominant cones are the
+        // pipeline's own and they are genuinely dirty on busy AND on
+        // memory stalls (the fetch path keeps running), so the
+        // skippable mass is the small periphery cones (~2-4% of edge
+        // Ir) while guards+marks add ~38% more branches and an I1
+        // point.  Gating pays only for designs with LARGE idle
+        // subsystems; the dirty-model machinery (masks, marks,
+        // sabotage tripwire) stays sealed and available.
         let gating_on = gate.is_some()
             && nodes.len() == 1
             && !self.vcd_trace
-            && std::env::var("TRS_GATING").as_deref() != Ok("0");
+            && std::env::var("TRS_GATING").as_deref() == Ok("1");
         let mut gate_masks: Vec<Option<Vec<(u32, u64)>>> = Vec::new();
         let mut dirty_sync: Vec<Vec<(u32, u64)>> = Vec::new();
         let mut dirty_bypass: Vec<Vec<(u32, u64)>> = Vec::new();
@@ -3872,6 +3881,32 @@ impl Interp {
                     .filter_map(|gi| bit_of.get(gi).copied())
                     .collect();
                 gate_masks.push(Some(pairs(&bits)));
+            }
+            // TRS_GATE_MASK_CENSUS=1: per watched instance, how many
+            // gated masks contain its bit — the hot-bit poisoning
+            // census (a high-fanin instance that changes every cycle
+            // defeats every mask it appears in)
+            if std::env::var_os("TRS_GATE_MASK_CENSUS").is_some() {
+                let mut fanin: HashMap<u32, usize> = HashMap::new();
+                for gm in gate_masks.iter().flatten() {
+                    for &(w, m) in gm {
+                        for b in 0..64u32 {
+                            if m & (1 << b) != 0 {
+                                *fanin.entry(w * 64 + b).or_insert(0) += 1;
+                            }
+                        }
+                    }
+                }
+                let mut rows: Vec<(usize, u32)> =
+                    fanin.iter().map(|(&b, &c)| (c, b)).collect();
+                rows.sort_unstable_by(|a, b| b.cmp(a));
+                for (c, bit) in rows.iter().take(25) {
+                    let gi = written_all[*bit as usize];
+                    eprintln!(
+                        "trs gate census: bit {bit} in {c} masks — {}",
+                        self.insts[gi].path
+                    );
+                }
             }
             if std::env::var_os("TRS_JIT_TRACE").is_some() {
                 let gated = gate_masks.iter().filter(|m| m.is_some()).count();

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -2967,6 +2967,10 @@ impl Interp {
         // replan pass): joined into outlined_execs before any sharing/
         // hoist/elision table is computed, so the plan stays coherent
         forced_outline: &std::collections::HashSet<usize>,
+        // activity-gating dirty-region geometry (allocated by
+        // jit_plan for every request kind); None = the caller forbids
+        // gating for this plan (stats runs, traced artifacts)
+        gate: Option<trs_codegen::abi::GateLayout>,
     ) -> trs_codegen::abi::EdgeSsaPlan {
         let specs_lite: Vec<(usize, usize)> =
             specs.iter().map(|sp| (sp.inst, sp.rule_idx)).collect();
@@ -2978,6 +2982,13 @@ impl Interp {
         struct Cone {
             /// prim instances this cone reads with NO stability contract
             reads: HashSet<usize>,
+            /// EVERY prim instance this cone reads, stability contract
+            /// or not: the activity-gate sensitivity masks are built
+            /// from this set — a stability contract says a value
+            /// cannot move INTRA-edge, but gating asks whether it
+            /// moved ACROSS edges, where stable reads change like any
+            /// other (using `reads` here was the unsound shortcut)
+            reads_all: HashSet<usize>,
             /// transitive def closure (inst, def), incl. the root
             defs: HashSet<(usize, StrId)>,
             /// root def's own expr node count (share-census units)
@@ -2988,7 +2999,13 @@ impl Interp {
         }
         impl Default for Cone {
             fn default() -> Self {
-                Cone { reads: HashSet::new(), defs: HashSet::new(), mass: 0, poison: 0 }
+                Cone {
+                    reads: HashSet::new(),
+                    reads_all: HashSet::new(),
+                    defs: HashSet::new(),
+                    mass: 0,
+                    poison: 0,
+                }
             }
         }
         impl Cone {
@@ -2997,6 +3014,7 @@ impl Interp {
             }
             fn absorb(&mut self, o: &Cone) {
                 self.reads.extend(o.reads.iter().copied());
+                self.reads_all.extend(o.reads_all.iter().copied());
                 self.defs.extend(o.defs.iter().copied());
                 self.poison |= o.poison;
             }
@@ -3106,6 +3124,7 @@ impl Interp {
                             if !stable_read(pc, cx.itp.s(*method)) {
                                 out.reads.insert(gi);
                             }
+                            out.reads_all.insert(gi);
                             // hoist purity: the read must be an
                             // arena-inline load for THIS instance
                             let ie = &cx.inst_envs[&inst];
@@ -3709,6 +3728,139 @@ impl Interp {
                 .collect();
             eprintln!("trs edge-ssa: poisoned shared defs: {}", po.join(" "));
         }
+        // ---- activity gating: sensitivity masks + dirty write masks ----
+        // Armed only for single-row untraced plans (multi-comp designs
+        // would need a cross-comp roll point; alts append variant rows
+        // and fail the row check).  A section is gateable only when its
+        // whole read cone — CF, WF, eager defs, plus the CF cones of
+        // its transitive ME inhibitors (explicit slot loads outside the
+        // def closure) — is pure arena-inline prim reads: poison bits
+        // 1/2/4/8 (ports, foreign/task/trap, boxed prims, EN reads) all
+        // mark inputs the dirty bitmap cannot see.  Reset/clock/param
+        // port reads (bit 16) are admissible: the runtime saturates the
+        // bitmaps on reset activity, clocks/params are domain-constant.
+        // Masks use Cone.reads_all (a stability contract bounds INTRA-
+        // edge movement; gating asks about CROSS-edge movement).
+        let gating_on = gate.is_some()
+            && nodes.len() == 1
+            && !self.vcd_trace
+            && std::env::var("TRS_GATING").as_deref() != Ok("0");
+        let mut gate_masks: Vec<Option<Vec<(u32, u64)>>> = Vec::new();
+        let mut dirty_sync: Vec<Vec<(u32, u64)>> = Vec::new();
+        let mut dirty_bypass: Vec<Vec<(u32, u64)>> = Vec::new();
+        if gating_on {
+            const SAFE: [&str; 7] =
+                ["reg", "configreg", "creg", "wire", "fifo", "regfile", "bram"];
+            // same-cycle-visible classes: wires (readers see this
+            // edge's write), CReg later ports, FIFOs conservatively as
+            // a class (cat does not distinguish loopy/bypass variants)
+            const BYPASS: [&str; 3] = ["wire", "creg", "fifo"];
+            // bit per WRITTEN instance: an instance nothing writes
+            // cannot go dirty (autonomous-tick prims are excluded by
+            // the SAFE-cat check on the read side)
+            let mut written_all: Vec<usize> = write_sets
+                .iter()
+                .flat_map(|w| w.iter().copied())
+                .collect();
+            written_all.sort_unstable();
+            written_all.dedup();
+            let bit_of: HashMap<usize, u32> = written_all
+                .iter()
+                .enumerate()
+                .map(|(i, &gi)| (gi, i as u32))
+                .collect();
+            let pairs = |bits: &std::collections::BTreeSet<u32>| {
+                let mut out: Vec<(u32, u64)> = Vec::new();
+                for &b in bits {
+                    let (w, m) = (b / 64, 1u64 << (b % 64));
+                    match out.last_mut() {
+                        Some((lw, lm)) if *lw == w => *lm |= m,
+                        _ => out.push((w, m)),
+                    }
+                }
+                out
+            };
+            // cf-slot -> owner ordinal, for the inhibitor closure
+            let cf_owner: HashMap<u32, usize> = specs
+                .iter()
+                .enumerate()
+                .map(|(o, sp)| (sp.cf_slot, o))
+                .collect();
+            for (o, sp) in specs.iter().enumerate() {
+                // write masks (every ordinal, autofire included)
+                let mut sync = std::collections::BTreeSet::new();
+                let mut byp = std::collections::BTreeSet::new();
+                for &gi in &exec_writes[o] {
+                    let b = bit_of[&gi];
+                    sync.insert(b);
+                    if cx
+                        .prim_cat
+                        .get(&gi)
+                        .is_some_and(|c| BYPASS.contains(c))
+                    {
+                        byp.insert(b);
+                    }
+                }
+                dirty_sync.push(pairs(&sync));
+                dirty_bypass.push(pairs(&byp));
+                // read mask: autofire pseudo-specs have no sched
+                // section to gate
+                if sp.autofire.is_some() {
+                    gate_masks.push(None);
+                    continue;
+                }
+                // transitive inhibitor closure over ordinals (an
+                // inhibited CF reads the inhibitor's latched CF, which
+                // its own inhibitors shaped, and so on)
+                let mut need: Vec<usize> = vec![o];
+                let mut seen: HashSet<usize> = need.iter().copied().collect();
+                let mut qi = 0;
+                while qi < need.len() {
+                    let q = need[qi];
+                    qi += 1;
+                    for sl in &specs[q].inhibit_slots {
+                        if let Some(&oo) = cf_owner.get(sl) {
+                            if seen.insert(oo) {
+                                need.push(oo);
+                            }
+                        }
+                    }
+                }
+                let mut c = Cone::default();
+                for (qi2, &q) in need.iter().enumerate() {
+                    let qs = &specs[q];
+                    let mir = inst_envs[&qs.inst].mir;
+                    let r = &self.d.modules[mir].rules[qs.rule_idx];
+                    c.absorb(&cone(&mut cx, qs.inst, r.can_fire));
+                    if qi2 == 0 {
+                        // own rule only: WF + eager defs
+                        c.absorb(&cone(&mut cx, qs.inst, r.will_fire));
+                        for &e in &qs.eager {
+                            c.absorb(&cone(&mut cx, qs.inst, e));
+                        }
+                    }
+                }
+                let inhibitors_resolved = specs[o]
+                    .inhibit_slots
+                    .iter()
+                    .all(|sl| cf_owner.contains_key(sl));
+                let reads_safe = c.reads_all.iter().all(|gi| {
+                    cx.prim_cat.get(gi).is_some_and(|pc| SAFE.contains(pc))
+                });
+                if c.poison & 0b1111 != 0 || !reads_safe || !inhibitors_resolved
+                {
+                    gate_masks.push(None);
+                    continue;
+                }
+                let bits: std::collections::BTreeSet<u32> = c
+                    .reads_all
+                    .iter()
+                    .filter_map(|gi| bit_of.get(gi).copied())
+                    .collect();
+                gate_masks.push(Some(pairs(&bits)));
+            }
+        }
+
         // export keep-set (specialized compile: slot stores survive
         // only for COMPILED consumers — inhibitor loads and outlined
         // bodies; the slot-level debug contract is not part of the
@@ -3717,6 +3869,18 @@ impl Interp {
             .iter()
             .flat_map(|sp| sp.inhibit_slots.iter().copied())
             .collect();
+        // gating consumers: a SKIPPED section's slots are the only
+        // carrier of its values, so every CF/WF/eager store must
+        // survive elision (readers hit def()'s slot fallbacks on
+        // edge-cache miss — the miss is NEW: ungated edges always
+        // insert into the cache).  The epilogue and exec-site bypass
+        // ORs also load every WF slot.  Same keep-set as has_early.
+        if gating_on {
+            for e in inst_envs.values() {
+                export_slots.extend(e.cfwf_slot.values().copied());
+                export_slots.extend(e.eager_slot.values().map(|&(b, _)| b));
+            }
+        }
         // interp-side consumers: with any early (clock-crossing) rule,
         // the PG_FINAL pass reads compiled CF slots (inhibitors via
         // latched_or_arena) and eager/WF defs via eval's arena
@@ -3765,6 +3929,10 @@ impl Interp {
             sched_over: Vec::new(),
             ord_fnodes: HashMap::new(),
             export_slots,
+            gate: gating_on.then_some(gate).flatten(),
+            gate_masks,
+            dirty_sync,
+            dirty_bypass,
         }
     }
 
@@ -4959,7 +5127,7 @@ impl Interp {
                 .collect();
             let _ = self.edge_ssa_plan(
                 &inst_envs, &nodes, &specs, has_early, true,
-                &Default::default(),
+                &Default::default(), None,
             );
         }
         // sharing census (TRS_JIT_SHARE_STATS=1): how many defs are
@@ -5265,6 +5433,28 @@ impl Interp {
                 ((h.mir, h.def), (HelperRef::Sym(h.sym.clone()), h.width, h.ports.clone()))
             })
             .collect();
+        // ---- activity-gating dirty region (geometry only; ARMING is
+        // the edge plan's decision) ----
+        // Allocated for EVERY request kind so Emit and Load agree on
+        // the arena length (the artifact bakes nslots and refuses a
+        // mismatch): CURRENT dirty words, NEXT dirty words, last-WF
+        // bits.  Bits cover all instances (pessimistic — masks only
+        // ever use written ones); a few hundred bytes at CPU scale.
+        let gate_layout = {
+            let words = (self.insts.len() as u32).div_ceil(64).max(1);
+            let lastwf_words = (specs.len() as u32).div_ceil(64).max(1);
+            let cur_base = alloc(&mut nslots, words);
+            let next_base = alloc(&mut nslots, words);
+            let lastwf_base = alloc(&mut nslots, lastwf_words);
+            trs_codegen::abi::GateLayout {
+                cur_base,
+                next_base,
+                lastwf_base,
+                words,
+                lastwf_words,
+                rule_bit_base: self.insts.len() as u32,
+            }
+        };
         // Load attempt FIRST: an artifact carrying protos skips
         // trial_lower entirely (0.32s of sudoku startup); any failure
         // falls back to in-process compilation (which trials below)
@@ -5510,6 +5700,7 @@ impl Interp {
                         has_early,
                         false,
                         forced,
+                        Some(gate_layout),
                     );
                     // traced artifacts keep wire ticks boxed: the tick
                     // latches `written` for the VCD dump (and clears
@@ -5668,8 +5859,25 @@ impl Interp {
                 for &slot in &memo_stamp_slots {
                     unsafe { *arena_ptr.add(slot as usize) = u64::MAX };
                 }
+                // activity gating: dirty bitmaps start ALL-ONES so the
+                // first edges recompute every cone (slots hold no
+                // trustworthy values yet); harmless if the artifact
+                // was linked ungated (nothing reads the words)
+                for i in 0..gate_layout.words {
+                    unsafe {
+                        *arena_ptr.add((gate_layout.cur_base + i) as usize) =
+                            u64::MAX;
+                        *arena_ptr.add((gate_layout.next_base + i) as usize) =
+                            u64::MAX;
+                    }
+                }
                 self.jit_arena_ptr = arena_ptr;
                 self.jit_arena_len = nslots as usize;
+                self.jit_gate = Some((
+                    gate_layout.cur_base,
+                    gate_layout.next_base,
+                    gate_layout.words,
+                ));
                 self.runcore_pending = self.runcore_image_encode();
                 // Boot-descriptor stage A: capture what only the emit
                 // can see — per-comp tick coverage (needs inst_envs)
@@ -5925,9 +6133,22 @@ impl Interp {
         for &slot in &memo_stamp_slots {
             unsafe { *arena_ptr.add(slot as usize) = u64::MAX };
         }
+        // activity gating: bitmaps start ALL-ONES (see the Emit-path
+        // twin); the runtime saturates them again on reset activity
+        for i in 0..gate_layout.words {
+            unsafe {
+                *arena_ptr.add((gate_layout.cur_base + i) as usize) = u64::MAX;
+                *arena_ptr.add((gate_layout.next_base + i) as usize) = u64::MAX;
+            }
+        }
         self.jit_arena_ptr = arena_ptr;
         self.jit_arena_len = nslots as usize;
         self.jit_reset_slots = reset_node_slot;
+        self.jit_gate = Some((
+            gate_layout.cur_base,
+            gate_layout.next_base,
+            gate_layout.words,
+        ));
         // two-fill bake gate: perturb every mem-file data region
         // (post-attach, pre-advance) so the window capture can prove
         // the rest of the state independent of file content

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -303,6 +303,7 @@ impl LazyJit {
                     .expect("cold compile cell without a stashed design"),
                 insts: &self.insts,
                 now_slot: self.now_slot,
+                gate_scratch: None,
             };
             let reps: Vec<RuleSpec> =
                 (lo..hi).map(|c| self.specs[self.classes[c].0].clone()).collect();
@@ -923,7 +924,7 @@ fn aot_or_jit_scheds(
             .chunks(chunk)
             .map(|c| {
                 sc.spawn(move || {
-                    let env = PlanEnv { d, insts: inst_envs, now_slot };
+                    let env = PlanEnv { d, insts: inst_envs, now_slot, gate_scratch: None };
                     compile_scheds(&env, c, helpers, jit_foreign_cb, jit_sigfpe_cb, jit_prim_cb)
                 })
             })
@@ -1086,7 +1087,13 @@ fn aot_emit(
                     .unwrap_or_default(),
             })
             .collect();
-        let env = PlanEnv { d, insts: inst_envs, now_slot };
+        let env = PlanEnv {
+            d,
+            insts: inst_envs,
+            now_slot,
+            gate_scratch: edge_plan
+                .and_then(|p| p.gate.as_ref().map(|g| g.scratch)),
+        };
         let _g = trs_codegen::abi::AotModeGuard::set();
         let t1 = std::time::Instant::now();
         let obj = match compile_design_object(
@@ -1250,7 +1257,7 @@ fn aot_emit(
     let mut helper_obj: Option<Vec<u8>> = None;
     if helpers_on {
         let _g = trs_codegen::abi::AotModeGuard::set();
-        let env = PlanEnv { d, insts: inst_envs, now_slot };
+        let env = PlanEnv { d, insts: inst_envs, now_slot, gate_scratch: None };
         let pseudo = specs[0].clone();
         match compile_helpers_object(&env, helper_specs, refs_sym, &pseudo) {
             Ok(o) => helper_obj = Some(o),
@@ -1267,14 +1274,14 @@ fn aot_emit(
         for c in specs.chunks(chunk) {
             handles.push(sc.spawn(move || {
                 let _g = trs_codegen::abi::AotModeGuard::set();
-                let env = PlanEnv { d, insts: inst_envs, now_slot };
+                let env = PlanEnv { d, insts: inst_envs, now_slot, gate_scratch: None };
                 compile_object_chunk(&env, c, helpers_on.then_some(refs_sym), true, false)
             }));
         }
         for c in reps.chunks(rchunk) {
             handles.push(sc.spawn(move || {
                 let _g = trs_codegen::abi::AotModeGuard::set();
-                let env = PlanEnv { d, insts: inst_envs, now_slot };
+                let env = PlanEnv { d, insts: inst_envs, now_slot, gate_scratch: None };
                 compile_object_chunk(&env, c, helpers_on.then_some(refs_sym), false, true)
             }));
         }
@@ -3849,6 +3856,13 @@ impl Interp {
                 });
                 if c.poison & 0b1111 != 0 || !reads_safe || !inhibitors_resolved
                 {
+                    if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                        eprintln!(
+                            "trs gate: ordinal {o} UNGATED poison={:#b} \
+                             safe={reads_safe} inh={inhibitors_resolved}",
+                            c.poison
+                        );
+                    }
                     gate_masks.push(None);
                     continue;
                 }
@@ -3858,6 +3872,23 @@ impl Interp {
                     .filter_map(|gi| bit_of.get(gi).copied())
                     .collect();
                 gate_masks.push(Some(pairs(&bits)));
+            }
+            if std::env::var_os("TRS_JIT_TRACE").is_some() {
+                let gated = gate_masks.iter().filter(|m| m.is_some()).count();
+                let bits: usize = gate_masks
+                    .iter()
+                    .flatten()
+                    .map(|m| {
+                        m.iter().map(|&(_, b)| b.count_ones() as usize).sum::<usize>()
+                    })
+                    .sum();
+                eprintln!(
+                    "trs gate: {gated}/{} sections gated, {} state bits, \
+                     {} mask bits total",
+                    gate_masks.len(),
+                    written_all.len(),
+                    bits
+                );
             }
             // SABOTAGE WITNESS (validation hook, not a product knob):
             // clear ONE dirty-sync bit that some gated cone actually
@@ -3979,7 +4010,7 @@ impl Interp {
         request: &JitRequest,
         trace: bool,
     ) -> Option<Vec<FnProtos>> {
-        let env = PlanEnv { d: &self.d, insts: inst_envs, now_slot };
+        let env = PlanEnv { d: &self.d, insts: inst_envs, now_slot, gate_scratch: None };
         let t0 = std::time::Instant::now();
         match trial_lower(&env, specs) {
             Ok(p) => {
@@ -5477,6 +5508,7 @@ impl Interp {
             let cur_base = alloc(&mut nslots, words);
             let next_base = alloc(&mut nslots, words);
             let lastwf_base = alloc(&mut nslots, lastwf_words);
+            let scratch = alloc(&mut nslots, 1);
             trs_codegen::abi::GateLayout {
                 cur_base,
                 next_base,
@@ -5484,6 +5516,7 @@ impl Interp {
                 words,
                 lastwf_words,
                 rule_bit_base: self.insts.len() as u32,
+                scratch,
             }
         };
         // Load attempt FIRST: an artifact carrying protos skips
@@ -6028,7 +6061,7 @@ impl Interp {
                 return HelperMap::new();
             }
             trs_codegen::lower::llvm_init_once();
-            let env = PlanEnv { d: &self.d, insts: inst_envs, now_slot };
+            let env = PlanEnv { d: &self.d, insts: inst_envs, now_slot, gate_scratch: None };
             let pseudo = specs[0].clone();
             let t0 = std::time::Instant::now();
             match compile_helpers(&env, &helper_specs, &refs_sym, &pseudo) {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -300,6 +300,11 @@ pub struct Interp {
     central_engaged: bool,
     /// reset node -> arena slot holding the port level (1 = deasserted)
     jit_reset_slots: Vec<u32>,
+    /// activity-gating bitmap geometry (cur base, next base, words)
+    /// when a jit arena is attached: reset activity saturates the
+    /// bitmaps (reset ticks change state without any rule firing —
+    /// invisible to the compiled dirty maintenance)
+    jit_gate: Option<(u32, u32, u32)>,
     /// TRACED artifact only: (instance, VCD-declared def) -> recording
     /// slot (base, width).  When a key has a slot, the slot is the
     /// single authority — interp-side recording writes it (not the
@@ -845,6 +850,7 @@ impl Interp {
             runcore_window: None,
             central_engaged: false,
             jit_reset_slots: Vec::new(),
+            jit_gate: None,
             jit_rec_defs: HashMap::new(),
             jit_rec_meths: HashMap::new(),
             rng: GlibcRandom::new(),
@@ -3197,6 +3203,20 @@ impl Interp {
                 unsafe {
                     *self.jit_arena_ptr.add(self.jit_reset_slots[n] as usize) = (!v) as u64;
                 }
+                // activity gating: reset transitions (and the rst_tick
+                // activity they start) change prim state without any
+                // rule firing — saturate the dirty bitmaps so every
+                // cone recomputes until real dirtiness re-establishes
+                if let Some((cur, next, words)) = self.jit_gate {
+                    unsafe {
+                        for i in 0..words {
+                            *self.jit_arena_ptr.add((cur + i) as usize) =
+                                u64::MAX;
+                            *self.jit_arena_ptr.add((next + i) as usize) =
+                                u64::MAX;
+                        }
+                    }
+                }
             }
             if self.trace_clk {
                 eprintln!("[t={}] reset node {n} -> asserted={v}", self.now);
@@ -4746,6 +4766,27 @@ impl Interp {
                             }
                         } else {
                             p.tick(pname, t, pos, gate);
+                        }
+                    }
+                    // activity gating: a reset tick that RAN may have
+                    // moved prim state with no rule firing — saturate
+                    // the dirty bitmaps (cheap; only reset-active
+                    // edges reach here, see the rst_active skip above)
+                    if *is_rst && gate {
+                        if let Some((cur, next, words)) = self.jit_gate {
+                            if !self.jit_arena_ptr.is_null() {
+                                unsafe {
+                                    for i in 0..words {
+                                        *self
+                                            .jit_arena_ptr
+                                            .add((cur + i) as usize) = u64::MAX;
+                                        *self
+                                            .jit_arena_ptr
+                                            .add((next + i) as usize) =
+                                            u64::MAX;
+                                    }
+                                }
+                            }
                         }
                     }
                     if self.rstgen_out.contains_key(&inst) {

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -689,6 +689,17 @@ pub fn try_boot(so: &str, max_cycles: u64, plusargs: &[String]) -> Option<i32> {
         // arena code in trs_codegen — the same target the classic
         // loader wires (a BRAM design calls through it every edge;
         // leaving it NULL was the first driver segfault)
+        // activity gating: a gated artifact exports its dirty-bitmap
+        // geometry (absent = ungated); the mem-file overlays below
+        // change state the BAKED bitmaps never witnessed, so they
+        // saturate the bitmaps before the first steady edge
+        let gate_geom: Option<(u64, u64, u64)> = lib
+            .get::<*const u64>(b"trs_gate_geom")
+            .ok()
+            .map(|g| {
+                let p: *const u64 = *g;
+                (*p, *p.add(1), *p.add(2))
+            });
         if let Ok(g) = lib.get::<*mut usize>(b"trs_bram_tick_cb") {
             **g = trs_codegen::abi::trs_bram_tick as usize;
         }
@@ -776,6 +787,21 @@ pub fn try_boot(so: &str, max_cycles: u64, plusargs: &[String]) -> Option<i32> {
                 .get_mut(inst)
                 .expect("load row without a restored prim (parse gate)")
                 .runcore_overlay(file, *bin);
+        }
+        // overlays changed state the baked dirty bitmaps did not
+        // witness: saturate so every cone recomputes until real
+        // dirtiness re-establishes (bounds-guarded against skew)
+        if !boot.loads.is_empty() {
+            if let Some((cur, next, words)) = gate_geom {
+                if cur + words <= boot.nslots as u64
+                    && next + words <= boot.nslots as u64
+                {
+                    for i in 0..words {
+                        *ap.add((cur + i) as usize) = u64::MAX;
+                        *ap.add((next + i) as usize) = u64::MAX;
+                    }
+                }
+            }
         }
         let envp = &mut rc as *mut RunCore as *mut core::ffi::c_void;
         let pos_fns: Vec<


### PR DESCRIPTION
Rung 35 of the trs stack (base: #153). Two arcs in one rung: the activity-gating machinery the census (#153) gated GO — which measured out as an honest **null on active CPU cores** and lands **opt-in** — and the **dispatcher structure** (outlined sched sections behind a test-and-call edge fn), which is the link-scaling fix for the Toooba monolith pathology and proceeds regardless of the null.

## Arc 1 — activity gating: built, sealed, measured null, opt-in

Mechanism (commits 1–4): per-instance dirty bitmaps (CUR/NEXT words + a shared scratch word) in the arena for every request kind (Emit/Load geometry agreement; `AOT_LAYOUT_REV` 23); gateable pure sched sections sit behind `(mask & CUR) == 0` skips; **accurate write-site marks** (regs compare stored≠old, ConfigRegs new≠live, wires mark the taken condition — fire-edge semantics with revert-to-default falling out, fifos mark taken enq/deq) consumed at each exec call site into NEXT + same-cycle CUR; masks from `Cone.reads_all` over cf/wf/eager cones + transitive ME-inhibitor closure; skipped sections don't publish latched SSA (`gate_no_latch`) so readers take `def()`'s existing slot fallbacks; bitmaps saturate on reset transitions, and RunCore boots saturate via the exported `trs_gate_geom` global.

The measured null (Flute RV64GC, same-boot interleaved min-of-3, byte parity verified): v1 (fired-rule dirtiness) lost 17% — fires ≠ dirty, housekeeping rules rewrite unchanged values. v1.5 (accurate marks) is **Ir-NEUTRAL** (total +0.7%, edge_c0 −1.4% — the skips engage and pay their own cost) but **0.88x wall on busy AND chase** from +38% conditional branches and an I1 point. Root cause: per-rule interp read mass does not proxy compiled Ir mass — the deep pipeline muxes read few prims but carry most of edge_c0 and are dirty whenever the core does anything; a stalled core still fetches. The ~88% skippable latch events are the SoC periphery, ~2–4% of edge Ir. **`TRS_GATING` is opt-in**; the machinery (masks, marks, mask-fanin census, sabotage tripwire) lands sealed for designs with large idle subsystems.

## Arc 2 — the dispatcher structure (commits 5–6)

- **`EdgeSsaPlan::outline_sched`**: every sched section lowers into its own bounded internal `noinline` function (`void(arena, env)`, the same `sched_section` emitter); `edge_c0` becomes a dispatcher of calls. Cross-section values travel through CF/WF/eager slots — exports widen to all of them, hoists empty (spine SSA cannot dominate another function), no-latch inside the outlined body: exactly the slot-fallback lattice the gating seals proved, and the lattice standalone sched fns have always lowered with.
- **Size dial, measured on both sides**: engages only when the budget replan runs out of exec victims AND the edge fn exceeds `TRS_JIT_SCHED_OUTLINE_BUDGET` (default 1M IR insns). Flute's edge fn measures **271,143 insns and stays inline**: forcing the outline shape costs **0.68x wall** (34.7s vs 23.7s busy — lost cross-section SSA sharing + 372 calls/edge), while the outlined shape **links faster** (33s vs 39s). The first implementation outlined at the old 16k give-up point — a silent 1.4x default regression the A/B caught before it landed; recorded as a scored prediction miss.
- **Group guards** (gating armed, either structure): maximal runs of consecutive gated sections sit behind one outer union-mask test. Flute: **18 outer guards cover 238 of 258** gated stream sections; the gated chase leg improves 21.3s → 19.9s (0.88x → 0.92x of ungated). The busy branch delta only shrank ~7% — outer tests pay only when unions skip — recorded as a miss against the registered ≥25%.
- **O1 size tier** (reinstated; the deleted backstop's "no superlinear-in-size pass" claim is falsified in the `AOT_PIPELINE` doc): when the module's largest function exceeds `TRS_JIT_FN_INSN_BUDGET` (2M insns), the default pipeline demotes to `default<O1>` — its EarlyCSE runs without MemorySSA, dodging the convicted superlinear dominated-use rewrite. Witnessed at a forced-low budget: loud tier trace, byte parity, and the demoted module at **0.96x of the bespoke pipeline** min-of-3 (the opt ladder's O1≈O3 reproduced; optnone's O0 would have cost 1.5x).

## Witnesses

- Batteries **22/22 × 9 legs** (default / `TRS_JIT_OUTLINE=1` / `TRS_GATING=1` × classic / `TRS_RUNCORE=1`, plus all three re-run on the final binary), zero bring-up iterations.
- Corpus seals at this head: **1003 PASS / 0 DIFF six times** — gated ×2 + default during the null arc, then default / outline-forced / gated after the dispatcher — engines **1003 aot + 0 interp** every time, zero mismatch, zero panics (PERF_REGRESS 24/30/31, within band).
- Sabotage tripwire: dropping ONE watched dirty-sync bit is announced at link and produces 9.2GB of wrong bytes vs a 125-byte clean run.
- Flute byte parity on every leg, including the budget-dial trip and the tier trip; disassembly shows `gsec*` as local-only symbols (no dynsym rows) with calls surviving the pipeline.
- Predictions registered before measurement and scored: **6 HIT / 2 MISS / 1 pending** (the pending one is Toooba).

## Follow-ups

- **Toooba un-park** is the structure's real witness (its trs link OOM'd then wedged >39min single-threaded in early-cse on the monolithic edge fn; the Bluesim leg's bounded per-module objects linked fine — that contrast is the diagnosis). Full rebuild queued.
- Sharding the outlined section functions across `--jit-split`/`--jit-threads` modules for parallel codegen: not in this diff (bounded functions fix the diagnosed per-function superlinearity; the section fns live in the edge module). Toooba's measured link decides whether it's needed.
- The 1M/2M thresholds are first calibrations (Flute at 271k with 3.7x margin); Toooba's measurement refines them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_