### PR TITLE
CI: branch-match downstream repos on workflow_dispatch

### DIFF
--- a/.github/workflows/checkout_possible_branch.sh
+++ b/.github/workflows/checkout_possible_branch.sh
@@ -41,7 +41,10 @@ if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
         exit 1
     fi
     user_branch_checkout "${HEAD_OWNER}" "${GITHUB_HEAD_REF}"
-elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+elif [ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+    # workflow_dispatch also sets GITHUB_REF_NAME (the ref dispatched on),
+    # so release runs dispatched on a branch pick up name-matched
+    # downstream branches exactly like a push of that branch would
     user_branch_checkout "${GITHUB_REPOSITORY_OWNER}" "${GITHUB_REF_NAME}"
 else
     echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"


### PR DESCRIPTION
Cherry-pick of Chris's `dccadaca` from `claude/lever3-plus-1060` onto `main`,
so the fix stops being carried per-branch.

## The hole

`checkout_possible_branch.sh` resolves a name-matched branch in the head owner's
fork for `pull_request` and `push`, and falls through to `default_checkout` for
everything else. `matx-release.yml` is started with `gh workflow run`, so its
`GITHUB_EVENT_NAME` is `workflow_dispatch` and it takes the fallback: every
dispatched release run clones `B-Lang-org/bsc-contrib`, `bdw` and `Toooba` at
their default branches, ignoring the name-matched MatX branches that exist for
exactly that release.

`GITHUB_REPOSITORY_OWNER` and `GITHUB_REF_NAME` are both set for dispatches, and
the `push` arm already uses just those two, so the fix is to let dispatch fall
into the arm that was already correct for it. One line, plus a comment.

## Why now

`release-prep-2026-sep` waives four CI jobs on every step:

```
matx-release.yml/Build/Test: {macos-15,ubuntu-22.04} / Test bdw ...: failure
matx-release.yml/Build/Test: {macos-15,ubuntu-22.04} / Test bsc-contrib ...: failure
```

Those are not bdw or bsc-contrib bugs. The bdw job fails 12 golden comparisons
of bsc-produced output (`3h`/`4h` `GtkWaveScript` and `NovasRC` dumps, the
`virtual_3h`/`virtual_4h` bluetcl output), plus `link_via_verilog_test` and
`simulate_via_verilog_test` once #1092/#1093 change what a Verilog link prints.
They are stale against a branch-local bsc, and a name-matched companion branch
is how July cleared the same class of failure — `MatX-inc/bdw` and
`MatX-inc/bsc-contrib` both still carry `release-2026.07.rc4/5/6/8`, two regold
commits each. Without this fix those companions are never consulted on a
dispatched run.

## Scope

`823b977b` on `release-2026.07.rc6` bundled this hunk with a gating Verilator
job. Only the hook change is here. The resulting script is byte-identical to
rc6's (`5ace0b88`), and both patches share the same pre-image (`7049ff3d`), so
this is rc6's change and nothing else.

`B-Lang-org/bsc` triggers `ci.yml` on `[ push, pull_request ]` only, so upstream
never dispatches and sees no behaviour change from this. It still closes a gap
in what the script claims to do, and would be reasonable to send upstream
separately.

-- Claude (via Claude Code), on behalf of @matx-jeffnewbern
