### PR TITLE
trs: stop rebuilding from names what the exporter already knows

### DIFF
--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -91,6 +91,8 @@ pub struct PrimCallSpec {
     /// global instance index of the prim
     pub inst: usize,
     pub method: StrId,
+    /// port the call addresses, for a multi-ported prim method
+    pub port: u32,
     /// argument widths, in order (marshaled as consecutive word runs)
     pub arg_widths: Vec<u32>,
     /// result width (0 = action, no result)
@@ -392,6 +394,7 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
         for pc in v {
             w(o, pc.inst as u32);
             w(o, pc.method);
+            w(o, pc.port);
             w(o, pc.ret_width);
             w(o, pc.is_action as u32);
             w(o, pc.arg_widths.len() as u32);
@@ -465,6 +468,7 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
         for _ in 0..n {
             let inst = r(b, i)? as usize;
             let method = r(b, i)?;
+            let port = r(b, i)?;
             let ret_width = r(b, i)?;
             let is_action = r(b, i)? != 0;
             let argc = r(b, i)?;
@@ -475,7 +479,7 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
             for _ in 0..argc {
                 arg_widths.push(r(b, i)?);
             }
-            v.push(PrimCallSpec { inst, method, arg_widths, ret_width, is_action });
+            v.push(PrimCallSpec { inst, method, port, arg_widths, ret_width, is_action });
         }
         Some(v)
     }

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -2853,7 +2853,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             return Ok(1);
         }
         let m = &self.env.d.modules[ie.mir];
