### PR TITLE
trs: make the toolchain work off Linux/x86-64

### DIFF
--- a/src/trs/Makefile
+++ b/src/trs/Makefile
@@ -20,19 +20,43 @@ all: install
 # link against (docs/TCL-CAPI.md).
 #
 # The hybrid JIT needs llvm-sys (LLVM 18 dev headers).  The prefix is
-# AUTO-DETECTED via llvm-config-18 so a plain build produces the full
-# product (a lean install silently downgraded every artifact to the
-# interpreter until the perf fence caught it); LLVM_SYS_181_PREFIX in
-# the environment overrides the probe.  Without either, the lean
-# interpreter-only fallback builds (no LLVM required).
-LLVM_SYS_181_PREFIX ?= $(shell llvm-config-18 --prefix 2>/dev/null)
+# AUTO-DETECTED so a plain build produces the full product (a lean
+# install silently downgrades every artifact to the interpreter);
+# LLVM_SYS_181_PREFIX in the environment overrides the probe.  Without
+# either, the lean interpreter-only fallback builds (no LLVM required).
+#
+# The probe takes the first llvm-config that answers "18", because no
+# single name finds it everywhere: distros install llvm-config-18,
+# while Homebrew's llvm@18 is keg-only, so its llvm-config is spelled
+# without a version AND never reaches PATH — the keg has to be asked
+# for by name.  A plain llvm-config counts only when it is an 18.
+# (`case ... in 18.*)` would end the $(shell) early: make balances the
+# parens of an expansion before the shell ever sees the text.)
+LLVM_CONFIG ?= $(shell \
+	for c in llvm-config-18 \
+	         "$$(brew --prefix llvm@18 2>/dev/null)/bin/llvm-config" \
+	         llvm-config; do \
+	  if "$$c" --version 2>/dev/null | grep -q '^18\.'; then \
+	    echo "$$c"; break; \
+	  fi; \
+	done)
+ifneq ($(LLVM_CONFIG),)
+LLVM_SYS_181_PREFIX ?= $(shell $(LLVM_CONFIG) --prefix 2>/dev/null)
+endif
 ifneq ($(LLVM_SYS_181_PREFIX),)
 export LLVM_SYS_181_PREFIX
 TRS_FLAGS = --features jit
 CAPI_FLAGS  =
 else
 # lean fallback: no compile tier, but artifact LOADING stays (aot
-# needs no LLVM) — artifacts built elsewhere run at full speed
+# needs no LLVM) — artifacts built elsewhere run at full speed.
+# Loud, because the product it yields looks identical and runs an
+# order slower: every artifact this build links falls to the
+# interpreter, and the only other thing that notices is the perf fence.
+$(warning trs: no LLVM 18 found — building the interpreter-only tier.)
+$(warning trs: artifacts from this build will run INTERPRETED.  Install)
+$(warning trs: LLVM 18 (apt: llvm-18-dev, brew: llvm@18) or point)
+$(warning trs: LLVM_SYS_181_PREFIX at one to get the compile tier.)
 TRS_FLAGS = --features aot
 CAPI_FLAGS  = --no-default-features --features aot
 endif

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -663,6 +663,22 @@ fn gate_static(e: &Expr) -> bool {
 }
 
 
+/// The portable tuning baseline for the architecture this runs on.
+///
+/// A CPU name belongs to one architecture: LLVM ignores a name its
+/// target does not recognize and warns once per module, which loses the
+/// baseline and buries the log.  On x86-64, v3 measures within noise of
+/// host-native on the bench pool (wide-value memcpy code is the only
+/// vector consumer).  Elsewhere the empty string leaves the choice to
+/// LLVM, whose per-triple default is the portable one.
+fn portable_cpu() -> &'static str {
+    if cfg!(target_arch = "x86_64") {
+        "x86-64-v3"
+    } else {
+        ""
+    }
+}
+
 fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     use inkwell::targets::{CodeModel, RelocMode, Target, TargetMachine};
     llvm_init_once();
@@ -673,10 +689,8 @@ fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
     // artifacts are cached and shipped (.so, trs link --exe), and the
     // load gates check design identity, not CPU features — a
     // host-native artifact from an AVX-512 box SIGILLs elsewhere with
