### PR TITLE
trs/36: wire performance — BypassWire tick no-op + arena attachment (Toooba 3.44x behind Bluesim → 2.48x ahead)

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -111,6 +111,9 @@ pub struct InstEnv {
     /// local RWire/PulseWire instance name -> (base slot, width): valid
     /// word at base, value words after it
     pub wire_slot: HashMap<StrId, (u32, u32)>,
+    /// local BypassWire instance name -> (base slot, width): value
+    /// words only — no valid word (whas is const-true) and no tick
+    pub bypass_slot: HashMap<StrId, (u32, u32)>,
     /// local ConfigReg instance name -> (base slot, width): old value,
     /// current value, written_at instant (see ArenaKind::CReg)
     pub creg_slot: HashMap<StrId, (u32, u32)>,
@@ -521,7 +524,7 @@ pub const STRING_CONCAT_FUNC: StrId = u32::MAX - 1;
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is
 /// refused at load instead of silently misreading the arena.
-pub const AOT_LAYOUT_REV: u64 = 23; // 23: activity-gating dirty words
+pub const AOT_LAYOUT_REV: u64 = 24; // 24: BypassWire arena slots (rung 36)
 /// How a caller reaches an outlined def-piece helper: a baked address
 /// (JIT: the helper engine compiled first) or a named symbol (AOT: ld
 /// resolves it inside the artifact .so).

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -3080,6 +3080,19 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 _ => nope("wire read mismatch"),
             };
         }