-        match m.defs.iter().find(|d| d.name == name) {
+        match m.def(name) {
             Some(d) if d.width >= 1 => Ok(d.width),
             Some(_) => Ok(0), // zero-width def: the empty bit-vector
             None => Err(Ineligible(format!(
@@ -4417,9 +4417,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return true;
                 };
                 let m = &self.env.d.modules[ie.mir];
-                m.defs
-                    .iter()
-                    .find(|d| d.name == *n)
+                m.def(*n)
                     .is_some_and(|d| self.effectful_expr(inst, &d.expr, seen))
             }
             E::MethCall { instance, method, args, .. } => {
@@ -4437,10 +4435,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     // result closure only
                     let cm = &self.env.d.modules[ce.mir];
                     return cm
-                        .methods
-                        .iter()
-                        .find(|mm| mm.name == *method)
-                        .and_then(|mm| mm.result.as_ref())
+                        .method_idx(*method)
+                        .and_then(|mi| cm.methods[mi].result.as_ref())
                         .is_some_and(|r| self.effectful_expr(child, r, seen));
                 }
                 // prim child: dynamic-arg value reads may warn —
@@ -4857,7 +4853,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             return nope("cyclic def");
         }
         let m = &self.env.d.modules[ie.mir];
-        let Some(d) = m.defs.iter().find(|d| d.name == n) else {
+        let Some(d) = m.def(n) else {
             let chain: Vec<&str> = f
                 .expanding
                 .iter()
@@ -5261,7 +5257,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 return nope("eager def without slot");
             }
             let m = &self.env.d.modules[self.ie(f.inst)?.mir];
-            let Some(d) = m.defs.iter().find(|d| d.name == e) else {
+            let Some(d) = m.def(e) else {
                 continue;
             };
             let dex = d.expr.clone();
@@ -5796,7 +5792,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                let Some(d) = m.def(*n) else {
                     return false;
                 };
                 seen.push(*n);
@@ -5842,7 +5838,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                let Some(d) = m.def(*n) else {
                     return false;
                 };
                 seen.push(*n);
@@ -5900,7 +5896,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let Ok(ie) = self.ie(f.inst) else { return false };
                 let m = &self.env.d.modules[ie.mir];
-                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                let Some(d) = m.def(*n) else {
                     return false;
                 };
                 seen.push(*n);
@@ -6003,7 +5999,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let ie = self.ie(f.inst)?;
                 let m = &self.env.d.modules[ie.mir];
-                let Some(d) = m.defs.iter().find(|d| d.name == *n) else {
+                let Some(d) = m.def(*n) else {
                     return nope("unknown string def");
                 };
                 if f.expanding.contains(n) {

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -3273,6 +3273,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     f,
                     child,
                     GATE_OUT_METHOD,
+                    0,
                     &[],
                     1,
                     false,
@@ -3909,7 +3910,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
             self.builder.position_at_end(slow_bb);
             let sv = self
-                .emit_prim_call(f, child, method, args, width, false)?
+                .emit_prim_call(f, child, method, port, args, width, false)?
                 .expect("value prim call returns");
             f.ssa = saved;
             let s_end = self.builder.get_insert_block().unwrap();
@@ -3945,11 +3946,9 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             return Ok(self.load_val(f, off, bw));
         }
         if let Some(&(base, cw)) = ie.creg5_slot.get(&instance) {
-            // CReg port reads return the LIVE value (schedule order
-            // makes port k's read see earlier ports' writes)
-            if !(mname.starts_with("port") && mname.ends_with("__read")) {
-                return nope("creg value method mismatch");
-            }
+            // a CReg's only value method is a port read, and it returns
+            // the LIVE value (schedule order makes port k's read see
+            // earlier ports' writes)
             if cw != width {
                 return nope("creg read width mismatch");
             }
@@ -3987,7 +3986,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         };
         if !self.env.insts.contains_key(&child) {
             let v = self
-                .emit_prim_call(f, child, method, args, width, false)?
+                .emit_prim_call(f, child, method, port, args, width, false)?
                 .expect("value prim call returns");
             return Ok(v);
         }
@@ -4233,6 +4232,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         f: &mut Frame<'ctx>,
         prim_inst: usize,
         method: StrId,
+        port: u32,
         args: &[Expr],
         ret_width: u32,
         is_action: bool,
@@ -4292,6 +4292,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         self.prim_calls.push(PrimCallSpec {
             inst: prim_inst,
             method,
+            port,
             arg_widths,
             ret_width: if is_action { 0 } else { ret_width },
             is_action,
@@ -5428,34 +5429,21 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             return nope("auto-fire spec out of step with the method");
         }
         let (margs, body, mname) = (m.args.clone(), m.body.clone(), m.name);
-        // sibling RDY_<m> lookup — same rule as the interp's
-        // always_en_rdy and the parent-call inline: no RDY method
-        // exported = constant ready
-        let rdy = {
-            let rdy_name =
-                format!("RDY_{}", self.env.d.strings[mname as usize]);
-            self.env
-                .d
-                .strings
+        // sibling RDY lookup — same rule as the interp's always_en_rdy
+        // and the parent-call inline: no RDY method exported = constant
+        // ready
+        let rdy = m.rdy.and_then(|id| {
+            self.env.d.modules[mir]
+                .methods
                 .iter()
-                .position(|x| x == &rdy_name)
-                .and_then(|id| {
-                    self.env.d.modules[mir]
-                        .methods
-                        .iter()
-                        .enumerate()
-                        .find(|(_, mm)| mm.name == id as StrId)
-                        .map(|(mi, mm)| (mi, mm.result.clone()))
-                })
-        };
+                .enumerate()
+                .find(|(_, mm)| mm.name == id)
+                .map(|(mi, mm)| (mi, mm.result.clone()))
+        });
         let en_slot = {
             let en_name =
                 format!("EN_{}", self.env.d.strings[mname as usize]);
-            self.env
-                .d
-                .strings
-                .iter()
-                .position(|x| x == &en_name)
+            self.env.d.str_id(&en_name)
                 .and_then(|id| ie.en_slot.get(&(id as StrId)).copied())
         };
         // callee frame on the top itself, args bound to the baked
@@ -6276,23 +6264,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             // the RESULT still evaluates when the body
                             // is skipped (the C++ returns the stale
                             // port value).  No RDY exported = ready.
-                            let rdy_id = if m.always_enabled {
-                                let rdy_name = format!(
-                                    "RDY_{}",
-                                    self.env.d.strings[*method as usize]
-                                );
-                                self.env
-                                    .d
-                                    .strings
-                                    .iter()
-                                    .position(|x| x == &rdy_name)
-                                    .map(|id| id as StrId)
-                                    .filter(|id| {
-                                        cmod.methods.iter().any(|mm| mm.name == *id)
-                                    })
-                            } else {
-                                None
-                            };
+                            let rdy_id = m.always_enabled.then_some(m.rdy).flatten();
                             if args.len() != m.args.len() {
                                 return nope("method arg count mismatch");
                             }
@@ -6303,12 +6275,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             let body = m.body.clone();
                             let en_name =
                                 format!("EN_{}", self.env.d.strings[*method as usize]);
-                            let en_slot = self
-                                .env
-                                .d
-                                .strings
-                                .iter()
-                                .position(|x| x == &en_name)
+                            let en_slot = self.env.d.str_id(&en_name)
                                 .and_then(|id| cie.en_slot.get(&(id as StrId)).copied());
                             let mut cf = self.child_frame(f, child, Some(mi))?;
                             let wc = self.expr_width(f, cond)?;
@@ -6565,7 +6532,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         return nope("prim actionvalue method (no trampoline AV path)");
                         #[allow(unreachable_code)]
                         let v = self
-                            .emit_prim_call(f, child, *method, args, wd, true)?
+                            .emit_prim_call(f, child, *method, *port, args, wd, true)?
                             .expect("av prim call returns");
                         let g_end = self.builder.get_insert_block().unwrap();
                         self.builder.build_unconditional_branch(jn_bb).unwrap();
@@ -7048,7 +7015,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
                     self.builder.position_at_end(slow_bb);
                     let saved: HashMap<StrId, IntValue<'ctx>> = f.ssa.clone();
-                    self.emit_prim_call(f, child, *method, args, 0, true)?;
+                    self.emit_prim_call(f, child, *method, *port, args, 0, true)?;
                     f.ssa = saved;
                     self.builder.build_unconditional_branch(done_bb).unwrap();
 
@@ -7115,7 +7082,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
                     self.builder.position_at_end(slow_bb);
                     let saved: HashMap<StrId, IntValue<'ctx>> = f.ssa.clone();
-                    self.emit_prim_call(f, child, *method, args, 0, true)?;
+                    self.emit_prim_call(f, child, *method, *port, args, 0, true)?;
                     f.ssa = saved;
                     self.builder.build_unconditional_branch(done_bb).unwrap();
 
@@ -7123,11 +7090,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return Ok(());
                 }
                 if let Some(&(base, cw)) = ie.creg5_slot.get(instance) {
-                    // branchless port write: value = select(cond, v, old)
-                    if !(mname.starts_with("port") && mname.ends_with("__write"))
-                        || args.is_empty()
-                    {
-                        return nope("non-write CReg action");
+                    // branchless port write: value = select(cond, v, old).
+                    // A CReg's only action method is a port write.
+                    if args.is_empty() {
+                        return nope("CReg write without a value");
                     }
                     let vw = self.expr_width(f, &args[0])?;
                     let v0 = self.expr(f, &args[0])?;
@@ -7230,6 +7196,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                                 Ineligible("fifo child missing".into())
                             })?,
                             *method,
+                            *port,
                             &targs,
                             0,
                             true,
@@ -7347,7 +7314,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
                         self.builder.position_at_end(slow_bb);
                         let saved: HashMap<StrId, IntValue<'ctx>> = f.ssa.clone();
-                        self.emit_prim_call(f, child, *method, args, 0, true)?;
+                        self.emit_prim_call(f, child, *method, *port, args, 0, true)?;
                         f.ssa = saved;
                         self.builder.build_unconditional_branch(done_bb).unwrap();
 
@@ -7469,7 +7436,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         let t = self.ctx.bool_type().const_int(1, false);
                         self.gate_mark(f, t);
                     }
-                    self.emit_prim_call(f, child, *method, args, 0, true)?;
+                    self.emit_prim_call(f, child, *method, *port, args, 0, true)?;
                     self.builder.build_unconditional_branch(sk_bb).unwrap();
                     self.builder.position_at_end(sk_bb);
                     return Ok(());
@@ -7504,31 +7471,14 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // method at call time (the C++ check_rdy wrapper); EN
                 // still lands when the caller fires. No RDY method
                 // exported = constant ready.
-                let rdy_id = if m.always_enabled {
-                    let rdy_name =
-                        format!("RDY_{}", self.env.d.strings[*method as usize]);
-                    self.env
-                        .d
-                        .strings
-                        .iter()
-                        .position(|x| x == &rdy_name)
-                        .map(|id| id as StrId)
-                        .filter(|id| cmod.methods.iter().any(|mm| mm.name == *id))
-                } else {
-                    None
-                };
+                let rdy_id = m.always_enabled.then_some(m.rdy).flatten();
                 if args.len() != m.args.len() {
                     return nope("method arg count mismatch");
                 }
                 let margs = m.args.clone();
                 let body = m.body.clone();
                 let en_name = format!("EN_{}", self.env.d.strings[*method as usize]);
-                let en_slot = self
-                    .env
-                    .d
-                    .strings
-                    .iter()
-                    .position(|x| x == &en_name)
+                let en_slot = self.env.d.str_id(&en_name)
                     .and_then(|id| cie.en_slot.get(&(id as StrId)).copied());
 
                 let mut cf = self.child_frame(f, child, Some(mi))?;

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -700,7 +700,7 @@ impl<'a> ConeAnalyzer<'a> {
         if self.seen.contains(&(mir, n)) {
             return PieceInfo { eff: 0, outlinable: false, stable: false, outlined: false, ports: Vec::new() };
         }
-        let Some(di) = self.d.modules[mir].defs.iter().position(|dd| dd.name == n) else {
+        let Some(di) = self.d.modules[mir].def_idx(n) else {
             return PieceInfo { eff: 0, outlinable: false, stable: false, outlined: false, ports: Vec::new() };
         };
         self.seen.push((mir, n));
@@ -5429,11 +5429,7 @@ impl Interp {
             for (afi, (mname, argv)) in
                 self.autofire.clone().iter().enumerate()
             {
-                let Some(mi) = self.d.modules[tmir]
-                    .methods
-                    .iter()
-                    .position(|m| m.name == *mname)
-                else {
+                let Some(mi) = self.d.modules[tmir].method_idx(*mname) else {
                     if trace {
                         eprintln!("trs jit: off (autofire method missing)");
                     }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -125,8 +125,8 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
     } else {
         &lz.scheds[ordinal].prim_calls[local]
     };
-    let (inst, method, ret_width, is_action) =
-        (pc.inst, pc.method, pc.ret_width, pc.is_action);
+    let (inst, method, port, ret_width, is_action) =
+        (pc.inst, pc.method, pc.port, pc.ret_width, pc.is_action);
     // pc borrows the OWNED Arc clone, so it outlives every interp use
     // below — no arg_widths copy needed (this trampoline runs per
     // boxed prim access; a Vec clone + a Vec per argument showed as
@@ -158,9 +158,9 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         };
         *out = g;
     } else if is_action {
-        interp.call_action(inst, method, &argv);
+        interp.call_action(inst, method, port, &argv);
     } else {
-        let v = interp.call_value(inst, method, &argv, ret_width);
+        let v = interp.call_value(inst, method, port, &argv, ret_width);
         let words = ((ret_width.max(1) as usize) + 63) / 64;
         let dst = std::slice::from_raw_parts_mut(out, words);
         for (i, d) in dst.iter_mut().enumerate() {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -679,6 +679,8 @@ struct Stepper {
     jit: Option<JitPlans>,
 }
 
+
+
 impl Interp {
     /// Identity salt of the top-level bindings, already folded into
     /// `bir_hash` by the loaders: a compiled artifact's stamp must
@@ -892,7 +894,7 @@ impl Interp {
             .enumerate()
             .map(|(i, s)| (s.clone(), i as StrId))
             .collect();
-        it.vcd_trace = it.d.strings.iter().any(|s| s.starts_with("$dump"));
+        it.vcd_trace = it.d.uses_wave_tasks;
         let top_mod = it.mod_by_name[&it.d.top];
         // the top module's reset inputs are all the kernel-driven reset
         let top_binds: HashMap<StrId, usize> = it.d.modules[it.mods[top_mod].ir]

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -5489,25 +5489,7 @@ impl Interp {
                     None => return Value::zero(width.max(1)),
                 };
                 let m = &self.d.modules[mir].methods[mi];
-                let mut e = m.ready.clone();
-                // the exported ready pred can reference the
-                // PRE-block-conversion name (Def(RDY_<m>)) that no
-                // def table carries; the reference resolves it to
-                // the method's CAN_FIRE def (mkGCD.cxx:
-                // PORT_RDY_result = DEF_CAN_FIRE_result)
-                if let Some(Expr::Def(dn)) = &e {
-                    if !self.mods[module].defs.contains_key(dn) {
-                        let cf = format!("CAN_FIRE_{}", self.s(method));
-                        if let Some(id) =
-                            self.d.str_id(&cf).map(|i| i as usize)
-                        {
-                            if self.mods[module].defs.contains_key(&(id as StrId))
-                            {
-                                e = Some(Expr::Def(id as StrId));
-                            }
-                        }
-                    }
-                }
+                let e = m.ready.clone();
                 match e {
                     Some(e) => {
                         let mut ctx = Ctx::default();

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -153,6 +153,15 @@ pub struct Interp {
     mod_by_name: HashMap<StrId, usize>,
     /// instance path -> instance state index
     inst_by_path: HashMap<String, usize>,
+    /// name -> interned id.  Design::strings is the id->name direction;
+    /// several lookups need the other one, and scanning the table for a
+    /// match is O(strings) per call on paths that run per method call.
+    str_by_name: HashMap<String, StrId>,
+    /// method -> EN_<method> / RDY_<method>.  Asked once per method
+    /// call, and the answer is a property of the design, so the derived
+    /// name is built once rather than on every call.
+    en_id_of_meth: HashMap<StrId, Option<StrId>>,
+    rdy_id_of_meth: HashMap<StrId, Option<StrId>>,
     insts: Vec<Inst>,
     cycle: u64,
     /// current simulation time (the time of the executing clock edge)
@@ -801,6 +810,9 @@ impl Interp {
             mods,
             mod_by_name,
             inst_by_path: HashMap::new(),
+            str_by_name: HashMap::new(),
+            en_id_of_meth: HashMap::new(),
+            rdy_id_of_meth: HashMap::new(),
             insts: Vec::new(),
             fe: ForeignEnv::new(),
             dyn_strs: Vec::new(),
@@ -873,6 +885,13 @@ impl Interp {
         };
         // def/method-call recording must run from t=0 if the design can
         // ever start dumping ($dump* task present); -V sets it too
+        it.str_by_name = it
+            .d
+            .strings
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.clone(), i as StrId))
+            .collect();
         it.vcd_trace = it.d.strings.iter().any(|s| s.starts_with("$dump"));
         let top_mod = it.mod_by_name[&it.d.top];
         // the top module's reset inputs are all the kernel-driven reset
@@ -1988,15 +2007,43 @@ impl Interp {
     /// method — the always_enabled method's own `ready` expr can
     /// reference defs bsc dropped along with the caller-side condition.
     /// No RDY method exported = constant ready.
+    /// The interned id of a method's companion EN_/RDY_ signal, or None
+    /// where the design exports no such signal.
+    fn derived_id(&mut self, method: StrId, prefix: &str) -> Option<StrId> {
+        let cached = if prefix == "EN_" {
+            self.en_id_of_meth.get(&method).copied()
+        } else {
+            self.rdy_id_of_meth.get(&method).copied()
+        };
+        if let Some(v) = cached {
+            return v;
+        }
+        let name = format!("{prefix}{}", self.s(method));
+        let v = self.str_by_name.get(&name).copied();
+        if prefix == "EN_" {
+            self.en_id_of_meth.insert(method, v);
+        } else {
+            self.rdy_id_of_meth.insert(method, v);
+        }
+        v
+    }
+
+    fn en_id_of(&mut self, method: StrId) -> Option<StrId> {
+        self.derived_id(method, "EN_")
+    }
+
+    fn rdy_id_of(&mut self, method: StrId) -> Option<StrId> {
+        self.derived_id(method, "RDY_")
+    }
+
     fn always_en_rdy(&mut self, callee: usize, module: usize, method: StrId) -> bool {
-        let rdy_name = format!("RDY_{}", self.s(method));
-        let Some(id) = self.d.strings.iter().position(|x| x == &rdy_name) else {
+        let Some(id) = self.rdy_id_of(method) else {
             return true;
         };
-        if !self.mods[module].methods.contains_key(&(id as StrId)) {
+        if !self.mods[module].methods.contains_key(&id) {
             return true;
         }
-        self.call_value(callee, id as StrId, &[], 1).as_u64() & 1 == 1
+        self.call_value(callee, id, &[], 1).as_u64() & 1 == 1
     }
 
     /// Record that an action/actionvalue method fired this pass: the C++
@@ -2007,17 +2054,16 @@ impl Interp {
         if self.vcd_trace {
             self.vcd_rec_meth_time(callee, method);
         }
-        let en = format!("EN_{}", self.s(method));
-        if let Some(en_id) = self.d.strings.iter().position(|x| x == &en) {
+        if let Some(en_id) = self.en_id_of(method) {
             if let Some(c) = self.census.as_mut() {
-                c.exec_latch(callee, en_id as StrId, &Value::from_u64(1, 1));
+                c.exec_latch(callee, en_id, &Value::from_u64(1, 1));
             }
             if let InstKind::User { latched, .. } = &mut self.insts[callee].kind {
-                latched.insert(en_id as StrId, Value::from_u64(1, 1));
+                latched.insert(en_id, Value::from_u64(1, 1));
             }
             // JIT body fallback: native scheds read EN from the arena
             if !self.jit_arena_ptr.is_null() {
-                if let Some(&slot) = self.jit_en_slots.get(&(callee, en_id as StrId)) {
+                if let Some(&slot) = self.jit_en_slots.get(&(callee, en_id)) {
                     unsafe { *self.jit_arena_ptr.add(slot as usize) = 1 };
                 }
             }
@@ -2519,8 +2565,8 @@ impl Interp {
             }
             // the method function writes its own EN/arg/result ports
             let en = format!("EN_{}", self.s(me.name));
-            if let Some(en_id) = self.d.strings.iter().position(|x| x == &en) {
-                usage.entry(en_id as StrId).or_default().insert(fk);
+            if let Some(&en_id) = self.str_by_name.get(&en) {
+                usage.entry(en_id).or_default().insert(fk);
             }
             for a in &me.args {
                 usage.entry(a.name).or_default().insert(fk);
@@ -2533,8 +2579,7 @@ impl Interp {
             // (rule inhibitors) falls out of the rule-cone marking above
             if me.kind != ir::MethodKind::Value {
                 let wf = format!("WILL_FIRE_{}", self.s(me.name));
-                if let Some(id) = self.d.strings.iter().position(|x| x == &wf) {
-                    let id = id as StrId;
+                if let Some(&id) = self.str_by_name.get(&wf) {
                     if defs_by_name.contains_key(&id) {
                         usage.entry(id).or_default().insert(fk);
                     }
@@ -2605,8 +2650,8 @@ impl Interp {
             let is_action = me.kind != ir::MethodKind::Value;
             if is_action {
                 let en = format!("EN_{}", self.s(me.name));
-                if let Some(en_id) = self.d.strings.iter().position(|x| x == &en) {
-                    let n_fns = usage.get(&(en_id as StrId)).map(|s| s.len()).unwrap_or(0);
+                if let Some(&en_id) = self.str_by_name.get(&en) {
+                    let n_fns = usage.get(&en_id).map(|s| s.len()).unwrap_or(0);
                     if n_fns >= 2 || (self.d.keep_fires && n_fns >= 1) {
                         ports.push(ModVar {
                             name: en,
@@ -2812,7 +2857,7 @@ impl Interp {
         }
         // input clock port: chase the parent's binding expression
         if let InstKind::User { clk_binds, .. } = &self.insts[inst].kind {
-            let pid = self.d.strings.iter().position(|x| x == wire);
+            let pid = self.str_by_name.get(wire).map(|&i| i as usize);
             if let Some(pid) = pid {
                 if let Some((owner, e)) = clk_binds.get(&(pid as StrId)) {
                     let (owner, e) = (*owner, e.clone());
@@ -5418,7 +5463,7 @@ impl Interp {
         match kind {
             MethPortKind::En => {
                 let en = format!("EN_{}", self.s(method));
-                let id = self.d.strings.iter().position(|x| x == &en);
+                let id = self.str_by_name.get(&en).map(|&i| i as usize);
                 let mut set = match (&self.insts[i].kind, id) {
                     (InstKind::User { latched, .. }, Some(id)) => {
                         latched.contains_key(&(id as StrId))
@@ -5488,7 +5533,7 @@ impl Interp {
                     if !self.mods[module].defs.contains_key(dn) {
                         let cf = format!("CAN_FIRE_{}", self.s(method));
                         if let Some(id) =
-                            self.d.strings.iter().position(|x| x == &cf)
+                            self.str_by_name.get(&cf).map(|&i| i as usize)
                         {
                             if self.mods[module].defs.contains_key(&(id as StrId))
                             {

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -156,12 +156,10 @@ pub struct Interp {
     /// name -> interned id.  Design::strings is the id->name direction;
     /// several lookups need the other one, and scanning the table for a
     /// match is O(strings) per call on paths that run per method call.
-    str_by_name: HashMap<String, StrId>,
     /// method -> EN_<method> / RDY_<method>.  Asked once per method
     /// call, and the answer is a property of the design, so the derived
     /// name is built once rather than on every call.
     en_id_of_meth: HashMap<StrId, Option<StrId>>,
-    rdy_id_of_meth: HashMap<StrId, Option<StrId>>,
     insts: Vec<Inst>,
     cycle: u64,
     /// current simulation time (the time of the executing clock edge)
@@ -812,9 +810,7 @@ impl Interp {
             mods,
             mod_by_name,
             inst_by_path: HashMap::new(),
-            str_by_name: HashMap::new(),
             en_id_of_meth: HashMap::new(),
-            rdy_id_of_meth: HashMap::new(),
             insts: Vec::new(),
             fe: ForeignEnv::new(),
             dyn_strs: Vec::new(),
@@ -887,13 +883,6 @@ impl Interp {
         };
         // def/method-call recording must run from t=0 if the design can
         // ever start dumping ($dump* task present); -V sets it too
-        it.str_by_name = it
-            .d
-            .strings
-            .iter()
-            .enumerate()
-            .map(|(i, s)| (s.clone(), i as StrId))
-            .collect();
         it.vcd_trace = it.d.uses_wave_tasks;
         let top_mod = it.mod_by_name[&it.d.top];
         // the top module's reset inputs are all the kernel-driven reset
@@ -1612,15 +1601,15 @@ impl Interp {
                     None => Value::from_u64(1, 1),
                 }
             }
-            Expr::MethCall { width, instance, method, args, .. } => {
+            Expr::MethCall { width, instance, method, port, args } => {
                 let argv: Vec<Value> =
                     args.iter().map(|a| self.eval(inst, ctx, a)).collect();
                 let child = self.child_of(inst, *instance);
-                self.call_value(child, *method, &argv, *width)
+                self.call_value(child, *method, *port, &argv, *width)
             }
             Expr::MethValue { width, instance, method } => {
                 let child = self.child_of(inst, *instance);
-                self.call_value(child, *method, &[], *width)
+                self.call_value(child, *method, 0, &[], *width)
             }
             Expr::TaskValue { width, cookie } => {
                 // value produced by the paired Task action earlier in this
@@ -1632,7 +1621,8 @@ impl Interp {
                     .unwrap_or_else(|| Value::undet(*width))
             }
             Expr::ForeignCall { width, func, args } => {
-                let fname = self.s(*func).to_string();
+                // Arc clone, not a String: this runs per evaluated call
+                let fname = self.arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .map(|a| self.eval_arg(inst, ctx, a, false))
@@ -1904,7 +1894,14 @@ impl Interp {
         a
     }
 
-    fn call_value(&mut self, callee: usize, method: StrId, argv: &[Value], w: u32) -> Value {
+    fn call_value(
+        &mut self,
+        callee: usize,
+        method: StrId,
+        port: u32,
+        argv: &[Value],
+        w: u32,
+    ) -> Value {
         if self.census.is_some() {
             if let InstKind::Prim(_) = &self.insts[callee].kind {
                 if let Some(c) = self.census.as_mut() {
@@ -1921,7 +1918,7 @@ impl Interp {
                 // the FloatTest malloc profile (disjoint fields, so
                 // the &mut prim borrow tolerates it)
                 let mname: &str = &self.d.strings[method as usize];
-                let r = p.value_method(mname, argv, self.now);
+                let r = p.value_method(mname, port, argv, self.now);
                 if self.trace_events {
                     let path = self.insts[callee].path.clone();
                     eprintln!("[{}] {}.{} -> {}", self.cycle, path, mname,
@@ -1952,7 +1949,7 @@ impl Interp {
         }
     }
 
-    fn call_action(&mut self, callee: usize, method: StrId, argv: &[Value]) {
+    fn call_action(&mut self, callee: usize, method: StrId, port: u32, argv: &[Value]) {
         if self.trace_events {
             if let InstKind::Prim(_) = &self.insts[callee].kind {
                 let mname = self.d.strings[method as usize].clone();
@@ -1973,7 +1970,7 @@ impl Interp {
                 // borrow, don't clone (same disjoint-fields fix as
                 // call_value; per-event-tax audit finding 3)
                 let mname: &str = &self.d.strings[method as usize];
-                p.action_method(mname, argv, self.now);
+                p.action_method(mname, port, argv, self.now);
             }
             InstKind::User { module, .. } => {
                 let module = *module;
@@ -2004,48 +2001,32 @@ impl Interp {
         }
     }
 
-    /// check_rdy for an always_enabled method: the C++ wraps the body in
-    /// `if (RDY_<m> port)` (cvtIFace), so evaluate the sibling RDY_<m>
-    /// method — the always_enabled method's own `ready` expr can
-    /// reference defs bsc dropped along with the caller-side condition.
-    /// No RDY method exported = constant ready.
-    /// The interned id of a method's companion EN_/RDY_ signal, or None
-    /// where the design exports no such signal.
-    fn derived_id(&mut self, method: StrId, prefix: &str) -> Option<StrId> {
-        let cached = if prefix == "EN_" {
-            self.en_id_of_meth.get(&method).copied()
-        } else {
-            self.rdy_id_of_meth.get(&method).copied()
-        };
-        if let Some(v) = cached {
+    /// The interned id of a method's companion EN_ signal, or None where
+    /// the design exports no such signal.
+    fn en_id_of(&mut self, method: StrId) -> Option<StrId> {
+        if let Some(v) = self.en_id_of_meth.get(&method).copied() {
             return v;
         }
-        let name = format!("{prefix}{}", self.s(method));
-        let v = self.str_by_name.get(&name).copied();
-        if prefix == "EN_" {
-            self.en_id_of_meth.insert(method, v);
-        } else {
-            self.rdy_id_of_meth.insert(method, v);
-        }
+        let name = format!("EN_{}", self.s(method));
+        let v = self.d.str_id(&name);
+        self.en_id_of_meth.insert(method, v);
         v
     }
 
-    fn en_id_of(&mut self, method: StrId) -> Option<StrId> {
-        self.derived_id(method, "EN_")
-    }
-
-    fn rdy_id_of(&mut self, method: StrId) -> Option<StrId> {
-        self.derived_id(method, "RDY_")
-    }
-
+    /// check_rdy for an always_enabled method: the C++ wraps the body in
+    /// `if (RDY_<m> port)` (cvtIFace), so evaluate the sibling RDY method
+    /// — the always_enabled method's own `ready` expr can reference defs
+    /// bsc dropped along with the caller-side condition.  No RDY method
+    /// exported = constant ready.
     fn always_en_rdy(&mut self, callee: usize, module: usize, method: StrId) -> bool {
-        let Some(id) = self.rdy_id_of(method) else {
+        let mir = self.mods[module].ir;
+        let Some(&mi) = self.mods[module].methods.get(&method) else {
             return true;
         };
-        if !self.mods[module].methods.contains_key(&id) {
+        let Some(id) = self.d.modules[mir].methods[mi].rdy else {
             return true;
-        }
-        self.call_value(callee, id, &[], 1).as_u64() & 1 == 1
+        };
+        self.call_value(callee, id, 0, &[], 1).as_u64() & 1 == 1
     }
 
     /// Record that an action/actionvalue method fired this pass: the C++
@@ -2203,20 +2184,21 @@ impl Interp {
     fn exec_action(&mut self, inst: usize, ctx: &mut Ctx, a: &Action) {
         // no finished check — see exec_stmt
         match a {
-            Action::MethCall { instance, method, cond, args, .. } => {
+            Action::MethCall { instance, method, port, cond, args } => {
                 if !self.eval(inst, ctx, cond).as_bool() {
                     return;
                 }
                 let argv: Vec<Value> =
                     args.iter().map(|x| self.eval(inst, ctx, x)).collect();
                 let child = self.child_of(inst, *instance);
-                self.call_action(child, *method, &argv);
+                self.call_action(child, *method, *port, &argv);
             }
             Action::Foreign { func, cond, args, signed } => {
                 if !self.eval(inst, ctx, cond).as_bool() {
                     return;
                 }
-                let fname = self.s(*func).to_string();
+                // Arc clone, not a String: this runs per evaluated call
+                let fname = self.arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .zip(signed.iter().chain(std::iter::repeat(&false)))
@@ -2229,7 +2211,8 @@ impl Interp {
                 if !self.eval(inst, ctx, cond).as_bool() {
                     return;
                 }
-                let fname = self.s(*func).to_string();
+                // Arc clone, not a String: this runs per evaluated call
+                let fname = self.arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .zip(signed.iter().chain(std::iter::repeat(&false)))
@@ -2567,7 +2550,7 @@ impl Interp {
             }
             // the method function writes its own EN/arg/result ports
             let en = format!("EN_{}", self.s(me.name));
-            if let Some(&en_id) = self.str_by_name.get(&en) {
+            if let Some(en_id) = self.d.str_id(&en) {
                 usage.entry(en_id).or_default().insert(fk);
             }
             for a in &me.args {
@@ -2579,17 +2562,20 @@ impl Interp {
             // an action method's function writes its WILL_FIRE def
             // (cvtIFace wf_stmts); whether the schedule also reads it
             // (rule inhibitors) falls out of the rule-cone marking above
-            if me.kind != ir::MethodKind::Value {
-                let wf = format!("WILL_FIRE_{}", self.s(me.name));
-                if let Some(&id) = self.str_by_name.get(&wf) {
-                    if defs_by_name.contains_key(&id) {
-                        usage.entry(id).or_default().insert(fk);
-                    }
+            if let Some(id) = me.will_fire {
+                if defs_by_name.contains_key(&id) {
+                    usage.entry(id).or_default().insert(fk);
                 }
             }
         }
 
         // member selection
+        // the action method each WILL_FIRE def belongs to
+        let wf_owner: HashMap<StrId, StrId> = m
+            .methods
+            .iter()
+            .filter_map(|me| me.will_fire.map(|wf| (wf, me.name)))
+            .collect();
         let mut members: Vec<ModVar> = Vec::new();
         for rst in &m.resets {
             if let Expr::Port(n) = &rst.wire {
@@ -2620,16 +2606,9 @@ impl Interp {
                 let dname = self.s(d.name).to_string();
                 // an action method's WILL_FIRE follows the call, like EN
                 // (the schedule zeroes it each edge, the call sets it)
-                let src = dname
-                    .strip_prefix("WILL_FIRE_")
-                    .and_then(|rest| {
-                        m.methods
-                            .iter()
-                            .find(|me| {
-                                me.kind != ir::MethodKind::Value && self.s(me.name) == rest
-                            })
-                            .map(|me| VcdSrc::PortEn(me.name))
-                    })
+                let src = wf_owner
+                    .get(&d.name)
+                    .map(|&owner| VcdSrc::PortEn(owner))
                     .unwrap_or(VcdSrc::Def(d.name));
                 let domain = usage
                     .get(&d.name)
@@ -2652,7 +2631,7 @@ impl Interp {
             let is_action = me.kind != ir::MethodKind::Value;
             if is_action {
                 let en = format!("EN_{}", self.s(me.name));
-                if let Some(&en_id) = self.str_by_name.get(&en) {
+                if let Some(en_id) = self.d.str_id(&en) {
                     let n_fns = usage.get(&en_id).map(|s| s.len()).unwrap_or(0);
                     if n_fns >= 2 || (self.d.keep_fires && n_fns >= 1) {
                         ports.push(ModVar {
@@ -2859,7 +2838,7 @@ impl Interp {
         }
         // input clock port: chase the parent's binding expression
         if let InstKind::User { clk_binds, .. } = &self.insts[inst].kind {
-            let pid = self.str_by_name.get(wire).map(|&i| i as usize);
+            let pid = self.d.str_id(wire).map(|i| i as usize);
             if let Some(pid) = pid {
                 if let Some((owner, e)) = clk_binds.get(&(pid as StrId)) {
                     let (owner, e) = (*owner, e.clone());
@@ -3162,17 +3141,26 @@ impl Interp {
         entries
     }
 
+    /// The instance an interned path names.
+    fn inst_of_path(&self, path: StrId) -> usize {
+        let p: &str = &self.d.strings[path as usize];
+        *self
+            .inst_by_path
+            .get(p)
+            .unwrap_or_else(|| panic!("unknown instance {p:?}"))
+    }
+
     /// Resolve qualified cross-inhibit pairs into the (later inst,
     /// later rule) -> earlier-CFs lookup for one interleaving.
     fn resolve_cross(
         &mut self,
-        pairs: &[(StrId, StrId)],
+        pairs: &[(ir::QualRule, ir::QualRule)],
     ) -> BTreeMap<(usize, StrId), Vec<(usize, StrId)>> {
         let mut cross: BTreeMap<(usize, StrId), Vec<(usize, StrId)>> =
             BTreeMap::new();
         for (earlier, later) in pairs {
-            let (e_inst, e_rule) = self.split_qual(*earlier);
-            let (l_inst, l_rule) = self.split_qual(*later);
+            let (e_inst, e_rule) = (self.inst_of_path(earlier.instance), earlier.rule);
+            let (l_inst, l_rule) = (self.inst_of_path(later.instance), later.rule);
             let e_mod = self.module_of(e_inst);
             let e_mir = self.mods[e_mod].ir;
             let e_ri = self.mods[e_mod].rules[&e_rule];
@@ -3765,7 +3753,7 @@ impl Interp {
                 let early: HashSet<(usize, StrId)> = comp
                     .early
                     .iter()
-                    .map(|q| self.split_qual(*q))
+                    .map(|q| (self.inst_of_path(q.instance), q.rule))
                     .collect();
                 let entries = self.resolve_entries(&comp.entries, comp.posedge, &early);
                 // cross-inhibit lookup: (later inst, later rule) -> earlier CFs
@@ -3777,10 +3765,7 @@ impl Interp {
                     .alts
                     .iter()
                     .map(|a| {
-                        let gpath = self.s(a.guard_inst).to_string();
-                        let gi = *self.inst_by_path.get(&gpath).unwrap_or_else(|| {
-                            panic!("unknown guard instance path {gpath:?}")
-                        });
+                        let gi = self.inst_of_path(a.guard_inst);
                         RAlt {
                             guard_inst: gi,
                             guard: a.guard.clone(),
@@ -4732,7 +4717,7 @@ impl Interp {
                         {
                             for mi in idxs {
                                 let (m, argv) = self.autofire[mi].clone();
-                                self.call_action(0, m, &argv);
+                                self.call_action(0, m, 0, &argv);
                             }
                         }
                     }
@@ -4813,7 +4798,7 @@ impl Interp {
                             {
                                 for mi in idxs {
                                     let (m, argv) = self.autofire[mi].clone();
-                                    self.call_action(0, m, &argv);
+                                    self.call_action(0, m, 0, &argv);
                                 }
                             }
                         }
@@ -5090,27 +5075,6 @@ impl Interp {
         if self.fe.fataled { 1 } else { 0 }
     }
 
-    /// "a.b.RL_r" -> (instance index of "a.b", rule StrId of "RL_r")
-    fn split_qual(&mut self, q: StrId) -> (usize, StrId) {
-        let s = self.s(q).to_string();
-        let (ipath, rname) = match s.rfind('.') {
-            Some(k) => (&s[..k], &s[k + 1..]),
-            None => ("", s.as_str()),
-        };
-        let inst = *self
-            .inst_by_path
-            .get(ipath)
-            .unwrap_or_else(|| panic!("unknown instance {ipath:?}"));
-        // find the StrId for the local rule name
-        let rid = self
-            .d
-            .strings
-            .iter()
-            .position(|x| x == rname)
-            .unwrap_or_else(|| panic!("unknown rule name {rname:?}"))
-            as StrId;
-        (inst, rid)
-    }
 }
 
 /// dollar_display's Target collects errors with push_front and prints
@@ -5465,7 +5429,7 @@ impl Interp {
         match kind {
             MethPortKind::En => {
                 let en = format!("EN_{}", self.s(method));
-                let id = self.str_by_name.get(&en).map(|&i| i as usize);
+                let id = self.d.str_id(&en).map(|i| i as usize);
                 let mut set = match (&self.insts[i].kind, id) {
                     (InstKind::User { latched, .. }, Some(id)) => {
                         latched.contains_key(&(id as StrId))
@@ -5535,7 +5499,7 @@ impl Interp {
                     if !self.mods[module].defs.contains_key(dn) {
                         let cf = format!("CAN_FIRE_{}", self.s(method));
                         if let Some(id) =
-                            self.str_by_name.get(&cf).map(|&i| i as usize)
+                            self.d.str_id(&cf).map(|i| i as usize)
                         {
                             if self.mods[module].defs.contains_key(&(id as StrId))
                             {

--- a/src/trs/crates/trs-interp/src/prim.rs
+++ b/src/trs/crates/trs-interp/src/prim.rs
@@ -148,9 +148,9 @@ pub trait Prim {
         None
     }
     /// Value-method call (pure read).
-    fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value;
+    fn value_method(&mut self, method: &str, port: u32, args: &[Value], now: u64) -> Value;
     /// Action-method call (mutates).
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64);
+    fn action_method(&mut self, method: &str, port: u32, args: &[Value], now: u64);
     /// ActionValue-method call.
     fn actionvalue_method(&mut self, method: &str, args: &[Value], now: u64) -> Value {
         let _ = (method, args, now);
@@ -787,10 +787,10 @@ impl Prim for Probe {
         let v = self.value.clone();
         vcd_flat_dump(w, dt, now, self.vcd_id, &v, &mut self.vcd_back);
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("Probe: unknown value method {method:?}")
     }
-    fn action_method(&mut self, _method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, _method: &str, _port: u32, args: &[Value], _now: u64) {
         if let Some(v) = args.first() {
             self.value = v.clone();
         }
@@ -802,10 +802,10 @@ impl Prim for Probe {
 struct ProbeWire;
 
 impl Prim for ProbeWire {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ProbeWire: unknown value method {method:?}")
     }
-    fn action_method(&mut self, _method: &str, _args: &[Value], _now: u64) {}
+    fn action_method(&mut self, _method: &str, _port: u32, _args: &[Value], _now: u64) {}
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
 }
 
@@ -815,13 +815,13 @@ struct ResetToBool {
 }
 
 impl Prim for ResetToBool {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "isAsserted" | "_read" | "read" => Value::from_u64(1, self.in_reset as u64),
             m => panic!("ResetToBool: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("ResetToBool: unknown action method {method:?}")
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
@@ -1189,7 +1189,7 @@ impl Prim for Counter {
         self.vcd_back = Some(back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         match method {
             "value" | "_read" => {
                 if self.get_saved_at() == now {
@@ -1201,7 +1201,7 @@ impl Prim for Counter {
             m => panic!("Counter: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         if self.suppressed() {
             return;
         }
@@ -1880,7 +1880,7 @@ impl Prim for RegFile {
         ks.sort_unstable();
         Some(ks)
     }
-    fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) -> Value {
         match method {
             "sub" => {
                 let a = args[0].as_u64();
@@ -1934,7 +1934,7 @@ impl Prim for RegFile {
             m => panic!("RegFile: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "upd" => {
                 let a = args[0].as_u64();
@@ -2137,7 +2137,7 @@ impl Prim for LatchCrossingReg {
         self.vcd_back = Some((self.d_latch.clone(), self.s_flop.clone()));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         match method {
             "read" | "_read" => self.s_flop.clone(),
             "crossed" => {
@@ -2154,7 +2154,7 @@ impl Prim for LatchCrossingReg {
             m => panic!("LatchCrossingReg: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "_write" => {
                 if !self.in_reset {
@@ -2230,7 +2230,7 @@ impl Prim for DualPortRam {
     fn class_name(&self) -> &'static str {
         "DualPortRam"
     }
-    fn value_method(&mut self, method: &str, args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) -> Value {
         match method {
             "read" | "sub" => {
                 let addr = args[0].as_u64();
@@ -2243,7 +2243,7 @@ impl Prim for DualPortRam {
             m => panic!("DualPortRam: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "upd" => {
                 let addr = args[0].as_u64();
@@ -2376,7 +2376,7 @@ impl Prim for Reg {
         vec![PrimSym { key: "", width: self.width, range: None }]
     }
     fn sym_read(&mut self, key: &str, now: u64) -> Option<Value> {
-        (key.is_empty()).then(|| self.value_method("read", &[], now))
+        (key.is_empty()).then(|| self.value_method("read", 0, &[], now))
     }
     fn vcd_defs(
         &mut self,
@@ -2398,7 +2398,7 @@ impl Prim for Reg {
         vcd_flat_dump(w, dt, now, self.vcd_id, &v, &mut self.vcd_back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         match method {
             "read" | "get" | "_read" => self.load(),
             // crossing read: a same-instant write is not yet visible
@@ -2419,7 +2419,7 @@ impl Prim for Reg {
             m => panic!("Reg: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "set" | "put" | "_write" => {
                 // sync-reset registers never suppress writes — the reset
@@ -2546,13 +2546,13 @@ impl RegAligned {
 }
 
 impl Prim for RegAligned {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "read" | "_read" => self.value.clone(),
             m => panic!("RegAligned: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "_write" => {
                 // METH__write (bs_prim_mod_reg.h:284): stage the value;
@@ -2705,7 +2705,7 @@ impl Prim for ConfigReg {
         vcd_flat_dump(w, dt, now, self.vcd_id, &v, &mut self.vcd_back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         self.refresh();
         match method {
             "read" | "get" => {
@@ -2718,7 +2718,7 @@ impl Prim for ConfigReg {
             m => panic!("ConfigReg: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "set" | "put" => {
                 if self.async_rst && self.suppress {
@@ -2941,14 +2941,14 @@ impl Prim for RWire {
         self.vcd_back = Some((written, self.value.clone()));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "whas" => Value::from_u64(1, self.get_valid() as u64),
             "wget" => self.get_value(),
             m => panic!("RWire: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             "wset" | "send" => {
                 if self.width > 0 {
@@ -3049,14 +3049,14 @@ impl Prim for BypassWire {
     fn class_name(&self) -> &'static str {
         "BypassWire"
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "wget" | "read" => self.get_value(),
             "whas" => Value::from_u64(1, 1),
             m => panic!("BypassWire: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             // zero-width wires (BypassWire0) are set with no argument
             "wset" | "write" => {
@@ -3099,6 +3099,11 @@ impl Prim for BypassWire {
 
 // ===============
 
+/// Ports a CReg has.  Five is the language's limit, not a modelling
+/// choice: `mkCReg` rejects more at elaboration (PreludeBSV.bsv).  The
+/// reference models the same five (`bs_prim_mod_reg.h`, `ArenaKind::CReg5`).
+const CREG_PORTS: usize = 5;
+
 /// CReg with up to 5 ports (bs_prim_mod_reg.h:817): sequential port
 /// writes are immediate; tick commits the registered view.
 struct CReg {
@@ -3139,9 +3144,9 @@ impl CReg {
             async_rst,
             suppress: false,
             slot: None,
-            write_val: (0..5).map(|_| Value::undet(width)).collect(),
-            did_write: vec![false; 5],
-            did_write_rec: vec![false; 5],
+            write_val: (0..CREG_PORTS).map(|_| Value::undet(width)).collect(),
+            did_write: vec![false; CREG_PORTS],
+            did_write_rec: vec![false; CREG_PORTS],
             read_val0: Value::undet(width),
             vcd_base: 0,
             vcd_back: None,
@@ -3215,11 +3220,11 @@ impl Prim for CReg {
         // bs_prim_mod_reg.h:989-1022: parent-scope alias shares Q_OUT_0's
         // id; per-port Q_OUT_i/EN_i/D_IN_i, all clock-backdated
         let bits = self.value.width;
-        let mut n = w.reserve_ids(3 * 5);
+        let mut n = w.reserve_ids(3 * CREG_PORTS as u32);
         self.vcd_base = n;
         w.write_def(n, name, bits);
         w.scope_start(name, None);
-        for i in 0..5 {
+        for i in 0..CREG_PORTS {
             w.set_clock(n, clk);
             w.write_def(n, &format!("Q_OUT_{i}"), bits);
             n += 1;
@@ -3244,9 +3249,9 @@ impl Prim for CReg {
         let bit = |b: bool| Value::from_u64(1, b as u64);
         let mut num = self.vcd_base;
         // chained Q_OUT values: port i sees earlier ports' writes
-        let mut qouts: Vec<Value> = Vec::with_capacity(5);
+        let mut qouts: Vec<Value> = Vec::with_capacity(CREG_PORTS);
         let mut tmp = self.read_val0.clone();
-        for i in 0..5 {
+        for i in 0..CREG_PORTS {
             qouts.push(tmp.clone());
             if self.did_write_rec[i] {
                 tmp = self.write_val[i].clone();
@@ -3254,7 +3259,7 @@ impl Prim for CReg {
         }
         match dt {
             D::Xs => {
-                for _ in 0..5 {
+                for _ in 0..CREG_PORTS {
                     w.write_x(num, bits, now);
                     num += 1;
                     w.write_x(num, 1, now);
@@ -3266,12 +3271,12 @@ impl Prim for CReg {
             D::Changes => {
                 let (bq, be, bd) = self.vcd_back.clone().unwrap_or_else(|| {
                     (
-                        (0..5).map(|_| Value::undet(bits)).collect(),
-                        vec![false; 5],
-                        (0..5).map(|_| Value::undet(bits)).collect(),
+                        (0..CREG_PORTS).map(|_| Value::undet(bits)).collect(),
+                        vec![false; CREG_PORTS],
+                        (0..CREG_PORTS).map(|_| Value::undet(bits)).collect(),
                     )
                 });
-                for i in 0..5 {
+                for i in 0..CREG_PORTS {
                     if qouts[i] != bq[i] {
                         w.write_val(num, &qouts[i], now);
                     }
@@ -3287,7 +3292,7 @@ impl Prim for CReg {
                 }
             }
             _ => {
-                for i in 0..5 {
+                for i in 0..CREG_PORTS {
                     w.write_val(num, &qouts[i], now);
                     num += 1;
                     w.write_val(num, &bit(self.did_write_rec[i]), now);
@@ -3301,28 +3306,21 @@ impl Prim for CReg {
             Some((qouts, self.did_write_rec.clone(), self.write_val.clone()));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
-        // portK__read returns the live value (port 0 sees the registered
-        // value at cycle start because nothing has written yet)
-        if method.starts_with("port") && method.ends_with("__read") {
-            self.load_val()
-        } else {
-            panic!("CReg: unknown value method {method:?}")
-        }
+    fn value_method(&mut self, _method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
+        // a CReg's only value method is a port read, and it returns the
+        // live value (port 0 sees the registered value at cycle start
+        // because nothing has written yet)
+        self.load_val()
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
-        if method.starts_with("port") && method.ends_with("__write") {
-            if !(self.async_rst && self.suppress) {
-                self.store_val(args[0].clone());
-                let i = method.as_bytes()[4].saturating_sub(b'0') as usize;
-                if i < 5 {
-                    self.did_write[i] = true;
-                    self.write_val[i] = args[0].clone();
-                }
-            }
-        } else {
-            panic!("CReg: unknown action method {method:?}")
+    fn action_method(&mut self, _method: &str, port: u32, args: &[Value], _now: u64) {
+        // ...and its only action method is a port write
+        if self.async_rst && self.suppress {
+            return;
         }
+        self.store_val(args[0].clone());
+        let i = port as usize;
+        self.did_write[i] = true;
+        self.write_val[i] = args[0].clone();
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, gate: bool) {
         if !gate { return; }
@@ -3330,7 +3328,7 @@ impl Prim for CReg {
         self.read_val0 = self.load_val_reg();
         let v = self.load_val();
         self.store_val_reg(v);
-        for i in 0..5 {
+        for i in 0..CREG_PORTS {
             self.did_write_rec[i] = self.did_write[i];
             self.did_write[i] = false;
         }
@@ -3829,7 +3827,7 @@ impl Prim for Fifo {
         self.vcd_back = Some(back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         self.refresh();
         match method {
             "first" => self.data[self.fst].clone(),
@@ -3858,7 +3856,7 @@ impl Prim for Fifo {
             m => panic!("FIFO: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         self.refresh();
         if method == "enq" && !self.zero_width {
             // saved for VCD display before suppress/guard checks
@@ -4021,10 +4019,10 @@ impl Prim for ClockGen {
         w.write_def(clk_vcd_id, "CLK_OUT", 1);
         w.scope_end();
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ClockGen: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("ClockGen: unknown action method {method:?}")
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
@@ -4165,7 +4163,7 @@ impl Prim for SyncBit {
         self.vcd_back = Some((self.d1.clone(), self.d2.clone(), ss));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "read" | "_read" => {
                 if self.two_stage {
@@ -4177,7 +4175,7 @@ impl Prim for SyncBit {
             m => panic!("SyncBit: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "send" | "write" | "_write" => {
                 if !self.in_reset {
@@ -4294,13 +4292,13 @@ impl Prim for SyncPulse {
             Some((cur[0].clone(), cur[1].clone(), cur[2].clone(), cur[3].clone()));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "pulse" | "read" | "_read" => self.d2.xor(&self.d_pulse, 1),
             m => panic!("SyncPulse: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) {
         match method {
             "send" => {
                 if !self.in_reset {
@@ -4570,14 +4568,14 @@ impl Prim for SyncHandshake {
         self.hs.vcd_dump(w, dt, now);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         match method {
             "pulse" | "read" | "_read" => Value::from_u64(1, self.hs.pulse(now) as u64),
             "RDY_send" => Value::from_u64(1, self.hs.rdy_send() as u64),
             m => panic!("SyncHandshake: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         match method {
             "send" => self.hs.send(),
             m => panic!("SyncHandshake: unknown action method {m:?}"),
@@ -4686,14 +4684,14 @@ impl Prim for SyncReg {
         self.hs.vcd_dump(w, dt, now);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "read" | "_read" => self.d_out.clone(),
             "RDY_write" => Value::from_u64(1, self.hs.rdy_send() as u64),
             m => panic!("SyncReg: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "write" | "_write" => {
                 self.data.write(args[0].clone(), now);
@@ -4839,10 +4837,10 @@ impl Prim for SyncReset {
         }
         self.vcd_back = Some((self.in_reset, self.count));
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("SyncReset: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("SyncReset: unknown action method {method:?}")
     }
     fn tick(&mut self, port: &str, _now: u64, _clk_val: bool, gate: bool) {
@@ -4872,10 +4870,10 @@ impl SyncReset0 {
 }
 
 impl Prim for SyncReset0 {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("SyncReset0: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("SyncReset0: unknown action method {method:?}")
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
@@ -4914,10 +4912,10 @@ impl Prim for InitialReset {
         w.scope_start(name, None);
         w.scope_end();
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("InitialReset: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("InitialReset: unknown action method {method:?}")
     }
     fn tick(&mut self, port: &str, _now: u64, _clk_val: bool, gate: bool) {
@@ -5016,13 +5014,13 @@ impl Prim for MakeReset {
         vcd_flat_dump(w, dt, now, self.vcd_id, &v, &mut self.vcd_back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "isAsserted" => Value::from_u64(1, (self.rst == 0) as u64),
             m => panic!("MakeReset: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) {
         match method {
             "assertReset" => {
                 if !self.in_reset {
@@ -5172,14 +5170,14 @@ impl Prim for MakeClock {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "getClockValue" => Value::from_u64(1, self.current_high as u64),
             "getGateCond" => Value::from_u64(1, self.new_gate as u64),
             m => panic!("MakeClock: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             "setClockValue" => {
                 if !self.in_reset {
@@ -5323,13 +5321,13 @@ impl Prim for ClockDivider {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "clockReady" => Value::from_u64(1, (self.cntr == self.transition - 1) as u64),
             m => panic!("ClockDiv: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("ClockDiv: unknown action method {method:?}")
     }
     fn tick(&mut self, port: &str, _now: u64, _clk_val: bool, gate: bool) {
@@ -5472,13 +5470,13 @@ impl Prim for ClockInverter {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "clockReady" => Value::from_u64(1, 1),
             m => panic!("ClockInverter: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("ClockInverter: unknown action method {method:?}")
     }
     fn tick(&mut self, port: &str, _now: u64, clk_val: bool, gate: bool) {
@@ -5723,7 +5721,7 @@ impl SyncFifo {
 }
 
 impl Prim for SyncFifo {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "notEmpty" | "dNotEmpty" | "RDY_first" | "RDY_deq" => {
                 Value::from_u64(1, self.meth_not_empty() as u64)
@@ -5739,7 +5737,7 @@ impl Prim for SyncFifo {
             m => panic!("SyncFIFO: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "enq" => {
                 if self.width > 0 {
@@ -6305,7 +6303,7 @@ impl Prim for Bram {
         self.vcd_back = Some((back_a, back_b));
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         let read = |port_b: bool| -> Value {
             if self.slot.is_some() {
                 let w = self.vwords();
@@ -6324,7 +6322,7 @@ impl Prim for Bram {
             m => panic!("BRAM: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "put" | "a_put" => {
                 let wens = args[0].clone();
@@ -6519,10 +6517,10 @@ impl ResetMux {
 }
 
 impl Prim for ResetMux {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ResetMux: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             "select" => self.new_sel_a = args[0].as_bool(),
             m => panic!("ResetMux: unknown action method {m:?}"),
@@ -6582,10 +6580,10 @@ impl ResetEither {
 }
 
 impl Prim for ResetEither {
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ResetEither: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, _args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) {
         panic!("ResetEither: unknown action method {method:?}")
     }
     fn tick(&mut self, _port: &str, _now: u64, _clk_val: bool, _gate: bool) {}
@@ -6677,13 +6675,13 @@ impl Prim for GatedClock {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         match method {
             "getGateCond" => Value::from_u64(1, self.reg as u64),
             m => panic!("GatedClock: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             "setGateCond" => {
                 if !self.suppress {
@@ -6793,7 +6791,7 @@ impl Prim for RegTwo {
         vcd_flat_dump(w, dt, now, self.vcd_id, &v, &mut self.vcd_back);
     }
 
-    fn value_method(&mut self, method: &str, _args: &[Value], now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], now: u64) -> Value {
         match method {
             "get" | "read" => {
                 if self.written == now {
@@ -6805,7 +6803,7 @@ impl Prim for RegTwo {
             m => panic!("RegTwo: unknown value method {m:?}"),
         }
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         if self.async_rst && self.suppress {
             return;
         }
@@ -6888,10 +6886,10 @@ impl Prim for ClockMux {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ClockMux: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, args: &[Value], _now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], _now: u64) {
         match method {
             "select" => {
                 self.sel_a = args[0].as_bool();
@@ -7002,10 +7000,10 @@ impl Prim for ClockSelect {
     fn gate_out(&self) -> bool {
         self.gate_out
     }
-    fn value_method(&mut self, method: &str, _args: &[Value], _now: u64) -> Value {
+    fn value_method(&mut self, method: &str, _port: u32, _args: &[Value], _now: u64) -> Value {
         panic!("ClockSelect: unknown value method {method:?}")
     }
-    fn action_method(&mut self, method: &str, args: &[Value], now: u64) {
+    fn action_method(&mut self, method: &str, _port: u32, args: &[Value], now: u64) {
         match method {
             "select" => {
                 self.last_now = now;

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -557,7 +557,7 @@ unsafe extern "C" fn runcore_prim_cb(
                 .get(pc.method as usize)
                 .expect("prim method id outside the design string table"),
         );
-        p.action_method(name, &argv, rc.now);
+        p.action_method(name, pc.port, &argv, rc.now);
     } else {
         let name: &str = table_str(
             &rc.buf,
@@ -565,7 +565,7 @@ unsafe extern "C" fn runcore_prim_cb(
                 .get(pc.method as usize)
                 .expect("prim method id outside the design string table"),
         );
-        let v = p.value_method(name, &argv, rc.now);
+        let v = p.value_method(name, pc.port, &argv, rc.now);
         let words = ((pc.ret_width.max(1) as usize) + 63) / 64;
         let dst = std::slice::from_raw_parts_mut(out, words);
         for (i, d) in dst.iter_mut().enumerate() {

--- a/src/trs/crates/trs-interp/src/topbind.rs
+++ b/src/trs/crates/trs-interp/src/topbind.rs
@@ -242,11 +242,11 @@ pub(crate) fn resolve(
             }
         }
         // always_enabled implies RDY constant true: assert it at arm
-        // time via the sibling RDY_<m> method (what check_rdy
-        // evaluates; absent = constant ready).  The result is
-        // typically a def reference to a constant def — chase the
-        // chain rather than pattern-matching one shape.
-        if let Some(&rdy_id) = sidx.get(format!("RDY_{}", s(m.name)).as_str()) {
+        // time via the sibling RDY method (what check_rdy evaluates;
+        // absent = constant ready).  The result is typically a def
+        // reference to a constant def — chase the chain rather than
+        // pattern-matching one shape.
+        if let Some(rdy_id) = m.rdy {
             if let Some(rm) = top.methods.iter().find(|x| x.name == rdy_id) {
                 let const_true = match &rm.result {
                     None => true,

--- a/src/trs/crates/trs-interp/src/topbind.rs
+++ b/src/trs/crates/trs-interp/src/topbind.rs
@@ -97,8 +97,17 @@ pub(crate) struct ResolvedBinds {
     pub consumed_plus: Vec<String>,
 }
 
-fn str_id(d: &ir::Design, s: &str) -> Option<ir::StrId> {
-    d.strings.iter().position(|x| x == s).map(|i| i as ir::StrId)
+/// name -> interned id, the other direction from `Design::strings`.
+/// Built once per resolve: the callers ask for derived names
+/// (`RDY_<m>`, `EN_<m>`) once per top-level method, and scanning the
+/// table for each is O(methods * strings) for an answer a map gives
+/// directly.
+fn str_index(d: &ir::Design) -> std::collections::HashMap<&str, ir::StrId> {
+    d.strings
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.as_str(), i as ir::StrId))
+        .collect()
 }
 
 /// Resolve an expression to a constant u64 by chasing def references
@@ -204,6 +213,7 @@ pub(crate) fn resolve(
         .find(|m| m.name == d.top)
         .ok_or_else(|| "top module not found".to_string())?;
     let s = |id: ir::StrId| d.strings[id as usize].as_str();
+    let sidx = str_index(d);
 
     // ---- bindable surface ----
     // top-level arguments/parameters: the module's MethodArg inputs
@@ -236,7 +246,7 @@ pub(crate) fn resolve(
         // evaluates; absent = constant ready).  The result is
         // typically a def reference to a constant def — chase the
         // chain rather than pattern-matching one shape.
-        if let Some(rdy_id) = str_id(d, &format!("RDY_{}", s(m.name))) {
+        if let Some(&rdy_id) = sidx.get(format!("RDY_{}", s(m.name)).as_str()) {
             if let Some(rm) = top.methods.iter().find(|x| x.name == rdy_id) {
                 let const_true = match &rm.result {
                     None => true,
@@ -400,7 +410,7 @@ pub(crate) fn resolve(
     // EN_<m> reads constant 1 for auto-fired methods (tied high)
     let mut af: Vec<(ir::StrId, Vec<Value>)> = Vec::new();
     for (mname, args) in &autofire {
-        if let Some(en) = str_id(d, &format!("EN_{}", s(*mname))) {
+        if let Some(&en) = sidx.get(format!("EN_{}", s(*mname)).as_str()) {
             params.push((en, Value::from_u64(1, 1)));
         }
         let argv: Vec<Value> = args

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -26,7 +26,7 @@ pub use schedule::{
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 4;
+pub const BIR_VERSION: u32 = 5;
 
 /// magic(8) | BIR_VERSION le32(4) = 12 bytes, ahead of the CBOR body.
 ///
@@ -228,6 +228,13 @@ pub struct Design {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
     pub name: StrId,
+    /// name -> index over `defs` and `methods`, so a reference resolves
+    /// without a scan.  Read them through `def`/`def_idx`/`method_idx`.
+    /// Derived, not serialized: the decode paths build them.
+    #[serde(skip)]
+    def_ix: HashMap<StrId, usize>,
+    #[serde(skip)]
+    method_ix: HashMap<StrId, usize>,
     /// Hash of the module's exported content, for the object cache.
     pub content_hash: [u8; 32],
     pub clock_domains: Vec<ClockDomain>,
@@ -405,6 +412,24 @@ pub struct Method {
     /// The def this method's function writes to record that it fired
     /// (cvtIFace wf_stmts).  Action and ActionValue methods only.
     pub will_fire: Option<StrId>,
+}
+
+impl Module {
+    /// Index of a def by name, or None if this module has no such def.
+    pub fn def_idx(&self, name: StrId) -> Option<usize> {
+        self.def_ix.get(&name).copied()
+    }
+
+    /// A def by name, or None if this module has no such def.
+    pub fn def(&self, name: StrId) -> Option<&Def> {
+        self.def_idx(name).map(|i| &self.defs[i])
+    }
+
+    /// Index of a method by name, or None if this module has no such
+    /// method.
+    pub fn method_idx(&self, name: StrId) -> Option<usize> {
+        self.method_ix.get(&name).copied()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -599,6 +624,12 @@ impl Design {
             .enumerate()
             .map(|(i, s)| (s.clone(), i as StrId))
             .collect();
+        for m in &mut self.modules {
+            m.def_ix =
+                m.defs.iter().enumerate().map(|(k, d)| (d.name, k)).collect();
+            m.method_ix =
+                m.methods.iter().enumerate().map(|(k, x)| (x.name, k)).collect();
+        }
     }
 
     /// The id of an interned string, or None if the design has no such
@@ -632,6 +663,8 @@ mod tests {
             top: 0,
             modules: vec![Module {
                 name: 0,
+                def_ix: HashMap::new(),
+                method_ix: HashMap::new(),
                 content_hash: [0; 32],
                 clock_domains: vec![],
                 resets: vec![],

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -22,7 +22,17 @@ pub use schedule::{Composition, ModuleSchedule, SchedAlt, SchedNode, Schedule, S
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 2;
+pub const BIR_VERSION: u32 = 3;
+
+/// magic(8) | BIR_VERSION le32(4) = 12 bytes, ahead of the CBOR body.
+///
+/// The version has to be readable without decoding the body, or it
+/// cannot do its job: a schema change makes the body fail to
+/// deserialize, and a reader that learns the version from inside the
+/// body reports that failure instead of the mismatch that explains it.
+/// The last magic byte is the header's own format.
+const BIR_MAGIC: &[u8; 8] = b"TRSBIR\0\x01";
+const BIR_HEADER: usize = 12;
 
 /// Snapshot sidecar magic (`<base>.birsnap`, see `Design::snap_encode`).
 /// The trailing byte is the HEADER format; \x02 added the layout rev
@@ -179,9 +189,14 @@ impl<'de, T: serde::de::DeserializeOwned> Deserialize<'de> for Lazy<T> {
 /// A whole linked design: the top module and every module in its hierarchy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Design {
-    pub version: u32,
     /// String table; all `StrId`s index into this.
     pub strings: Vec<String>,
+    /// Whether the design calls a wave-recording task ($dumpvars and
+    /// family).  A fact recorded by the exporter, where rule bodies are
+    /// plain data: the runtime sees them deferred behind `Lazy`, and the
+    /// string table cannot distinguish a call to `$dumpvars` from a
+    /// string literal equal to it.
+    pub uses_wave_tasks: bool,
     pub top: StrId,
     pub modules: Vec<Module>,
     /// Hierarchical instance path -> module name (`ssys_instmap` analogue).
@@ -536,23 +551,31 @@ impl Design {
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Design, DecodeError> {
-        // deep expression trees (long fold chains) exceed ciborium's
-        // default recursion limit of 128
-        let design: Design =
-            ciborium::de::from_reader_with_recursion_limit(bytes, 65536)
-                .map_err(|e| DecodeError::Cbor(e.to_string()))?;
-        if design.version != BIR_VERSION {
+        // header first, and completely: everything below assumes a body
+        // this reader understands
+        if bytes.len() < BIR_HEADER || &bytes[..8] != BIR_MAGIC {
+            return Err(DecodeError::Cbor("not a .bir file".to_string()));
+        }
+        let found = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        if found != BIR_VERSION {
             return Err(DecodeError::VersionMismatch {
-                found: design.version,
+                found,
                 expected: BIR_VERSION,
             });
         }
+        // deep expression trees (long fold chains) exceed ciborium's
+        // default recursion limit of 128
+        let design: Design =
+            ciborium::de::from_reader_with_recursion_limit(&bytes[BIR_HEADER..], 65536)
+                .map_err(|e| DecodeError::Cbor(e.to_string()))?;
         verify::verify(&design).map_err(DecodeError::Invalid)?;
         Ok(design)
     }
 
     pub fn encode(&self) -> Vec<u8> {
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(BIR_HEADER);
+        out.extend_from_slice(BIR_MAGIC);
+        out.extend_from_slice(&BIR_VERSION.to_le_bytes());
         ciborium::into_writer(self, &mut out).expect("CBOR encoding cannot fail");
         out
     }
@@ -568,8 +591,8 @@ mod tests {
 
     fn tiny_design() -> Design {
         Design {
-            version: BIR_VERSION,
             strings: vec!["mkTop".into()],
+            uses_wave_tasks: false,
             top: 0,
             modules: vec![Module {
                 name: 0,
@@ -606,9 +629,9 @@ mod tests {
 
     #[test]
     fn version_check() {
-        let mut d = tiny_design();
-        d.version = BIR_VERSION + 1;
-        let bytes = d.encode();
+        let d = tiny_design();
+        let mut bytes = d.encode();
+        bytes[8..12].copy_from_slice(&(BIR_VERSION + 1).to_le_bytes());
         assert!(matches!(
             Design::decode(&bytes),
             Err(DecodeError::VersionMismatch { .. })

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -15,14 +15,18 @@ pub mod expr;
 pub mod schedule;
 pub mod verify;
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 pub use expr::{Action, Expr, PrimOp, Stmt};
-pub use schedule::{Composition, ModuleSchedule, SchedAlt, SchedNode, Schedule, Segment};
+pub use schedule::{
+    Composition, ModuleSchedule, QualRule, SchedAlt, SchedNode, Schedule, Segment,
+};
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 3;
+pub const BIR_VERSION: u32 = 4;
 
 /// magic(8) | BIR_VERSION le32(4) = 12 bytes, ahead of the CBOR body.
 ///
@@ -48,7 +52,7 @@ const SNAP_MAGIC: &[u8; 8] = b"TRSSNAP\x02";
 /// this with every such change (the AOT twin of this rule is
 /// `AOT_LAYOUT_REV` in trs-codegen); a stale rev makes readers fall
 /// back to the .bir instead of misdecoding.
-const SNAP_LAYOUT_REV: u32 = 3;
+const SNAP_LAYOUT_REV: u32 = 4;
 
 /// magic(8) | BIR_VERSION le32(4) | SNAP_LAYOUT_REV le32(4) |
 /// bir_hash le64(8) | payload fnv1a le64(8) = 32 bytes.
@@ -191,6 +195,11 @@ impl<'de, T: serde::de::DeserializeOwned> Deserialize<'de> for Lazy<T> {
 pub struct Design {
     /// String table; all `StrId`s index into this.
     pub strings: Vec<String>,
+    /// Reverse of `strings`, so a name resolves to its id without a
+    /// scan.  Read it through `str_id`.  Derived, not serialized: the
+    /// decode paths build it.
+    #[serde(skip)]
+    str_ids: HashMap<String, StrId>,
     /// Whether the design calls a wave-recording task ($dumpvars and
     /// family).  A fact recorded by the exporter, where rule bodies are
     /// plain data: the runtime sees them deferred behind `Lazy`, and the
@@ -390,6 +399,12 @@ pub struct Method {
     /// backend's cvtIFace check_rdy wrapper).
     #[serde(default)]
     pub always_enabled: bool,
+    /// The sibling method carrying this one's ready signal, when the
+    /// module exports one; None = constant ready.
+    pub rdy: Option<StrId>,
+    /// The def this method's function writes to record that it fired
+    /// (cvtIFace wf_stmts).  Action and ActionValue methods only.
+    pub will_fire: Option<StrId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -544,8 +559,9 @@ impl Design {
         SNAP_BLOB
             .with(|b| *b.borrow_mut() = Some(std::sync::Arc::new(blob.to_vec())));
         // caller's thread on purpose — see snap_encode's NOTE
-        let d: Design = bincode::deserialize(design).ok()?;
+        let mut d: Design = bincode::deserialize(design).ok()?;
         drop(_g);
+        d.index_strings();
         verify::verify(&d).ok()?;
         Some(d)
     }
@@ -565,11 +581,30 @@ impl Design {
         }
         // deep expression trees (long fold chains) exceed ciborium's
         // default recursion limit of 128
-        let design: Design =
+        let mut design: Design =
             ciborium::de::from_reader_with_recursion_limit(&bytes[BIR_HEADER..], 65536)
                 .map_err(|e| DecodeError::Cbor(e.to_string()))?;
+        design.index_strings();
         verify::verify(&design).map_err(DecodeError::Invalid)?;
         Ok(design)
+    }
+
+    /// Build `str_ids` from `strings`.  Every path that produces a
+    /// Design must call this — the field is derived, so neither the
+    /// CBOR body nor the snapshot image carries it.
+    fn index_strings(&mut self) {
+        self.str_ids = self
+            .strings
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.clone(), i as StrId))
+            .collect();
+    }
+
+    /// The id of an interned string, or None if the design has no such
+    /// string.
+    pub fn str_id(&self, name: &str) -> Option<StrId> {
+        self.str_ids.get(name).copied()
     }
 
     pub fn encode(&self) -> Vec<u8> {
@@ -592,6 +627,7 @@ mod tests {
     fn tiny_design() -> Design {
         Design {
             strings: vec!["mkTop".into()],
+            str_ids: HashMap::new(),
             uses_wave_tasks: false,
             top: 0,
             modules: vec![Module {

--- a/src/trs/crates/trs-ir/src/schedule.rs
+++ b/src/trs/crates/trs-ir/src/schedule.rs
@@ -84,9 +84,18 @@ pub struct TickCall {
     pub port: StrId,
 }
 
+/// A rule named from the design root.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct QualRule {
+    /// Interned instance path ("" = the top module).
+    pub instance: StrId,
+    /// The rule's module-local name.
+    pub rule: StrId,
+}
+
 /// The per-link, per-(clock, edge) interleaving of instance segments —
 /// what the top-level edge function executes.  Instance paths are interned
-/// dotted strings ("a.b.c"); rule paths are "a.b.RL_r".
+/// dotted strings ("a.b.c").
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Composition {
     /// Interned name of this composition's canonical clock oscillator.
@@ -98,12 +107,12 @@ pub struct Composition {
     pub entries: Vec<CompositionEntry>,
     /// Cross-instance tick order, producers before consumers.
     pub ticks: Vec<QualifiedTick>,
-    /// Clock-crossing rules run in the after-edge function (qualified).
-    pub early: Vec<StrId>,
-    /// Cross-module disjoint pairs (qualified rule paths) whose ME
-    /// inhibitors depend on this composed order: the first rule's CAN_FIRE
-    /// inhibits the second (which executes later in this composition).
-    pub cross_inhibits: Vec<(StrId, StrId)>,
+    /// Clock-crossing rules run in the after-edge function.
+    pub early: Vec<QualRule>,
+    /// Cross-module disjoint pairs whose ME inhibitors depend on this
+    /// composed order: the first rule's CAN_FIRE inhibits the second
+    /// (which executes later in this composition).
+    pub cross_inhibits: Vec<(QualRule, QualRule)>,
     /// Dynamic scheduling (bsc G0100-class designs): guarded alternative
     /// interleavings for this (clock, edge).  The per-cycle execution
     /// order of rules whose cross-boundary ordering constraint is
@@ -136,7 +145,7 @@ pub struct SchedAlt {
     pub entries: Vec<CompositionEntry>,
     /// Order-derived ME inhibitors for THIS interleaving (the base
     /// `cross_inhibits` encode the base order and do not apply).
-    pub cross_inhibits: Vec<(StrId, StrId)>,
+    pub cross_inhibits: Vec<(QualRule, QualRule)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/trs/tests/vcd/CRegVcd.bsv
+++ b/src/trs/tests/vcd/CRegVcd.bsv
@@ -1,0 +1,28 @@
+// Per-port CReg VCD surface: the reference records Q_OUT_i/EN_i/D_IN_i
+// for each port, so a wrong port index shows up as a misplaced write
+// even though the chained value the design reads stays correct.
+(* synthesize *)
+module sysCRegVcd();
+   Reg#(UInt#(8)) cyc <- mkReg(0);
+   Array#(Reg#(Bit#(8))) cr <- mkCReg(3, 0);
+   Reg#(Bit#(8)) sink <- mkReg(0);
+
+   rule tick;
+      cyc <= cyc + 1;
+      if (cyc == 8) $finish(0);
+   endrule
+
+   // each port writes a distinct value, so the per-port D_IN traces
+   // are distinguishable
+   rule w0 (pack(cyc)[0] == 0);
+      cr[0] <= cr[0] + 1;
+   endrule
+
+   rule w1 (pack(cyc)[1] == 0);
+      cr[1] <= cr[1] + 16;
+   endrule
+
+   rule readout;
+      sink <= cr[2];
+   endrule
+endmodule

--- a/src/trs/tests/vcd/run.sh
+++ b/src/trs/tests/vcd/run.sh
@@ -52,6 +52,7 @@ check SyncB sysSyncB -m 20
 check SyncHR sysSyncHR -m 22
 check BramVcd sysBramVcd -m 25
 check CDiv sysCDiv -m 25
+check CRegVcd sysCRegVcd -m 12
 # $finish edge boundary: the reference DROPS the finish instant's
 # buffered changes at shutdown (vcd.cxx flush_changes early-return
 # at t==now) — the post-finish state writes must NOT appear

--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -64,7 +64,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 2
+birVersion = 3
 
 -- ===============
 -- String interning
@@ -141,10 +141,24 @@ encStr = C.encodeString . T.pack
 -- SimSystem -> BIR
 
 -- | Encode a 'SimSystem' as a BIR design document.
+-- | magic(8) + BIR_VERSION little-endian(4), ahead of the CBOR body.
+--
+-- A reader has to settle the version before it decodes anything: a
+-- schema change makes the body fail to deserialize, and a version
+-- carried inside the body can only be reported after that failure has
+-- already happened.  The last magic byte is the header's own format.
+-- Mirrors BIR_MAGIC / BIR_HEADER in trs-ir.
+birHeader :: L.ByteString
+birHeader = L.pack (magic ++ leWord32 birVersion)
+  where
+    magic = [0x54, 0x52, 0x53, 0x42, 0x49, 0x52, 0x00, 0x01]  -- "TRSBIR\0\1"
+    leWord32 w = [ fromIntegral ((w `shiftR` k) .&. 0xff)
+                 | k <- [0, 8, 16, 24] ]
+
 simSystemToBir :: Bool -> M.Map String (S.Set AId) -> SimSystem
                -> L.ByteString
 simSystemToBir keepF symMap ssys =
-    CW.toLazyByteString (encDesign keepF symMap ssys)
+    birHeader <> CW.toLazyByteString (encDesign keepF symMap ssys)
 
 -- | Write the design's .bir file.
 writeBirFile :: FilePath -> Bool -> M.Map String (S.Set AId) -> SimSystem
@@ -185,8 +199,7 @@ encDesign keepF symMap ssys =
           clkId <- traverse str (ssys_default_clk ssys)
           rstId <- traverse str (ssys_default_rst ssys)
           return
-            [ ("version", encW32 birVersion)
-            , ("strings", mempty)   -- placeholder, replaced below
+            [ ("strings", mempty)   -- placeholder, replaced below
             , ("top", encW32 topId)
             , ("modules", encList modsEnc)
             , ("instance_map", encList instEnc)
@@ -195,6 +208,7 @@ encDesign keepF symMap ssys =
             , ("default_clock", encMaybe encW32 clkId)
             , ("default_reset", encMaybe encW32 rstId)
             , ("keep_fires", encBool keepF)
+            , ("uses_wave_tasks", encBool (designUsesWaveTasks pkgs))
             ]
 
         (fields, finalTbl) = runState action emptyStrTable
@@ -229,6 +243,32 @@ data ModSchedInfo = ModSchedInfo
 nodeKey :: SchedNode -> String
 nodeKey (Sched i) = "S:" ++ getIdBaseString i
 nodeKey (Exec i) = "E:" ++ getIdBaseString i
+
+-- | The wave-recording system tasks, as the trs runtime dispatches them.
+waveTaskNames :: S.Set String
+waveTaskNames = S.fromList
+    [ "$dumpfile", "$dumpvars", "$dumpon", "$dumpoff"
+    , "$dumpall", "$dumplimit", "$dumpflush" ]
+
+-- | The name a task-bearing action calls, if it is one.
+taskNameOf :: AAction -> Maybe String
+taskNameOf (AFCall { afcall_fun = f }) = Just f
+taskNameOf (ATaskAction { ataskact_fun = f }) = Just f
+taskNameOf _ = Nothing
+
+-- | Does this design record waveforms?
+--
+-- The runtime cannot answer this for itself: rule bodies reach it
+-- deferred, and the string table it could search holds every interned
+-- string, so a $display of the text "$dumpvars" reads the same as a
+-- call to it.  Here the actions are plain data and the question is
+-- exact.
+designUsesWaveTasks :: [SimPackage] -> Bool
+designUsesWaveTasks pkgs = or
+    [ maybe False (`S.member` waveTaskNames) (taskNameOf a)
+    | p <- pkgs
+    , r <- sp_rules p ++ concatMap aIfaceRules (sp_interface p)
+    , a <- arule_actions r ]
 
 analyzeModule :: S.Set String -> SimPackage -> ModSchedInfo
 analyzeModule pkgNames pkg =

--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -38,12 +38,13 @@ import Data.Word (Word32)
 import qualified Codec.CBOR.Encoding as C
 import qualified Codec.CBOR.Write as CW
 
+import Data.Char (isDigit)
 import Data.List (foldl', nub, sortBy)
 import Data.Maybe (mapMaybe, isJust)
 
 import ErrorUtil (internalError)
 import Id (Id, getIdBaseString, getIdQualString, isSignedId,
-           mkIdCanFire, mkIdWillFire, cmpIdByName)
+           mkIdCanFire, mkIdWillFire, mkRdyId, cmpIdByName)
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
@@ -64,7 +65,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 3
+birVersion = 4
 
 -- ===============
 -- String interning
@@ -555,15 +556,21 @@ encComposition instToMod msis topGates ss = do
             -- composed order is instance-specific.
             composedNodes =
                 [ (i, node) | (i, ds) <- entries, node <- segNodes i ds ]
+            -- `seen` keys on the joined path because that is how the
+            -- disjointness map is keyed, and carries the (instance,
+            -- rule) split the pairs are emitted as
             stepME (seen, acc) (i, Exec n) =
-                (S.insert (qp i (getIdBaseString n)) seen, acc)
+                (M.insert (qp i (getIdBaseString n)) (i, getIdBaseString n) seen,
+                 acc)
             stepME (seen, acc) (i, Sched n) =
-                let q = qp i (getIdBaseString n)
-                    inh = S.intersection (M.findWithDefault S.empty q disjQ) seen
+                let base = getIdBaseString n
+                    q = qp i base
+                    inh = M.restrictKeys seen
+                            (M.findWithDefault S.empty q disjQ)
                 -- Chunk-accumulate and concat once, so the fold stays
                 -- linear in the number of emitted pairs.
-                in  (seen, [ (d, q) | d <- S.toList inh ] : acc)
-            crossPairs = concat (reverse (snd (foldl' stepME (S.empty, []) composedNodes)))
+                in  (seen, [ (d, (i, base)) | d <- M.elems inh ] : acc)
+            crossPairs = concat (reverse (snd (foldl' stepME (M.empty, []) composedNodes)))
           in
             if dups
             then internalError
@@ -668,7 +675,11 @@ encComposition instToMod msis topGates ss = do
                 , ("domain", encW32 (fromIntegral dom))
                 , ("segment", encW32 (fromIntegral seg))
                 ]
-            encCrossPair (a, b) = encPair <$> strE a <*> strE b
+            encQualRule (ipath, rname) = do
+              iE <- strE ipath
+              rE <- strE rname
+              return $ encStruct [ ("instance", iE), ("rule", rE) ]
+            encCrossPair (a, b) = encPair <$> encQualRule a <*> encQualRule b
         entriesEnc <- mapM encEntry entries
         let encTick (inst, prim, port, rst, gate) = do
               iE <- strE inst
@@ -690,7 +701,8 @@ encComposition instToMod msis topGates ss = do
                 , ("reset", encBool rst), ("gate", gateE) ]
         ticksEnc <- mapM encTick ticks
         negTicksEnc <- mapM encTick neg_ticks
-        earlyEnc <- mapM (strE . qualPath) (ss_early_rules ss)
+        earlyEnc <- mapM (\i -> encQualRule (getIdQualString i, getIdBaseString i))
+                         (ss_early_rules ss)
         crossEnc <- mapM encCrossPair crossPairs
         altsEnc <- mapM (\(gpath, g, (aentries, across)) -> do
                            giE <- strE gpath
@@ -769,7 +781,16 @@ encModule pkgNames msi symSet pkg = do
                   , not (M.member (adef_objid d) (sp_local_defs pkg)) ]
     defsEnc <- mapM (encDef symSet) (M.elems (sp_local_defs pkg) ++ av_defs)
     rulesEnc <- mapM (encRule msi pkg) (sp_rules pkg)
-    methodsEnc <- concat <$> mapM (encMethod pkg) (sp_interface pkg)
+    -- a method's sibling RDY method and WILL_FIRE def are relations the
+    -- module's own tables settle; naming them here spares the runtime
+    -- rebuilding them from name text
+    let sibs = Siblings
+          { sibIfc = S.fromList (map (getIdBaseString . aif_name)
+                                     (sp_interface pkg))
+          , sibDefs = S.fromList (map (getIdBaseString . adef_objid)
+                                      (M.elems (sp_local_defs pkg) ++ av_defs))
+          }
+    methodsEnc <- concat <$> mapM (encMethod sibs pkg) (sp_interface pkg)
     schedEnc <- encSchedule msi pkg
     -- interface output clocks: external port name -> the internal osc
     -- wire being re-exported (constant = noClock, never ticks)
@@ -1124,31 +1145,50 @@ encRule msi pkg r = do
       , ("me_inhibits", encList inhibitsEnc)
       ]
 
+-- The module-local name tables a method's sibling references resolve
+-- against: its interface entries and its defs.
+data Siblings = Siblings { sibIfc :: S.Set String, sibDefs :: S.Set String }
+
+-- The sibling RDY method and WILL_FIRE def of a method, each named only
+-- when the module actually has one.  Only a method with actions has a
+-- WILL_FIRE def (cvtIFace wf_stmts).
+encSiblings :: Siblings -> Id -> Bool -> EncM (C.Encoding, C.Encoding)
+encSiblings sibs name hasActions = do
+    let present set i =
+            if getIdBaseString i `S.member` set then Just i else Nothing
+    rdyEnc <- traverse idE (present (sibIfc sibs) (mkRdyId name))
+    wfEnc <- traverse idE
+               (if hasActions
+                then present (sibDefs sibs) (mkIdWillFire name)
+                else Nothing)
+    return (encMaybe id rdyEnc, encMaybe id wfEnc)
+
 -- Interface methods.  Clock/reset/inout interface entries carry no
 -- executable content (they are in the clock/reset lists); skip them.
-encMethod :: SimPackage -> AIFace -> EncM [C.Encoding]
-encMethod pkg (AIDef name inputs props pred_ (ADef _ t e _) _ _) = do
-    m <- encMethodStruct pkg name "Value" (concat inputs) (Just pred_) [] (Just (t, e))
+encMethod :: Siblings -> SimPackage -> AIFace -> EncM [C.Encoding]
+encMethod sibs pkg (AIDef name inputs props pred_ (ADef _ t e _) _ _) = do
+    m <- encMethodStruct sibs pkg name "Value" (concat inputs) (Just pred_) [] (Just (t, e))
                          props
     return [m]
-encMethod pkg (AIAction inputs props pred_ name body _) = do
-    m <- encMethodStruct pkg name "Action" (concat inputs) (Just pred_)
+encMethod sibs pkg (AIAction inputs props pred_ name body _) = do
+    m <- encMethodStruct sibs pkg name "Action" (concat inputs) (Just pred_)
                          (concatMap arule_actions body) Nothing props
     return [m]
-encMethod pkg (AIActionValue inputs props pred_ name body retdef _) = do
-    m <- encMethodStructAV pkg name (concat inputs) (Just pred_)
+encMethod sibs pkg (AIActionValue inputs props pred_ name body retdef _) = do
+    m <- encMethodStructAV sibs pkg name (concat inputs) (Just pred_)
                            (concatMap arule_actions body) retdef props
     return [m]
-encMethod _ (AIClock {}) = return []
-encMethod _ (AIReset {}) = return []
-encMethod _ (AIInout {}) = return []
+encMethod _ _ (AIClock {}) = return []
+encMethod _ _ (AIReset {}) = return []
+encMethod _ _ (AIInout {}) = return []
 
 -- ActionValue methods: the return def is linearized with the body and
 -- the result is a reference to it.
-encMethodStructAV :: SimPackage -> Id -> [AInput] -> Maybe APred
+encMethodStructAV :: Siblings -> SimPackage -> Id -> [AInput] -> Maybe APred
                   -> [AAction] -> ADef -> WireProps -> EncM C.Encoding
-encMethodStructAV pkg name inputs mpred body retdef props = do
+encMethodStructAV sibs pkg name inputs mpred body retdef props = do
     nameId <- idE name
+    (rdyEnc, wfEnc) <- encSiblings sibs name True
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
     readyEnc <- traverse encExpr mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
@@ -1167,13 +1207,16 @@ encMethodStructAV pkg name inputs mpred body retdef props = do
       , ("result", resultEnc)
       , ("clock_domain", encW32 dom)
       , ("always_enabled", encBool (isAlwaysEn (sp_pps pkg) name))
+      , ("rdy", rdyEnc)
+      , ("will_fire", wfEnc)
       ]
 
-encMethodStruct :: SimPackage -> Id -> String -> [AInput] -> Maybe APred
-                -> [AAction] -> Maybe (AType, AExpr) -> WireProps
-                -> EncM C.Encoding
-encMethodStruct pkg name kind inputs mpred body mresult props = do
+encMethodStruct :: Siblings -> SimPackage -> Id -> String -> [AInput]
+                -> Maybe APred -> [AAction] -> Maybe (AType, AExpr)
+                -> WireProps -> EncM C.Encoding
+encMethodStruct sibs pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
+    (rdyEnc, wfEnc) <- encSiblings sibs name (kind /= "Value")
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
     readyEnc <- traverse encExpr mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
@@ -1193,6 +1236,8 @@ encMethodStruct pkg name kind inputs mpred body mresult props = do
       , ("result", encMaybe id resultEnc)
       , ("clock_domain", encW32 dom)
       , ("always_enabled", encBool ae)
+      , ("rdy", rdyEnc)
+      , ("will_fire", wfEnc)
       ]
 
 -- ===============
@@ -1212,6 +1257,19 @@ toLimbs w v =
     let nlimbs = max 1 ((fromIntegral w + 31) `div` 32)
         limb k = fromIntegral ((v `shiftR` (32 * k)) .&. 0xFFFFFFFF)
     in  map limb [0 .. nlimbs - 1]
+
+-- The port a method call addresses.  bsc encodes it in the method name
+-- of a multi-ported primitive ("port0__read", "port1__write" -- the
+-- CReg family); the number is data the runtime schedules on, so it is
+-- resolved here, at the one place that knows bsc's naming, instead of
+-- being re-parsed out of the name on every call.  Single-ported
+-- methods are port 0.
+methPortNum :: Id -> Word32
+methPortNum i =
+    case getIdBaseString i of
+      'p':'o':'r':'t':rest
+        | (ds@(_:_), '_':'_':_) <- span isDigit rest -> read ds
+      _ -> 0
 
 encExpr :: AExpr -> EncM C.Encoding
 encExpr (ASInt _ t lit) =
@@ -1236,7 +1294,7 @@ encExpr (AMethCall t obj meth args) = do
       [ ("width", encW32 (aTypeWidth t))
       , ("instance", o)
       , ("method", m)
-      , ("port", encW32 0)   -- P0 TODO: multi-port assignment
+      , ("port", encW32 (methPortNum meth))
       , ("args", encList argsEnc)
       ]
 encExpr (AMethValue t obj meth) = do
@@ -1395,7 +1453,7 @@ encAction _ (ACall obj meth (cond : args)) = do
     return $ encVariant "MethCall" $ encStruct
       [ ("instance", o)
       , ("method", m)
-      , ("port", encW32 0)   -- P0 TODO: multi-port assignment
+      , ("port", encW32 (methPortNum meth))
       , ("cond", condEnc)
       , ("args", encList argsEnc)
       ]

--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -65,7 +65,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 4
+birVersion = 5
 
 -- ===============
 -- String interning
@@ -1163,6 +1163,20 @@ encSiblings sibs name hasActions = do
                 else Nothing)
     return (encMaybe id rdyEnc, encMaybe id wfEnc)
 
+-- bsc's interface ready predicate can name the pre-block-conversion
+-- RDY_<m> signal, which is not a def and so resolves to nothing on its
+-- own; the backend reads the method's CAN_FIRE def in that position
+-- (mkGCD.cxx: PORT_RDY_result = DEF_CAN_FIRE_result).  Emit the
+-- reference that resolves, rather than one the reader has to repair.
+resolveReady :: Siblings -> Id -> AExpr -> AExpr
+resolveReady sibs name e@(ASDef t i)
+  | not (getIdBaseString i `S.member` sibDefs sibs)
+  , cf <- mkIdCanFire name
+  , getIdBaseString cf `S.member` sibDefs sibs
+  = ASDef t cf
+  | otherwise = e
+resolveReady _ _ e = e
+
 -- Interface methods.  Clock/reset/inout interface entries carry no
 -- executable content (they are in the clock/reset lists); skip them.
 encMethod :: Siblings -> SimPackage -> AIFace -> EncM [C.Encoding]
@@ -1190,7 +1204,7 @@ encMethodStructAV sibs pkg name inputs mpred body retdef props = do
     nameId <- idE name
     (rdyEnc, wfEnc) <- encSiblings sibs name True
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
-    readyEnc <- traverse encExpr mpred
+    readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
                         (bodyStmts pkg name props (Just retdef) body)
     let ADef ret_id rt _ _ = retdef
@@ -1218,7 +1232,7 @@ encMethodStruct sibs pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
     (rdyEnc, wfEnc) <- encSiblings sibs name (kind /= "Value")
     argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
-    readyEnc <- traverse encExpr mpred
+    readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
                         (bodyStmts pkg name props Nothing body)
     resultEnc <- traverse (encExpr . snd) mresult


### PR DESCRIPTION
## Why

The runtime kept rebuilding, from the text of names, facts the exporter
had in structured form and threw away. Every item below is the same
shape: bsc knows a number or a relation, the `.bir` does not carry it,
and the reader recovers it by string surgery — scanning the string
table for a name it just built, splitting a joined path at a
separator, or reading a digit out of a method name.

That costs more than time. A reconstruction can be *wrong* in ways a
lookup cannot, and two of these were.

## What was being rebuilt

**The CReg port number**, out of the method name's bytes, on every
write: `method.as_bytes()[4] - b'0'`, gated on `starts_with("port") &&
ends_with("__write")`. A malformed name saturating to port 0 was a
wrong answer waiting to happen; the `if i < 5` beside it was dead
code, since bsc rejects a sixth port at elaboration
(`PreludeBSV.bsv`). `Expr`/`Stmt::MethCall` have carried a `port` field
all along, written as a constant `0`. The exporter fills it now,
parsing bsc's `port<N>__read` convention once, at the one place that
already knows bsc's naming.

Both LLVM-side twins of that check went with it. `lower.rs` gated CReg
codegen on the same `starts_with`/`ends_with` and returned *ineligible*
on a mismatch — so a naming change would not have failed the build, it
would have quietly dropped designs to the interpreter.

**The sibling RDY method and WILL_FIRE def**, by building `"RDY_<m>"`
or `"WILL_FIRE_<m>"` and scanning. `Method` names them now, and the
exporter emits them exactly when the module has one — sharper than the
runtime's old proxy of "the string happens to be interned".

**Qualified rule references**, split at the last dot on every link.
`split_qual` did an `rfind`, two substrings, an instance lookup, and a
scan of the whole string table for the rule name, because the joined
form had no id for the part it needed. They are `QualRule { instance,
rule }` now.

**A `ready` reference that pointed at nothing.** A method's predicate
could be `Def(RDY_<m>)`, a pre-block-conversion signal that is not a
def; the reader repaired it by constructing `CAN_FIRE_<m>`. The
exporter has both tables, so it writes the reference that resolves.

**Whether the design records waves**, by scanning the string table for
anything starting with `"$dump"` — which also matches a `$display`
format string that happens to begin that way, silently switching on
wave recording and the unpruned plan. The exporter answers it from the
actions, as plain data, and writes `uses_wave_tasks`.

## O(n) lookups

The interpreter indexed each module's defs, rules and methods at load.
The code generator did not: it resolved a def reference by scanning the
module's whole def list, in `def`, `def_width` and `effectful_expr` —
which run per expression node. Quadratic in module size, on the path
that compiles the design.

`Module` carries the index now, built where the string index is built,
so both crates share one lookup instead of one crate having its own and
the other having none. Nine scans in the code generator and two in the
JIT became hash lookups. Two are left on purpose: the BDPI import list,
a handful of entries per design, and a module looked up by a name the
user typed, once.

## Format

`BIR_VERSION` 3 → 5, and a header split on the way.

`Design::decode` used to deserialize the whole body and *then* read the
version out of it, so a version mismatch reported as whatever the body
failed on — adding a field made every older `.bir` die on `missing
field`, naming the symptom and hiding the cause. A `.bir` now opens
with `magic(8) | BIR_VERSION le32(4)` and `decode` settles both before
touching the body. The body's own `version` field is gone: the header
owns it, and two records of one fact is how they drift.

Both bumps could have been additive — CBOR tolerates `serde(default)`
growth — and both would have been wrong. An older `.bir` defaulting
`uses_wave_tasks` to false records no waves for a design that asks for
them; an older `.bir` still carrying the unresolvable `Def(RDY_<m>)`
answers the wrong RDY. Refusing beats either.

`str_ids` is `#[serde(skip)]`, so **both** decode paths must rebuild
it. The snapshot sidecar is a bincode image of the same struct, and its
not doing so is what made every EN lookup miss on a warm cache;
`index_strings` is the single place that fills it now.

## Still on the old footing

**The EN port**, deliberately. Unlike RDY, bsc keeps enable ports in
submodule wire info, a module's own interface only implies them, and
always-enabled methods have them too — so the exporter cannot name them
without a rule that would be a guess, and guessing wrong moves JIT
enable-slot layout. Its lookups are at least no longer scans. Doing it
properly is Haskell-side work and wants its own change.

The interpreter's per-module maps still duplicate the IR's. They cannot
disagree — both are built from the same vectors at load — so this costs
memory and no correctness, and folding them in touches 28 call sites
for no functional gain.

## Tests

`tests/vcd` gains `CRegVcd`: a three-port CReg whose per-port
`Q_OUT_i`/`EN_i`/`D_IN_i` traces are compared byte-for-byte against the
reference. Nothing covered that surface, and it needed covering — the
port index feeds *only* VCD, since the chained value a design reads
comes from `store_val`, so a wrong index passed every existing test.

macOS 15 / arm64: `tests/regress` 35 PASS / 0 FAIL, `tests/vcd` 12 PASS
/ 0 FAIL, `tests/interactive` 35 PASS / 0 FAIL, plus the `trs-ir` unit
tests.

## Next

This is the prerequisite for module-scoped strings, not the thing
itself: with rule references structured rather than joined, the second
format break can carry `ModuleStrId`/`GlobalStrId`, instance indices in
place of paths, and per-module fragments.