-    // no fallback.  Measured on the bench pool, x86-64-v3 matches
-    // host-native runtime within noise (wide-value memcpy code is the
-    // only vector consumer); TRS_JIT_CPU overrides: "native" restores
-    // host tuning, or any LLVM cpu name (x86-64, x86-64-v4, znver4...).
+    // no fallback.  TRS_JIT_CPU overrides: "native" restores host
+    // tuning, or any LLVM cpu name (x86-64, x86-64-v4, znver4...).
     let cpu_env = std::env::var("TRS_JIT_CPU").ok();
     let (cpu, feats) = match cpu_env.as_deref() {
         Some("native") => (
@@ -684,7 +698,7 @@ fn aot_target_machine() -> Result<inkwell::targets::TargetMachine, Ineligible> {
             TargetMachine::get_host_cpu_features().to_string(),
         ),
         Some(name) => (name.to_string(), String::new()),
-        None => ("x86-64-v3".to_string(), String::new()),
+        None => (portable_cpu().to_string(), String::new()),
     };
     target
         .create_target_machine(

--- a/src/trs/crates/trs-interp/src/hostlink.rs
+++ b/src/trs/crates/trs-interp/src/hostlink.rs
@@ -1,0 +1,200 @@
+//! What the host's linker and assembler want, where the two families
+//! disagree.
+//!
+//! Mach-O and ELF differ in spelling far more than in capability: a C
+//! symbol carries a leading underscore in one and not the other, dead
+//! stripping and symbol hiding have different flags, the export list is
+//! a different file format, `libdl` and `libpthread` are part of
+//! libSystem rather than libraries to name, and `.align` counts bytes
+//! in one assembler and powers of two in the other.
+//!
+//! Every one of those differences is a way for a link to fail late and
+//! specifically -- or, worse, to succeed while exporting the wrong set.
+//! They live here together so that a new link site has one place to ask
+//! rather than a GNU spelling to copy.
+
+/// Whether the host links Mach-O.  Everything else here follows from it.
+pub const MACHO: bool = cfg!(target_os = "macos");
+
+/// A C function's name as the linker spells it.  Mach-O prefixes an
+/// underscore to every C symbol; ELF does not.
+pub fn asm_name(sym: &str) -> String {
+    if MACHO {
+        format!("_{sym}")
+    } else {
+        sym.to_string()
+    }
+}
+
+/// Demand a symbol nothing references, so that an archive member
+/// defining it is pulled in.  Takes the source name; supplies the
+/// linker's spelling.
+pub fn undefined(sym: &str) -> String {
+    format!("-Wl,-u,{}", asm_name(sym))
+}
+
+/// Discard sections nothing reaches.
+pub fn dead_strip() -> &'static [&'static str] {
+    if MACHO {
+        &["-Wl,-dead_strip"]
+    } else {
+        &["-Wl,--gc-sections"]
+    }
+}
+
+/// Drop the symbol table from the output.
+pub fn strip_symbols() -> &'static [&'static str] {
+    // Apple's -s is rejected as unsafe for dynamic libraries; -x drops
+    // local symbols and keeps the exported surface, which is what the
+    // export list already restricts.
+    if MACHO {
+        &["-Wl,-x"]
+    } else {
+        &["-Wl,-s"]
+    }
+}
+
+/// Bind a shared object's calls to its own definitions, so an intra-.so
+/// call does not pay a PLT stub and a GOT load.  Mach-O's two-level
+/// namespace does this without being asked.
+pub fn local_binding() -> &'static [&'static str] {
+    if MACHO {
+        &[]
+    } else {
+        &["-Wl,-Bsymbolic-functions"]
+    }
+}
+
+/// Refuse output that still has unresolved symbols.  Mach-O already
+/// does, and says `-undefined error` is deprecated when asked.
+pub fn no_undefined() -> &'static [&'static str] {
+    if MACHO {
+        &[]
+    } else {
+        &["-Wl,--no-undefined"]
+    }
+}
+
+/// The C++ runtime the LLVM libraries were built against.
+pub fn cxx_runtime() -> &'static str {
+    if MACHO {
+        "-lc++"
+    } else {
+        "-lstdc++"
+    }
+}
+
+/// Support libraries that llvm-sys's bindings reference and a shared
+/// libLLVM does not re-export.  Only a fallback: `llvm-config
+/// --system-libs --link-static` answers this for the LLVM actually in
+/// use, and these names are a guess at a Debian-shaped one.
+pub fn llvm_support_libs() -> &'static [&'static str] {
+    if MACHO {
+        &["-lzstd", "-lcurses"]
+    } else {
+        &["-ltinfo", "-lzstd"]
+    }
+}
+
+/// Where a package manager keeps libraries the compiler driver does not
+/// search by default.  Homebrew installs outside the SDK, so a library
+/// LLVM was built against can be present and still unfindable.
+pub fn lib_search_paths() -> Vec<String> {
+    if MACHO {
+        ["/opt/homebrew/lib", "/usr/local/lib"]
+            .into_iter()
+            .filter(|p| std::path::Path::new(p).is_dir())
+            .map(|p| format!("-L{p}"))
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
+/// Keep an executable's own symbols visible to what it dlopens.
+pub fn export_dynamic() -> &'static [&'static str] {
+    if MACHO {
+        &["-Wl,-export_dynamic"]
+    } else {
+        &["-Wl,--export-dynamic"]
+    }
+}
+
+/// Keep a dependency recorded even if nothing resolves against it yet.
+/// Apple's linker has no as-needed pass to turn off.
+pub fn no_as_needed() -> &'static [&'static str] {
+    if MACHO {
+        &[]
+    } else {
+        &["-Wl,--no-as-needed"]
+    }
+}
+
+/// dlopen and pthreads: separate libraries under glibc, part of
+/// libSystem on Mach-O.
+pub fn system_libs() -> &'static [&'static str] {
+    if MACHO {
+        &[]
+    } else {
+        &["-lpthread", "-ldl"]
+    }
+}
+
+/// Name one shared library to link against.  `-l:<file>` is a GNU
+/// extension; elsewhere the path itself is the argument.
+pub fn link_shared(path: &std::path::Path, soname: &str) -> String {
+    if MACHO {
+        path.display().to_string()
+    } else {
+        format!("-l:{soname}")
+    }
+}
+
+/// Write the export list in the host's format and return the flags that
+/// point the linker at it.
+///
+/// The two formats disagree about more than syntax: a version script
+/// names what stays global *and* hides the rest, while an exported
+/// symbols list is only the keep-set, with the hiding implied.  Both
+/// take globs, and Mach-O wants each pattern in the linker's spelling.
+pub fn export_list(
+    path: &std::path::Path,
+    keep: &[&str],
+) -> std::io::Result<Vec<String>> {
+    if MACHO {
+        let body: String =
+            keep.iter().map(|p| format!("{}\n", asm_name(p))).collect();
+        std::fs::write(path, body)?;
+        Ok(vec![format!("-Wl,-exported_symbols_list,{}", path.display())])
+    } else {
+        let body = format!("{{ global: {}; local: *; }};\n", keep.join("; "));
+        std::fs::write(path, body)?;
+        Ok(vec![format!("-Wl,--version-script={}", path.display())])
+    }
+}
+
+/// An assembly stub that embeds a file and brackets it with two
+/// symbols, in the host assembler's dialect.
+///
+/// Neither the section name nor the alignment directive carries over:
+/// Mach-O has no `.rodata` and no GNU-stack note, and its `.align`
+/// counts powers of two where the GNU assembler counts bytes, so `8`
+/// would mean 256.  `.p2align` means the same thing to both.
+pub fn incbin_stub(file: &std::path::Path, start: &str, end: &str) -> String {
+    let (sec, note) = if MACHO {
+        ("\t.section __TEXT,__const\n", "")
+    } else {
+        ("\t.section .rodata\n", "\t.section .note.GNU-stack,\"\",@progbits\n")
+    };
+    format!(
+        "{note}{sec}\t.p2align 3\n\
+         \t.globl {s}\n\
+         {s}:\n\
+         \t.incbin \"{f}\"\n\
+         \t.globl {e}\n\
+         {e}:\n",
+        s = asm_name(start),
+        e = asm_name(end),
+        f = file.display(),
+    )
+}

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1011,6 +1011,29 @@ enum EmitFail {
     EdgeOverBudget(std::collections::HashSet<usize>, u64),
 }
 
