### PR TITLE
trs: carry the waveform contract into the interactive model

### DIFF
--- a/src/trs/crates/trs/src/main.rs
+++ b/src/trs/crates/trs/src/main.rs
@@ -377,7 +377,9 @@ fn main() -> ExitCode {
                         )
                     }
                 }
-                return link_interactive(path, &base, interp.top_name());
+                return link_interactive(
+                    path, &base, interp.top_name(), &fmt_arg,
+                );
             }
             if exe {
                 // artifact-as-executable: <base> becomes a real PIE
@@ -1403,7 +1405,12 @@ fn write_capi_shim(bir_path: &str, base: &str, top: &str, compiled: bool) -> boo
 /// with the BIR embedded via incbin) and <base>, the same bluesim.tcl
 /// wrapper the reference emits — `sim load`-able by stock bluetcl and
 /// runnable by the interactive testsuite unchanged.
-fn link_interactive(bir_path: &str, base: &str, top: &str) -> ExitCode {
+fn link_interactive(
+    bir_path: &str,
+    base: &str,
+    top: &str,
+    formats: &str,
+) -> ExitCode {
     let fail = |m: String| {
         eprintln!("trs link --interactive: {m}");
         ExitCode::FAILURE
@@ -1448,9 +1455,16 @@ fn link_interactive(bir_path: &str, base: &str, top: &str) -> ExitCode {
         }
     }
     // the reference's wrapper, verbatim shape (bsc.hs writeBluesimWrapper)
+    // Which writers the model carries is a link-time decision the
+    // model itself cannot see: bk_init reads it from the environment,
+    // and absent it takes the historical default of vcd alone.  The
+    // fast wrapper exports this in its -c/-f dispatch for the same
+    // reason; without it here, `sim fst` on a model linked
+    // -dump-formats fst answers that it has no FST support.
     let wrapper = format!(
         r##"#!/bin/sh
 
+TRS_CAPI_FORMATS="{formats}"; export TRS_CAPI_FORMATS
 BLUESPECDIR=`echo 'puts $env(BLUESPECDIR)' | bluetcl`
 
 for arg in $@

--- a/src/trs/tests/interactive/run.sh
+++ b/src/trs/tests/interactive/run.sh
@@ -73,7 +73,15 @@ build() { # src top [flags and/or C link files]...
     for c in $cfiles; do bdpi="$bdpi --bdpi $c"; done
     $TRSBIR $birflags $bdpi "$top" >> "$top.bsc.log" 2>&1 \
         || { echo "FAIL $top (trs-bir)"; fail=1; return 1; }
-    "$TRS" link "$top.bir" --interactive -o "trs_$top" \
+    # which waveform writers a model carries is a link-time contract on
+    # both sides, so the trs link is told what the reference was told
+    trsfmt=""
+    prev=""
+    for a in $flags; do
+        [ "$prev" = "-dump-formats" ] && trsfmt="--dump-formats $a"
+        prev=$a
+    done
+    "$TRS" link "$top.bir" --interactive $trsfmt -o "trs_$top" \
         > "$top.trs.log" 2>&1 \
         || { echo "FAIL $top (trs link --interactive)"; fail=1; return 1; }
 }

--- a/src/trs/tests/vcd/run.sh
+++ b/src/trs/tests/vcd/run.sh
@@ -62,7 +62,9 @@ check FinishEdge sysFinishEdge -m 20
 # embed a timestamp, so parity is semantic (fstcmp.py).
 if command -v fst2vcd > /dev/null 2>&1; then
     rm -f fe.fst fe.vcd
-    $TRS run sysFinishEdge.bir +bscfst=fe.fst > /dev/null 2>&1
+    # the FST writer is present but not permitted by default, the
+    # reference's -dump-formats contract mirrored
+    $TRS run sysFinishEdge.bir --formats vcd,fst +bscfst=fe.fst > /dev/null 2>&1
     $TRS run sysFinishEdge.bir -V fe.vcd > /dev/null 2>&1
     if fst2vcd fe.fst > fe_dec.vcd 2>/dev/null \
        && python3 "$SRC/fstcmp.py" fe_dec.vcd fe.vcd > /dev/null; then


### PR DESCRIPTION
## What

`trs link --interactive` accepted `--dump-formats` and silently dropped
it, so an interactive model always behaved as vcd-only:

```
$ trs link mkTbGCD.bir --interactive --dump-formats vcd,fst -o m
$ ./m -f fsttcl.cmd
Error: this model was not built with FST support (rebuild with -dump-formats fst)
```

Which writers a model may use is a link-time decision the model cannot
see for itself: `bk_init` reads `TRS_CAPI_FORMATS` from the environment,
and absent it takes the historical default of vcd alone
(`vcd.rs`: `allowed_vcd: true, allowed_fst: false`). The **fast**
wrapper exports it in its `-c`/`-f` dispatch for that reason. The
interactive wrapper never did, and `link_interactive` did not even take
the value.

Nothing was missing but the permission. The FST writer is compiled into
`libtrs_capi` and sits in every model either way — setting the variable
by hand on a model linked *without* `--dump-formats` produces a correct
FST, byte-for-byte the size of the reference's:

```
$ TRS_CAPI_FORMATS=vcd,fst ./trs_mkTbGCD -f fsttcl.cmd
$ ls -l waves.fst   # 1346 bytes, as the reference wrote
```

## Two witnesses that could never have passed

- **`tests/interactive` fsttcl** built the reference with
  `-dump-formats vcd,fst` and linked trs with nothing, so the two models
  disagreed by construction. It now forwards to the trs link whatever
  the reference was given.
- **`tests/vcd`'s FST twin** ran `trs run` with no `--formats` at all.

Neither is platform-specific — both fail the same way anywhere. They
were invisible on macOS because `tests/interactive` could not run at all
until #159, and the vcd twin's failure was read as belonging to that
same family.

## Measured

macOS 15 / arm64:

| | |
|---|---|
| `tests/interactive` | **35 PASS / 0 FAIL** |
| `tests/vcd` | **11 PASS / 0 FAIL** |
| `tests/regress` | **35 PASS / 0 FAIL** |

First time every trs battery has been green on this platform.

## Not changed: why FST is opt-in

The default mirrors the reference, whose `-dump-formats` is vcd-only, so
that a design asking for FST gets the same refusal from both and
diffsweep's stdout comparison stays honest. Worth noting the
justification does not transfer: Bluesim's default is vcd-only because
FST means linking libfst+libz into *every generated executable*, a real
per-artifact cost that HANDOFF notes may not survive upstream review.
trs pays that once, in `libtrs_capi`, and carries the writer regardless.
So defaulting FST on would cost trs nothing and would trade one stdout
divergence from the reference — the MIRROR-vs-DIVERGE decision HANDOFF
leaves open. This branch keeps MIRROR and fixes the plumbing under it.