+        if let Some(&(base, ww)) = ie.bypass_slot.get(&instance) {
+            return match mname.as_str() {
+                // always-written by contract: whas is constant true
+                "whas" => {
+                    let one = self.ctx.i64_type().const_int(1, false);
+                    Ok(self.to_w(one, 64, 1, false))
+                }
+                "wget" | "read" if ww >= 1 && ww == width => {
+                    Ok(self.load_val(f, base, ww))
+                }
+                _ => nope("bypass wire read mismatch"),
+            };
+        }
         if let Some(&(base, rw)) = ie.creg_slot.get(&instance) {
             if !matches!(mname.as_str(), "read" | "get" | "_read") || !args.is_empty() {
                 return nope("non-read ConfigReg method in expression");
@@ -3427,6 +3440,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     && matches!(mname.as_str(), "read" | "get" | "_read")
                     || ie.wire_slot.contains_key(instance)
                         && matches!(mname.as_str(), "whas" | "wget")
+                    || ie.bypass_slot.contains_key(instance)
+                        && matches!(mname.as_str(), "whas" | "wget" | "read")
                     || ie.fifo_slot.contains_key(instance)
                         && matches!(
                             mname.as_str(),
@@ -6399,6 +6414,30 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     }
                     return Ok(());
                 }
+                if let Some(&(base, ww)) = ie.bypass_slot.get(instance) {
+                    if !matches!(mname.as_str(), "wset" | "write") {
+                        return nope("non-wset bypass wire action");
+                    }
+                    // gating: same fire-edge dirtiness contract as
+                    // RWire wset (mark the taken condition)
+                    self.gate_mark(f, cz);
+                    // branchless conditional store; no valid word to
+                    // maintain (whas is const-true by contract) and a
+                    // zero-width wset (no argument) moves no state
+                    if ww >= 1 && !args.is_empty() {
+                        let wv = self.expr_width(f, &args[0])?;
+                        let v0 = self.expr(f, &args[0])?;
+                        let v = self.to_w(v0, wv, ww, false);
+                        let oldv = self.load_val(f, base, ww);
+                        let selv = self
+                            .builder
+                            .build_select(cz, v, oldv, "bwv")
+                            .unwrap()
+                            .into_int_value();
+                        self.store_val(f, base, ww, selv);
+                    }
+                    return Ok(());
+                }
 
                 let Some(&child) = ie.children.get(instance) else {
                     return nope("action on unknown child");
@@ -6417,6 +6456,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         && (ie.reg_slot.contains_key(instance)
                             || ie.creg_slot.contains_key(instance)
                             || ie.wire_slot.contains_key(instance)
+                            || ie.bypass_slot.contains_key(instance)
                             || ie.fifo_slot.contains_key(instance))
                     {
                         let t = self.ctx.bool_type().const_int(1, false);

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -4418,6 +4418,10 @@ impl Interp {
                         Some(ArenaKind::Reg { .. }) => ChildClass::Reg,
                         Some(ArenaKind::ConfigReg { .. }) => ChildClass::CfgReg,
                         Some(ArenaKind::Wire { .. }) => ChildClass::Wire,
+                        // attachment is not a stability reclassification:
+                        // BypassWire keeps the opaque class it had when
+                        // unattached (any upgrade is its own rung)
+                        Some(ArenaKind::BypassWire { .. }) => ChildClass::Other,
                         Some(ArenaKind::Fifo { loopy, .. }) => ChildClass::Fifo { loopy },
                         // arena-backed but NO stability contract and
                         // reads can WARN (bounds): the split analyzer
@@ -4533,6 +4537,7 @@ impl Interp {
                 children.iter().map(|(k, v)| (*k, *v)).collect();
             let mut reg_slot = HashMap::new();
             let mut wire_slot = HashMap::new();
+            let mut bypass_slot = HashMap::new();
             let mut creg_slot = HashMap::new();
             let mut fifo_slot = HashMap::new();
             let mut regfile_slot = HashMap::new();
@@ -4556,6 +4561,11 @@ impl Interp {
                     Some(ArenaKind::Wire { width }) => {
                         let base = alloc(&mut nslots, 1 + width.max(1).div_ceil(64));
                         wire_slot.insert(name, (base, width));
+                        attach.push((ci, base));
+                    }
+                    Some(ArenaKind::BypassWire { width }) => {
+                        let base = alloc(&mut nslots, width.max(1).div_ceil(64));
+                        bypass_slot.insert(name, (base, width));
                         attach.push((ci, base));
                     }
                     Some(ArenaKind::ConfigReg { width }) => {
@@ -4852,6 +4862,7 @@ impl Interp {
                     children,
                     reg_slot,
                     wire_slot,
+                    bypass_slot,
                     creg_slot,
                     fifo_slot,
                     regfile_slot,

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -41,10 +41,28 @@ pub(crate) mod prof {
     pub static FOREIGN_CALLS: AtomicU64 = AtomicU64::new(0);
     pub static DISPATCH_NS: AtomicU64 = AtomicU64::new(0);
     pub static TICK_NS: AtomicU64 = AtomicU64::new(0);
-    /// per prim-method call counts (TRS_PROF=1)
+    /// per prim-method call counts (TRS_PROF=1), keyed Class.method
     pub static PRIM_HIST: std::sync::Mutex<
         Option<std::collections::HashMap<String, u64>>,
     > = std::sync::Mutex::new(None);
+    /// per prim-class end-of-edge tick counts (TRS_PROF=1): the tick
+    /// loop walks every residual (not-compiled-into-the-edge) ticked
+    /// prim each cycle — attribution for that mass lives here
+    pub static TICK_HIST: std::sync::Mutex<
+        Option<std::collections::HashMap<String, u64>>,
+    > = std::sync::Mutex::new(None);
+    pub fn hist_bump(
+        h: &std::sync::Mutex<Option<std::collections::HashMap<String, u64>>>,
+        key: &str,
+    ) {
+        let mut g = h.lock().unwrap();
+        let m = g.get_or_insert_with(Default::default);
+        if let Some(n) = m.get_mut(key) {
+            *n += 1;
+        } else {
+            m.insert(key.to_string(), 1);
+        }
+    }
     pub fn on() -> bool {
         static P: OnceLock<bool> = OnceLock::new();
         *P.get_or_init(|| std::env::var_os("TRS_PROF").is_some())
@@ -58,6 +76,13 @@ pub(crate) mod prof {
             v.sort_by_key(|(_, &n)| std::cmp::Reverse(n));
             for (meth, n) in v.into_iter().take(12) {
                 eprintln!("trs prof:   {n:>9}  .{meth}");
+            }
+        }
+        if let Some(h) = TICK_HIST.lock().unwrap().as_ref() {
+            let mut v: Vec<_> = h.iter().collect();
+            v.sort_by_key(|(_, &n)| std::cmp::Reverse(n));
+            for (class, n) in v.into_iter().take(12) {
+                eprintln!("trs prof:   {n:>9}  tick {class}");
             }
         }
         let g = |c: &AtomicU64| c.load(Ordering::Relaxed);
@@ -152,13 +177,14 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         } else {
             interp.s(method).to_string()
         };
-        prof::PRIM_HIST
-            .lock()
-            .unwrap()
-            .get_or_insert_with(Default::default)
-            .entry(meth)
-            .and_modify(|n| *n += 1)
-            .or_insert(1);
+        // keyed Class.method: the class decides the fix shape (e.g.
+        // BypassWire has no arena kind — every access bounces by
+        // construction — where an RWire bounce means a declined site)
+        let class = match &interp.insts[inst].kind {
+            InstKind::Prim(p) => p.class_name(),
+            _ => "user",
+        };
+        prof::hist_bump(&prof::PRIM_HIST, &format!("{class}.{meth}"));
     }
 }
 
@@ -6131,6 +6157,13 @@ impl Interp {
                             }
                         })
                         .collect::<Result<Vec<_>, String>>();
+                    if prof::on() {
+                        eprintln!(
+                            "trs prof: prims {nprims} attached {} (boxed {})",
+                            attach.len(),
+                            nprims - attach.len(),
+                        );
+                    }
                     self.runcore_stage_a = Some(RunCoreStageA {
                         covered,
                         edge_ssa: std::env::var("TRS_EDGE_SSA").as_deref()

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -4760,6 +4760,17 @@ impl Interp {
                         }
                     };
                     if let InstKind::Prim(p) = &mut self.insts[inst].kind {
+                        #[cfg(feature = "aot")]
+                        if _tt0.is_some() {
+                            // residual-tick attribution: every entry in
+                            // this loop is a per-cycle dyn dispatch the
+                            // compiled edge did NOT cover
+                            let k = if *is_rst { "rst" } else { "clk" };
+                            jit::prof::hist_bump(
+                                &jit::prof::TICK_HIST,
+                                &format!("{}:{k}", p.class_name()),
+                            );
+                        }
                         if *is_rst {
                             if gate {
                                 p.rst_tick(t);

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -317,6 +317,7 @@ pub(crate) const RC_PRIM_COUNTER: u64 = 5;
 pub(crate) const RC_PRIM_REGFILE: u64 = 6;
 pub(crate) const RC_PRIM_FIFO: u64 = 7;
 pub(crate) const RC_PRIM_BRAM: u64 = 8;
+pub(crate) const RC_PRIM_BYPASSWIRE: u64 = 9;
 
 /// Rebuild a native bounce servicer from its baked seed: the prim
 /// (dynamic state = the live slots it will adopt) plus its arena
@@ -364,6 +365,11 @@ pub(crate) fn runcore_restore(
                 RWire::new(&[Value::from_u64(32, w as u64)], false)
             };
             Some((Box::new(p), 1 + vw(w)))
+        }
+        (RC_PRIM_BYPASSWIRE, &[w], []) => {
+            let w = width_of(w)?;
+            let p = BypassWire::new(&[Value::from_u64(32, w as u64)], false);
+            Some((Box::new(p), vw(w)))
         }
         (RC_PRIM_CONFIGREG, &[w], []) => {
             let w = width_of(w)?;
@@ -495,6 +501,12 @@ pub enum ArenaKind {
     /// ceil(max(width,1)/64) words after it.  The end-of-edge tick
     /// clears the valid word (interpreted, like all ticks).
     Wire { width: u32 },
+    /// BypassWire/CrossingBypassWire: value in ceil(max(width,1)/64)
+    /// words at the base slot, nothing else — no valid word (whas is
+    /// const-true: always written by contract) and no tick protocol
+    /// (the value never reverts).  Rung 36: these accesses were 99.99%
+    /// of Toooba's trampoline traffic before attachment.
+    BypassWire { width: u32 },
     /// ConfigReg: reads must see the begin-of-instant value even after
     /// a same-instant write.  Layout: old value (w words), current
     /// value (w words), written_at instant (1 word).  Compiled reads
@@ -2953,13 +2965,51 @@ impl Prim for RWire {
 
 /// BypassWire: combinational wire, always written each cycle.
 struct BypassWire {
+    width: u32,
     value: Value,
+    /// JIT arena backing: value words at the base slot — NO valid word
+    /// (whas is const-true by the always-written contract) and no tick
+    /// protocol (nothing reverts), which is why this is its own
+    /// ArenaKind rather than a Wire with a phantom valid bit
+    slot: Option<*mut u64>,
 }
 
 impl BypassWire {
     fn new(consts: &[Value], zero_width: bool) -> BypassWire {
         let width = if zero_width { 1 } else { carg(consts, 0) as u32 };
-        BypassWire { value: Value::zero(width.max(1)) }
+        BypassWire {
+            width,
+            value: Value::zero(width.max(1)),
+            slot: None,
+        }
+    }
+    fn value_words(&self) -> usize {
+        ((self.width.max(1) as usize) + 63) / 64
+    }
+    fn get_value(&self) -> Value {
+        match self.slot {
+            Some(p) => {
+                let limbs = unsafe {
+                    std::slice::from_raw_parts(p, self.value_words())
+                }
+                .to_vec();
+                Value::from_limbs64(self.width.max(1), limbs)
+            }
+            None => self.value.clone(),
+        }
+    }
+    fn set_value(&mut self, v: &Value) {
+        match self.slot {
+            Some(p) => {
+                let dst = unsafe {
+                    std::slice::from_raw_parts_mut(p, self.value_words())
+                };
+                for (i, d) in dst.iter_mut().enumerate() {
+                    *d = v.limbs64().get(i).copied().unwrap_or(0);
+                }
+            }
+            None => self.value = v.clone(),
+        }
     }
 }
 
@@ -2969,7 +3019,7 @@ impl Prim for BypassWire {
     }
     fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
         match method {
-            "wget" | "read" => self.value.clone(),
+            "wget" | "read" => self.get_value(),
             "whas" => Value::from_u64(1, 1),
             m => panic!("BypassWire: unknown value method {m:?}"),
         }
@@ -2979,13 +3029,34 @@ impl Prim for BypassWire {
             // zero-width wires (BypassWire0) are set with no argument
             "wset" | "write" => {
                 if let Some(v) = args.first() {
-                    self.value = v.clone();
+                    self.set_value(v);
                 }
             }
             m => panic!("BypassWire: unknown action method {m:?}"),
         }
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
+    fn arena_kind(&self) -> Option<ArenaKind> {
+        Some(ArenaKind::BypassWire { width: self.width })
+    }
+    fn arena_attach(&mut self, slot: *mut u64) {
+        let words = self.value_words();
+        let dst = unsafe { std::slice::from_raw_parts_mut(slot, words) };
+        for (i, d) in dst.iter_mut().enumerate() {
+            *d = self.value.limbs64().get(i).copied().unwrap_or(0);
+        }
+        self.slot = Some(slot);
+    }
+    fn arena_adopt(&mut self, slot: *mut u64) {
+        self.slot = Some(slot);
+    }
+    fn runcore_slot(&self) -> Option<*mut u64> {
+        self.slot
+    }
+    fn runcore_seed(&self) -> Option<(u64, Vec<u64>, Vec<String>)> {
+        self.arena_kind()?;
+        Some((RC_PRIM_BYPASSWIRE, vec![self.width as u64], Vec::new()))
+    }
     // the empty tick above must also be DECLARED no-op or the per-edge
     // walk dispatches it per instance per cycle anyway — on Toooba
     // (RISCY-OOO bypass networks) that walk measured 47% of the wall

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -2986,6 +2986,12 @@ impl Prim for BypassWire {
         }
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
+    // the empty tick above must also be DECLARED no-op or the per-edge
+    // walk dispatches it per instance per cycle anyway — on Toooba
+    // (RISCY-OOO bypass networks) that walk measured 47% of the wall
+    fn tick_is_noop(&self) -> bool {
+        true
+    }
 }
 
 // ===============

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -90,6 +90,11 @@ pub trait Prim {
     fn sym_transient(&self) -> bool {
         false
     }
+    /// Prim class label for TRS_PROF attribution: bounce/tick
+    /// histograms aggregate by class (instances are too many to read).
+    fn class_name(&self) -> &'static str {
+        "prim"
+    }
     /// Same-cycle visibility (activity census): reads of this prim can
     /// observe writes made EARLIER IN THE SAME CYCLE (CReg ports,
     /// loopy/bypass FIFOs) — a sensitivity mask must treat a write to
@@ -1001,6 +1006,9 @@ impl Counter {
 }
 
 impl Prim for Counter {
+    fn class_name(&self) -> &'static str {
+        "Counter"
+    }
     // no sym_children: the reference registers NO symbols for
     // Counter (`sim ls` parity); the oracle still compares its
     // architectural value via state_children
@@ -1795,6 +1803,9 @@ thread_local! {
 }
 
 impl Prim for RegFile {
+    fn class_name(&self) -> &'static str {
+        "RegFile"
+    }
     fn sym_children(&self) -> Vec<PrimSym> {
         // bs_prim_mod_regfile.h: "" SYM_RANGE, high_addr/low_addr params
         vec![
@@ -2184,6 +2195,9 @@ impl DualPortRam {
 }
 
 impl Prim for DualPortRam {
+    fn class_name(&self) -> &'static str {
+        "DualPortRam"
+    }
     fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value {
         match method {
             "read" | "sub" => {
@@ -2323,6 +2337,9 @@ impl Reg {
 }
 
 impl Prim for Reg {
+    fn class_name(&self) -> &'static str {
+        "Reg"
+    }
     fn sym_children(&self) -> Vec<PrimSym> {
         vec![PrimSym { key: "", width: self.width, range: None }]
     }
@@ -2613,6 +2630,9 @@ impl ConfigReg {
 }
 
 impl Prim for ConfigReg {
+    fn class_name(&self) -> &'static str {
+        "ConfigReg"
+    }
     fn sym_children(&self) -> Vec<PrimSym> {
         vec![PrimSym { key: "", width: self.value.width, range: None }]
     }
@@ -2802,6 +2822,9 @@ impl RWire {
 }
 
 impl Prim for RWire {
+    fn class_name(&self) -> &'static str {
+        "RWire"
+    }
     fn sym_children(&self) -> Vec<PrimSym> {
         // bs_prim_mod_wire.h: "" and "value" share the data member;
         // isValid is the 1-bit valid member
@@ -2941,6 +2964,9 @@ impl BypassWire {
 }
 
 impl Prim for BypassWire {
+    fn class_name(&self) -> &'static str {
+        "BypassWire"
+    }
     fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
         match method {
             "wget" | "read" => self.value.clone(),
@@ -3054,6 +3080,9 @@ impl CReg {
 }
 
 impl Prim for CReg {
+    fn class_name(&self) -> &'static str {
+        "CReg"
+    }
     fn sym_bypass(&self) -> bool {
         true // later ports read earlier same-cycle writes
     }
@@ -3402,6 +3431,9 @@ impl Fifo {
 }
 
 impl Prim for Fifo {
+    fn class_name(&self) -> &'static str {
+        "Fifo"
+    }
     fn sym_bypass(&self) -> bool {
         // loopy: deq/first see same-instant enq effects; bypass:
         // one-deep same-instant enq→first bypass
@@ -6014,6 +6046,9 @@ impl Bram {
 }
 
 impl Prim for Bram {
+    fn class_name(&self) -> &'static str {
+        "Bram"
+    }
     fn vcd_defs(
         &mut self,
         w: &mut crate::vcd::Vcd,


### PR DESCRIPTION
Rung 36 of the trs stack (base: trs/35-gating / PR #154). The Toooba runtime diagnosis attributed ~52% of the trs wall to one prim class — BypassWire — on both axes, and this rung removes both.

## Diagnosis (class-keyed TRS_PROF attribution, commit 1)

The bounce histogram now keys by `Class.method` (new `Prim::class_name`) and a residual-tick histogram counts the per-edge tick walk by class. One 8-second ISA probe on Toooba split a day-old "47% ticks / 3% wget-wset" profile into:

- **Ticks**: `tick BypassWire:clk` 834,438 — one dispatch per wire per cycle into an **empty function**. The plan's `tick_is_noop` filter (Reg/ConfigReg precedent) was never extended to BypassWire, so RISCY-OOO-style bypass networks paid a dyn dispatch per wire per cycle to do nothing: 527.8s of a 1121.4s bench run.
- **Bounces**: 99.99% `BypassWire.wset/wget` (211M calls, 26.99s) — the class had no `arena_kind`, so every access trampolined by construction. RWire traffic: zero (compiled RWire sites hold).

## Fix 1 — `tick_is_noop` (one line, SEALED)

Tick lists are baked in artifact plans, so old artifacts stay correct (their extra entries are no-ops) and the win engages on re-emitted links; no PLAN_A_VERSION bump.

Measured on Toooba bench-20000 devnull, one binary, one boot, interleaved:

| leg | r1 | r2 |
|---|---|---|
| pre-fix artifact | 1068.55 | 945.35 |
| **fix-1 artifact** | **115.68** | **113.29** |
| Bluesim | 280.93 | 279.55 |

trs goes from 3.44x behind Bluesim to **2.48x ahead**, 1.39x behind the same-night Verilator anchor (80.78/81.74). Witnesses: batteries 22/22 ×2 modes; corpus seal **1003/0, engines 1003 aot, PERF_REGRESS 17**; byte parity 891,717 identical stdout bytes vs the Bluesim oracle; TICKS-GONE probe (residual tick time 0.006s, reset-window entries only). The registered prediction (340–480s) missed conservative by ~3x — the per-cycle walk also polluted caches, so its true cost exceeded its timed share; recorded in the predictions ledger.

## Fix 2 — arena attachment (witness chain in flight)

New `ArenaKind::BypassWire { width }`: value words only — deliberately not `Wire`, whose valid-word protocol and tick-clear semantics don't apply (whas is const-true by the always-written contract; nothing reverts). Slot-aware prim accessors (RWire pattern), `RC_PRIM_BYPASSWIRE` RunCore seed, inline lowering (wget/read = slot load, whas = constant true, wset/write = branchless conditional store with RWire's fire-edge gate-mark contract). Split-analyzer class stays `Other` — attachment is not a stability reclassification. **AOT_LAYOUT_REV 23 → 24** (slot allocation changes; stale artifacts refuse at load and recompile in-process).

Registered projection: removes the remaining 26.99s bounce mass → ~86s, ≈ the 81.7s Verilator anchor. The gated witness chain (rebuild-first, hard BOUNCES-GONE gate, A/B, parity, its own 1003-design seal) is running; results land on this PR when it completes.

Evidence ledger: `predictions-wireperf.md` in the session scratchpad (registered before each measurement, misses recorded), seal JSON `sweep-trs36a.json`, A/B transcripts, cachegrind pair vs Verilator (trs compiled code measures I1 3.18% / mispredicts 3.7% vs Verilator's 4.5% on identical work — the residual was dynamic residue, not codegen).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CerPH99xuDTaGhaBQ3wwqS)_