+/// Linker flags that bind the artifact's calls to its own definitions.
+///
+/// The artifact calls its OWN exec/sched fns, and their symbols must
+/// stay dynamically exported because the table-less loader path dlsyms
+/// them.  On ELF that combination costs a PLT stub and a GOT load at
+/// every intra-.so call (FloatTest: 415 call sites, 5.5M indirect
+/// branches per run) unless the link asks for local binding.
+/// Function-only binding leaves the callback DATA globals (trs_cb_*) on
+/// their normal GOT path, which the loader writes through dlsym.
+///
+/// Mach-O resolves a call to a definition in the same image without
+/// being asked -- that is what its two-level namespace does -- and
+/// Apple's ld rejects -Bsymbolic-functions as an unknown option, so
+/// there is nothing to pass.
+#[cfg(feature = "jit")]
+fn local_binding_flags() -> &'static [&'static str] {
+    if cfg!(target_os = "macos") {
+        &[]
+    } else {
+        &["-Wl,-Bsymbolic-functions"]
+    }
+}
+
 #[cfg(feature = "jit")]
 #[allow(clippy::too_many_arguments)]
 fn aot_emit(
@@ -1339,15 +1362,10 @@ fn aot_emit(
         // .so at the final path (it would dlopen-fail or worse on the
         // next run before the gates can judge it)
         let so_tmp = so.with_extension("so.tmp");
-        // -Bsymbolic-functions: the artifact calls its OWN exec/sched
-        // fns, but their symbols must stay dynamically exported (the
-        // table-less loader path dlsyms them) — without local binding
-        // every intra-.so call pays a PLT stub + GOT load (FloatTest:
-        // 415 call sites, 5.5M indirect branches/run).  Function-only
-        // binding keeps the callback DATA globals (trs_cb_*) on their
-        // normal GOT path, which the loader writes through dlsym.
         let st = std::process::Command::new(cc_tool())
-            .args(["-shared", "-Wl,-Bsymbolic-functions", "-o"])
+            .arg("-shared")
+            .args(local_binding_flags())
+            .arg("-o")
             .arg(&so_tmp)
             .args(&files)
             .arg(&mf)
@@ -1533,10 +1551,12 @@ fn aot_emit(
     std::fs::write(&mf, meta).map_err(|e| EmitFail::Infra(e.to_string()))?;
     files.push(mf);
     // temp+rename, same discipline as the single-object emit; local
-    // function binding for the same reason (see the one-module link)
+    // function binding for the same reason (see local_binding_flags)
     let so_tmp = so.with_extension("so.tmp");
     let st = std::process::Command::new("cc")
-        .args(["-shared", "-Wl,-Bsymbolic-functions", "-o"])
+        .arg("-shared")
+        .args(local_binding_flags())
+        .arg("-o")
         .arg(&so_tmp)
         .args(&files)
         .status()

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -982,7 +982,7 @@ fn aot_or_jit_scheds(
 /// artifact .so.
 /// The shared-link driver: TRS_CC overrides (set by `trs link --cc`,
 /// so hermetic builds pin the exact tool instead of PATH's `cc`).
-fn cc_tool() -> String {
+pub fn cc_tool() -> String {
     std::env::var("TRS_CC").unwrap_or_else(|_| "cc".into())
 }
 
@@ -1348,11 +1348,11 @@ fn aot_emit(
             .args(&files)
             .arg(&mf)
             .status()
-            .map_err(|e| EmitFail::Infra(format!("cc: {e}")))?;
+            .map_err(|e| EmitFail::Infra(format!("{}: {e}", cc_tool())))?;
         if !st.success() {
             std::fs::remove_dir_all(&tmp).ok();
             std::fs::remove_file(&so_tmp).ok();
-            return Err(EmitFail::Infra("cc -shared failed".into()));
+            return Err(EmitFail::Infra(format!("{} -shared failed", cc_tool())));
         }
         std::fs::rename(&so_tmp, so)
             .map_err(|e| EmitFail::Infra(format!("rename .so: {e}")))?;
@@ -1388,7 +1388,7 @@ fn aot_emit(
                 .args(["-o"])
                 .arg(&exe_tmp)
                 .status()
-                .map_err(|e| EmitFail::Infra(format!("cc exe: {e}")))?;
+                .map_err(|e| EmitFail::Infra(format!("{} exe: {e}", cc_tool())))?;
             if !st.success() {
                 std::fs::remove_dir_all(&tmp).ok();
                 std::fs::remove_file(&exe_tmp).ok();
@@ -1531,18 +1531,18 @@ fn aot_emit(
     // temp+rename, same discipline as the single-object emit; local
     // function binding for the same reason (see hostlink::local_binding)
     let so_tmp = so.with_extension("so.tmp");
-    let st = std::process::Command::new("cc")
+    let st = std::process::Command::new(cc_tool())
         .arg("-shared")
         .args(crate::hostlink::local_binding())
         .arg("-o")
         .arg(&so_tmp)
         .args(&files)
         .status()
-        .map_err(|e| EmitFail::Infra(format!("cc: {e}")))?;
+        .map_err(|e| EmitFail::Infra(format!("{}: {e}", cc_tool())))?;
     std::fs::remove_dir_all(&tmp).ok();
     if !st.success() {
         std::fs::remove_file(&so_tmp).ok();
-        return Err(EmitFail::Infra("cc -shared failed".into()));
+        return Err(EmitFail::Infra(format!("{} -shared failed", cc_tool())));
     }
     std::fs::rename(&so_tmp, so)
         .map_err(|e| EmitFail::Infra(format!("rename .so: {e}")))?;

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -1011,28 +1011,6 @@ enum EmitFail {
     EdgeOverBudget(std::collections::HashSet<usize>, u64),
 }
 
-/// Linker flags that bind the artifact's calls to its own definitions.
-///
-/// The artifact calls its OWN exec/sched fns, and their symbols must
-/// stay dynamically exported because the table-less loader path dlsyms
-/// them.  On ELF that combination costs a PLT stub and a GOT load at
-/// every intra-.so call (FloatTest: 415 call sites, 5.5M indirect
-/// branches per run) unless the link asks for local binding.
-/// Function-only binding leaves the callback DATA globals (trs_cb_*) on
-/// their normal GOT path, which the loader writes through dlsym.
-///
-/// Mach-O resolves a call to a definition in the same image without
-/// being asked -- that is what its two-level namespace does -- and
-/// Apple's ld rejects -Bsymbolic-functions as an unknown option, so
-/// there is nothing to pass.
-#[cfg(feature = "jit")]
-fn local_binding_flags() -> &'static [&'static str] {
-    if cfg!(target_os = "macos") {
-        &[]
-    } else {
-        &["-Wl,-Bsymbolic-functions"]
-    }
-}
 
 #[cfg(feature = "jit")]
 #[allow(clippy::too_many_arguments)]
@@ -1364,7 +1342,7 @@ fn aot_emit(
         let so_tmp = so.with_extension("so.tmp");
         let st = std::process::Command::new(cc_tool())
             .arg("-shared")
-            .args(local_binding_flags())
+            .args(crate::hostlink::local_binding())
             .arg("-o")
             .arg(&so_tmp)
             .args(&files)
@@ -1387,9 +1365,9 @@ fn aot_emit(
             // statically-linked LLVM whose constructors cost ~5ms at
             // every exec of the produced binary.
             let rt = if libdir.join("libtrs_rt.so").exists() {
-                "-l:libtrs_rt.so"
+                "libtrs_rt.so"
             } else {
-                "-l:libtrs_capi.so"
+                "libtrs_capi.so"
             };
             let mc = tmp.join("trs_main.c");
             std::fs::write(
@@ -1402,10 +1380,10 @@ fn aot_emit(
                 .arg(&mc)
                 .args(&files)
                 .arg(&mf)
-                .arg("-Wl,--export-dynamic")
-                .arg("-Wl,--no-as-needed")
+                .args(crate::hostlink::export_dynamic())
+                .args(crate::hostlink::no_as_needed())
                 .arg(format!("-L{}", libdir.display()))
-                .arg(rt)
+                .arg(crate::hostlink::link_shared(&libdir.join(rt), rt))
                 .arg(format!("-Wl,-rpath,{}", libdir.display()))
                 .args(["-o"])
                 .arg(&exe_tmp)
@@ -1551,11 +1529,11 @@ fn aot_emit(
     std::fs::write(&mf, meta).map_err(|e| EmitFail::Infra(e.to_string()))?;
     files.push(mf);
     // temp+rename, same discipline as the single-object emit; local
-    // function binding for the same reason (see local_binding_flags)
+    // function binding for the same reason (see hostlink::local_binding)
     let so_tmp = so.with_extension("so.tmp");
     let st = std::process::Command::new("cc")
         .arg("-shared")
-        .args(local_binding_flags())
+        .args(crate::hostlink::local_binding())
         .arg("-o")
         .arg(&so_tmp)
         .args(&files)

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -29,6 +29,7 @@ pub use out::{flush as stdout_flush, force_line as stdout_force_line};
 pub mod topbind;
 pub use topbind::{parse_bind, TopBind};
 #[cfg(feature = "aot")]
+pub mod hostlink;
 mod jit;
 #[cfg(feature = "aot")]
 pub use jit::{runcore_bake_commit, RunCoreBake};

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -31,6 +31,7 @@ pub use topbind::{parse_bind, TopBind};
 #[cfg(feature = "aot")]
 pub mod hostlink;
 mod jit;
+pub use jit::cc_tool;
 #[cfg(feature = "aot")]
 pub use jit::{runcore_bake_commit, RunCoreBake};
 #[cfg(feature = "aot")]

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -9,6 +9,8 @@
 
 use std::process::ExitCode;
 
+use trs_interp::hostlink;
+
 fn usage() -> ExitCode {
     eprintln!("trs {} (phase P0 scaffold)", env!("CARGO_PKG_VERSION"));
     eprintln!("usage: trs ir dump <module.bir>");
@@ -774,7 +776,8 @@ fn main() -> ExitCode {
                 eprintln!("trs capi-so: write {}: {e}", map.display());
                 return ExitCode::FAILURE;
             }
-            let r = capi_cc_link(&out, &[], &lib, &map, !rt);
+            let r = capi_cc_link(&out, &[], &lib, &map,
+                                 &["bk_*", "trs_*", "new_MODEL_*"], !rt);
             let _ = std::fs::remove_dir_all(&tmp);
             match r {
                 Ok(()) => {
@@ -1147,8 +1150,14 @@ fn capi_cc_link(
     inputs: &[&std::path::Path],
     lib: &std::path::Path,
     map: &std::path::Path,
+    keep: &[&str],
     llvm: bool,
 ) -> Result<(), String> {
+    // the export list's format is the host's business, not the
+    // caller's: a version script and an exported-symbols list say the
+    // same thing in different shapes
+    let export_flags = hostlink::export_list(map, keep)
+        .map_err(|e| format!("write {}: {e}", map.display()))?;
     let mut cc = std::process::Command::new("cc");
     cc.arg("-shared").arg("-fPIC").arg("-o").arg(out);
     for i in inputs {
@@ -1159,17 +1168,16 @@ fn capi_cc_link(
     // stubs) into the .so; -u pulls only what the bk_*/new_MODEL
     // closure actually needs
     for sym in BK_EXPORTS {
-        cc.arg(format!("-Wl,-u,{sym}"));
+        cc.arg(hostlink::undefined(sym));
     }
     cc.arg(lib)
         // rust emits function sections: dead-strip everything the
         // -u keep-list doesn't reach, and drop symbols (166MB -> )
-        .arg("-Wl,--gc-sections")
-        .arg("-Wl,-s")
-        .arg("-Wl,-Bsymbolic")
-        .arg(format!("-Wl,--version-script={}", map.display()))
-        .arg("-lpthread")
-        .arg("-ldl")
+        .args(hostlink::dead_strip())
+        .args(hostlink::strip_symbols())
+        .args(hostlink::local_binding())
+        .args(&export_flags)
+        .args(hostlink::system_libs())
         .arg("-lm")
         // vendored libfst (trs-interp build.rs) gzip-frames FST output
         // through zlib in every flavor, slim included
@@ -1177,26 +1185,66 @@ fn capi_cc_link(
         // -shared tolerates undefined symbols; RTLD_NOW (and a static
         // exe link against this .so) does not — fail at LINK time
         // instead of at sim load
-        .arg("-Wl,--no-undefined");
+        .args(hostlink::no_undefined());
     if llvm && cfg!(feature = "jit") {
         // a jit-featured capi staticlib references LLVM (rustc links
         // it into BINARIES only); use the shared libLLVM
-        let libdir = std::process::Command::new("llvm-config-18")
-            .arg("--libdir")
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
+        // llvm-config by whichever name reaches it: the distro's
+        // versioned one, then the prefix llvm-sys was pointed at, then
+        // the Debian default -- a build configured through
+        // LLVM_SYS_181_PREFIX has no versioned binary on PATH.
+        let ask = |prog: &std::path::Path, args: &[&str]| {
+            std::process::Command::new(prog)
+                .args(args)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+        // Which LLVM this staticlib was built against is a fact about
+        // the build, so the prefix llvm-sys was given is baked in at
+        // compile time; the environment at run time belongs to whoever
+        // is running trs and need not have it set at all.  A runtime
+        // value still wins, for moving an install.
+        let prefix = |p: &str| {
+            std::path::Path::new(p).join("bin").join("llvm-config")
+        };
+        let cfg = [
+            std::env::var("LLVM_SYS_181_PREFIX").ok().map(|p| prefix(&p)),
+            option_env!("LLVM_SYS_181_PREFIX").map(prefix),
+            Some(std::path::PathBuf::from("llvm-config-18")),
+        ]
+        .into_iter()
+        .flatten()
+        .find(|p| ask(p, &["--libdir"]).is_some());
+        let libdir = cfg
+            .as_deref()
+            .and_then(|p| ask(p, &["--libdir"]))
             .unwrap_or_else(|| "/usr/lib/llvm-18/lib".into());
+        // the staticlib's llvm-sys bindings reference LLVM's own system
+        // libraries directly, and which ones those are is a property of
+        // this LLVM build, not of the platform -- ask it rather than
+        // keeping a list that is right on one distribution
+        let sys_libs: Vec<String> = cfg
+            .as_deref()
+            .and_then(|p| ask(p, &["--system-libs", "--link-static"]))
+            .map(|s| s.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_else(|| {
+                hostlink::llvm_support_libs()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            });
         cc.arg(format!("-L{libdir}"))
             .arg("-lLLVM-18")
-            .arg("-lstdc++")
-            // the execution engine bindings reference libffi (shared
-            // libLLVM does not re-export it)
+            .arg(hostlink::cxx_runtime())
+            .args(&sys_libs)
+            // the execution engine bindings reference libffi, which
+            // llvm-config does not report
             .arg("-lffi")
-            // terminfo + zstd: llvm-sys support-library residue
-            .arg("-ltinfo")
-            .arg("-lzstd");
+            .args(hostlink::lib_search_paths());
     }
     match cc.status() {
         Ok(s) if s.success() => Ok(()),
@@ -1218,18 +1266,7 @@ fn write_shim_sources(
     let shim_c = tmp.join("shim.c");
     std::fs::write(
         &shim_s,
-        format!(
-            r##"	.section .note.GNU-stack,"",@progbits
-	.section .rodata
-	.align 8
-	.globl trs_bir_start
-trs_bir_start:
-	.incbin "{}"
-	.globl trs_bir_end
-trs_bir_end:
-"##,
-            bir_abs.display()
-        ),
+        hostlink::incbin_stub(bir_abs, "trs_bir_start", "trs_bir_end"),
     )
     .map_err(|e| format!("write {}: {e}", shim_s.display()))?;
     std::fs::write(
@@ -1295,12 +1332,10 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
         Err(e) => return note(e),
     };
     let map = tmp.join("export.map");
-    if let Err(e) = std::fs::write(
-        &map,
-        "{ global: new_MODEL_*; trs_*; local: *; };\n",
-    ) {
-        return note(format!("write {}: {e}", map.display()));
-    }
+    let shim_exports = match hostlink::export_list(&map, &["new_MODEL_*", "trs_*"]) {
+        Ok(f) => f,
+        Err(e) => return note(format!("write {}: {e}", map.display())),
+    };
     let so = format!("{base}.capi.so");
     let mut cc = std::process::Command::new("cc");
     cc.arg("-shared")
@@ -1316,11 +1351,11 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
         // itself references NO capi symbol — bluetcl dlsym's bk_*
         // through the dependency scope — so --as-needed (many distros'
         // default) would silently drop the DT_NEEDED: disable it.
-        .arg("-Wl,--no-as-needed")
-        .arg("-l:libtrs_capi.so")
+        .args(hostlink::no_as_needed())
+        .arg(hostlink::link_shared(&shared, "libtrs_capi.so"))
         .arg(format!("-Wl,-rpath,{}", shared_dir.display()))
-        .arg(format!("-Wl,--version-script={}", map.display()))
-        .arg("-Wl,--no-undefined");
+        .args(&shim_exports)
+        .args(hostlink::no_undefined());
     let r = cc.status();
     let _ = std::fs::remove_dir_all(&tmp);
     match r {
@@ -1383,14 +1418,9 @@ fn link_interactive(bir_path: &str, base: &str, top: &str) -> ExitCode {
         Err(e) => return fail(e),
     };
     let map = tmp.join("export.map");
-    if let Err(e) = std::fs::write(
-        &map,
-        "{ global: bk_*; trs_*; new_MODEL_*; local: *; };\n",
-    ) {
-        return fail(format!("write {}: {e}", map.display()));
-    }
     let so = format!("{base}.so");
-    if let Err(e) = capi_cc_link(&so, &[&shim_c, &shim_s], &lib, &map, true) {
+    if let Err(e) = capi_cc_link(&so, &[&shim_c, &shim_s], &lib, &map,
+                                 &["bk_*", "trs_*", "new_MODEL_*"], true) {
         return fail(e);
     }
     let _ = std::fs::remove_dir_all(&tmp);

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -1158,7 +1158,7 @@ fn capi_cc_link(
     // same thing in different shapes
     let export_flags = hostlink::export_list(map, keep)
         .map_err(|e| format!("write {}: {e}", map.display()))?;
-    let mut cc = std::process::Command::new("cc");
+    let mut cc = std::process::Command::new(trs_interp::cc_tool());
     cc.arg("-shared").arg("-fPIC").arg("-o").arg(out);
     for i in inputs {
         cc.arg(i);
@@ -1248,8 +1248,8 @@ fn capi_cc_link(
     }
     match cc.status() {
         Ok(s) if s.success() => Ok(()),
-        Ok(s) => Err(format!("cc exited {s}")),
-        Err(e) => Err(format!("cc: {e}")),
+        Ok(s) => Err(format!("{} exited {s}", trs_interp::cc_tool())),
+        Err(e) => Err(format!("{}: {e}", trs_interp::cc_tool())),
     }
 }
 
@@ -1345,7 +1345,7 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
         Err(e) => return note(format!("write {}: {e}", map.display())),
     };
     let so = format!("{base}.capi.so");
-    let mut cc = std::process::Command::new("cc");
+    let mut cc = std::process::Command::new(trs_interp::cc_tool());
     cc.arg("-shared")
         .arg("-fPIC")
         .arg("-o")
@@ -1368,8 +1368,8 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
     let _ = std::fs::remove_dir_all(&tmp);
     match r {
         Ok(s) if s.success() => {}
-        Ok(s) => return note(format!("cc exited {s}")),
-        Err(e) => return note(format!("cc: {e}")),
+        Ok(s) => return note(format!("{} exited {s}", trs_interp::cc_tool())),
+        Err(e) => return note(format!("{}: {e}", trs_interp::cc_tool())),
     }
     // companions: same-directory RELATIVE symlinks (they survive the
     // whole artifact directory moving together); a filesystem without

--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -1308,9 +1308,17 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
         false
     };
     let Some(shared) = find_capi_shared() else {
-        // silent: an install without the shared capi simply has no
-        // script tier — the artifact contract doesn't change
-        return false;
+        // Every other way this can fail says so, and so does this one:
+        // the artifact contract is unchanged either way, but an
+        // artifact quietly missing a documented tier is indisting-
+        // uishable from one that has it.  A lean install reaches here
+        // on purpose; so does a host where `trs capi-so` could not
+        // link, and only the message tells them apart.
+        return note(
+            "no libtrs_capi.so (looked at $TRS_CAPI_SO, then beside \
+             the trs binary and in ../lib)"
+                .to_string(),
+        );
     };
     let Some(shared_dir) = shared.parent().map(std::path::Path::to_path_buf) else {
         return note(format!("{} has no parent directory", shared.display()));

--- a/src/trs/tests/interactive/run.sh
+++ b/src/trs/tests/interactive/run.sh
@@ -18,6 +18,20 @@
 # `expected-status` entries: the wrapper's exit code must ALSO match.
 BSC=${BSC:-bsc}
 TRS=${TRS:-trs}
+
+# A run that hangs must not hang the battery, but the command that
+# bounds it is not portable: coreutils calls it timeout, Homebrew
+# installs it as gtimeout, and a stock macOS has neither.  Where none
+# exists the run is simply unbounded -- a battery that reports nothing
+# because `timeout` was missing is worse than one that can hang.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT="timeout 120"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT="gtimeout 120"
+else
+    TIMEOUT=""
+    echo "note: no timeout command; runs are unbounded"
+fi
 SRC=$(cd "$(dirname "$0")" && pwd)
 TSRC=$(cd "$SRC/../../../../testsuite/bsc.bluesim/interactive" && pwd)
 case "$BSC" in
@@ -56,9 +70,9 @@ build() { # src top [flags and/or C link files]...
 }
 check() { # top cmd [expected-status]
     top=$1; cmd=$2; want=${3:-0}
-    timeout 120 ./"ref_$top" -f "$cmd" > "ref_${top}_${cmd%.cmd}.out" 2>&1
+    $TIMEOUT ./"ref_$top" -f "$cmd" > "ref_${top}_${cmd%.cmd}.out" 2>&1
     ref_rc=$?
-    timeout 120 ./"trs_$top" -f "$cmd" > "trs_${top}_${cmd%.cmd}.out" 2>&1
+    $TIMEOUT ./"trs_$top" -f "$cmd" > "trs_${top}_${cmd%.cmd}.out" 2>&1
     trs_rc=$?
     [ "$ref_rc" = "$want" ] \
         || echo "WARN $top $cmd: reference exit $ref_rc (expected $want)"
@@ -215,11 +229,11 @@ vcdtcldiff() { # ref got
 }
 if [ -x ./ref_mkTbGCD ]; then
     rm -f waves.vcd
-    timeout 120 ./ref_mkTbGCD -f vcdtcl.cmd > ref_mkTbGCD_vcdtcl.out 2>&1
+    $TIMEOUT ./ref_mkTbGCD -f vcdtcl.cmd > ref_mkTbGCD_vcdtcl.out 2>&1
     ref_rc=$?
     mv waves.vcd ref_waves.vcd 2>/dev/null
     rm -f waves.vcd
-    timeout 120 ./trs_mkTbGCD -f vcdtcl.cmd > trs_mkTbGCD_vcdtcl.out 2>&1
+    $TIMEOUT ./trs_mkTbGCD -f vcdtcl.cmd > trs_mkTbGCD_vcdtcl.out 2>&1
     trs_rc=$?
     ok=1
     [ "$ref_rc" = "$trs_rc" ] || ok=0
@@ -233,11 +247,11 @@ fi
 # fstcmp.py: FST bytes embed timestamps, so no byte compare)
 if [ -x ./ref_mkTbGCD ] && command -v fst2vcd > /dev/null 2>&1; then
     rm -f waves.fst
-    timeout 120 ./ref_mkTbGCD -f fsttcl.cmd > ref_mkTbGCD_fsttcl.out 2>&1
+    $TIMEOUT ./ref_mkTbGCD -f fsttcl.cmd > ref_mkTbGCD_fsttcl.out 2>&1
     ref_rc=$?
     mv waves.fst ref_waves.fst 2>/dev/null
     rm -f waves.fst
-    timeout 120 ./trs_mkTbGCD -f fsttcl.cmd > trs_mkTbGCD_fsttcl.out 2>&1
+    $TIMEOUT ./trs_mkTbGCD -f fsttcl.cmd > trs_mkTbGCD_fsttcl.out 2>&1
     trs_rc=$?
     ok=1
     [ "$ref_rc" = "$trs_rc" ] || ok=0


### PR DESCRIPTION
## Why

`trs link` could not produce an artifact anywhere but Linux on x86-64,
and `trs capi-so` could not link at all, so on any other host every
artifact silently lacked its `-c`/`-f` script tier. This branch makes
the whole toolchain work off Linux/x86-64.

It started as two flags and became a sweep, because they kept coming in
different shapes.

## Five families, not one

**Linker flags.** `-Bsymbolic-functions` is a GNU ld option that Apple's
ld rejects outright, killing the link *after* the whole LLVM pipeline
has run. Also `--gc-sections`, `-s`, `--no-undefined`,
`--export-dynamic`, `--no-as-needed`, `-lpthread`, `-ldl`, and the
`-l:libfoo.so` form.

**Symbol spelling.** `-Wl,-u` takes the *linker's* name for a symbol,
and Mach-O prefixes an underscore to every C symbol. Asking for `c_mix`
where the object defines `_c_mix` fails naming every import it was told
to keep — which is the entire archive-BDPI path, the only path `-u`
exists for.

**Export lists.** A version script names the keep-set *and* hides the
rest; an exported-symbols list is only the keep-set, one pattern per
line, in the linker's spelling. Three sites were hand-writing
`{ global: …; local: *; };` strings. `export_list` now writes the file
and returns the flags, so a caller passes `["bk_*", "trs_*",
"new_MODEL_*"]` and never sees the format. This is the one that would
have failed *silently* — a wrong export set changes what is visible
without failing the link.

**Assembler dialect.** The BIR-embedding stub was hand-written `.s` with
`.section .note.GNU-stack,"",@progbits` and `.rodata`, which the Mach-O
assembler rejects. Its `.align 8` is worse than rejected: `.align`
counts bytes to the GNU assembler and powers of two to Mach-O's, so the
same line means 8 bytes on one and 256 on the other.

**Toolchain discovery.** A hardcoded `/usr/lib/llvm-18/lib` fallback and
`-ltinfo`/`-lzstd`/`-lstdc++` by their Debian names. Which system
libraries LLVM needs is a property of the LLVM build, not the platform,
so `capi_cc_link` asks `llvm-config --system-libs --link-static` and
keeps the hardcoded list only as a fallback, marked as the guess it is.

The build-time twin of that: the Makefile probed for `llvm-config-18`
and nothing else, which is the one name Homebrew never provides —
`llvm@18` is keg-only, so its `llvm-config` is spelled without a
version *and* is not on `PATH`. A Mac with LLVM 18 correctly installed
therefore built the interpreter-only tier, and that failure is quiet by
construction: the binary and every artifact it links behave
identically, just an order slower. It surfaces as a whole battery
reporting "compiled mode unavailable" with nothing saying why. The
probe now takes the first `llvm-config` that answers 18 — versioned
name, the Homebrew keg asked for by name, or a plain one that happens
to be an 18 — and the lean fallback warns instead of passing for a
normal build. (A `case … in 18.*)` cannot be used to write that test:
make balances the parens of a `$(shell …)` before the shell sees it, so
a case label's unmatched paren truncates the command — into this same
silent fallback.)

`hostlink` (in `trs-interp`, used by both crates) holds all of it, so a
new link site has one place to ask instead of a spelling to copy.

## Two build-time facts being re-derived at run time

Both were wrong in the same way.

`x86-64-v3` was pinned as the artifact CPU. The *reasoning* is sound and
unchanged — artifacts are cached and shipped, and the load gates check
design identity rather than CPU features, so a host-native artifact from
an AVX-512 box would SIGILL elsewhere — but a CPU name belongs to one
architecture, and LLVM warns once per module and ignores it everywhere
else, losing the baseline and burying the log.

The LLVM libdir lookup read `LLVM_SYS_181_PREFIX` from the environment
at **run** time, where nothing sets it: the Makefile exports it while
*building* trs, not while running it. So every link fell through to the
Debian path even though the answer had been available during its own
compilation. It is captured with `option_env!` now, runtime override
still ahead of it.

## Measured

macOS 15 / arm64, one worktree and one bsc, changing only the trs
binary:

| | before | after |
|---|---|---|
| `tests/regress` | 4 PASS / 31 FAIL | **35 / 0** |
| `tests/vcd` | 0 / 11 | **10 / 1** |
| `tests/interactive` | 0 / 19 | **34 / 1** |
| `libtrs_capi.so` | never built | 44MB, links |
| `libtrs_rt.so` | never built | links |

Every one of those 31 regress failures was an AOT link.
`TRS_REQUIRE_AOT=1` links clean, so these are compiled artifacts rather
than interpreter fallbacks.

**`tests/interactive` had never run on this platform.** It is the real
gate on the Mach-O export list: bluetcl `sim load`s the model and drives
it, which a wrong export set would break silently. Its runs were bounded
with `timeout`, which coreutils ships, Homebrew prefixes as `gtimeout`,
and macOS lacks entirely — both legs were exiting 127, which is what had
been hiding the battery's real state. The harness now takes whichever
exists and says so when there is none.

## Known remaining

None outstanding.

`fsttcl` was open when this branch was written: the trs model answered
"not built with FST support" where the reference dumped waves. #161
(trs/43-wave-formats) fixes it — `trs link --interactive` was accepting
`-dump-formats` and dropping it, so the model never received the
permission, though the FST writer is compiled into every model either
way. Not a host convention, and not platform-specific: it fails the
same way anywhere, and was invisible here only because the interactive
battery could not run on macOS until this branch. `tests/vcd`'s FST
twin was the same fault, asking for FST without asking for the writer.
Both batteries finish green with #161 — `tests/vcd` 11/0,
`tests/interactive` 35/0.

The shape #161 takes — mirror the reference's contract, carried on the
link command line — is one of the options HANDOFF weighs for
`-dump-formats`. It is an assumption the implementation makes, not a
decision anyone has taken; HANDOFF still carries that question as open.

Nothing here changes behaviour on Linux/x86-64: every helper returns
exactly what was passed before.



