### PR TITLE
trs: left-justified formats, and no spec that can end a run

### DIFF
--- a/src/trs/crates/trs-interp/src/foreign.rs
+++ b/src/trs/crates/trs-interp/src/foreign.rs
@@ -154,14 +154,13 @@ impl ForeignEnv {
         &mut self,
         args: &[Arg],
         base: u32,
-        now: u64,
         loc: &str,
         newline: bool,
         errs: &mut Vec<String>,
     ) {
         let mut out = std::mem::take(&mut self.fmt_out);
         out.clear();
-        format::format_args_into(&mut out, args, base, now, loc, errs);
+        format::format_args_into(&mut out, args, base, loc, errs);
         if newline {
             out.push('\n');
         }
@@ -173,7 +172,7 @@ impl ForeignEnv {
     /// task was consumed here — including quiet/post-finish
     /// suppression — and false when the name belongs to the owner
     /// ($dump* family, BDPI imports).
-    pub(crate) fn action(&mut self, name: &str, args: &[Arg], now: u64, loc: &str) -> bool {
+    pub(crate) fn action(&mut self, name: &str, args: &[Arg], loc: &str) -> bool {
         // oracle secondary: console output and the VCD task family are
         // suppressed wholesale ($f* writes die in write_fd; Sink slots
         // cover the files).  $fatal is NOT in this list — its finished/
@@ -253,7 +252,7 @@ impl ForeignEnv {
                     _ => 0x8000_0000,
                 };
                 let mut errs = Vec::new();
-                let mut text = format::format_args(&args[1..], base, now, loc, &mut errs);
+                let mut text = format::format_args(&args[1..], base, loc, &mut errs);
                 if name.starts_with("$fdisplay") {
                     text.push('\n');
                 }
@@ -312,49 +311,49 @@ impl ForeignEnv {
             }
             "$display" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 10, now, loc, true, &mut errs);
+                self.write_display(args, 10, loc, true, &mut errs);
                 emit_output_errors(&errs);
             }
             "$displayh" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 16, now, loc, true, &mut errs);
+                self.write_display(args, 16, loc, true, &mut errs);
                 emit_output_errors(&errs);
             }
             "$displayb" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 2, now, loc, true, &mut errs);
+                self.write_display(args, 2, loc, true, &mut errs);
                 emit_output_errors(&errs);
             }
             "$displayo" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 8, now, loc, true, &mut errs);
+                self.write_display(args, 8, loc, true, &mut errs);
                 emit_output_errors(&errs);
             }
             "$write" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 10, now, loc, false, &mut errs);
+                self.write_display(args, 10, loc, false, &mut errs);
                 emit_output_errors(&errs);
             }
             "$writeh" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 16, now, loc, false, &mut errs);
+                self.write_display(args, 16, loc, false, &mut errs);
                 emit_output_errors(&errs);
             }
             "$writeb" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 2, now, loc, false, &mut errs);
+                self.write_display(args, 2, loc, false, &mut errs);
                 emit_output_errors(&errs);
             }
             "$writeo" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 8, now, loc, false, &mut errs);
+                self.write_display(args, 8, loc, false, &mut errs);
                 emit_output_errors(&errs);
             }
             // dollar_error/dollar_warning/dollar_info format exactly like
             // $display — bsc compiles the severity prefix into the message
             "$error" | "$warning" | "$info" => {
                 let mut errs = Vec::new();
-                self.write_display(args, 10, now, loc, true, &mut errs);
+                self.write_display(args, 10, loc, true, &mut errs);
                 emit_output_errors(&errs);
             }
             "$fatal" => {
@@ -366,7 +365,7 @@ impl ForeignEnv {
                 };
                 if !self.quiet {
                     let mut errs = Vec::new();
-                    self.write_display(rest, 10, now, loc, true, &mut errs);
+                    self.write_display(rest, 10, loc, true, &mut errs);
                     emit_output_errors(&errs);
                 } else {
                     crate::prim::note_window_effect();
@@ -545,7 +544,7 @@ impl ForeignEnv {
                 };
                 let mut errs = Vec::new();
                 let text = format::format_sformat(
-                    args, base, now, loc, name == "$sformatAV", &mut errs,
+                    args, base, loc, name == "$sformatAV", &mut errs,
                 );
                 emit_output_errors(&errs);
                 let packed = format::str_value(&text);

--- a/src/trs/crates/trs-interp/src/format.rs
+++ b/src/trs/crates/trs-interp/src/format.rs
@@ -78,9 +78,10 @@ fn push_pad(out: &mut String, c: char, n: usize) {
 
 /// Append one formatted value.  Semantics are fmt_val's original,
 /// bug-compat included: the final length (sign included) pads up to
-/// `width`; bases 2/8/16 zero-pad, base 10 pads with the caller's
-/// zero_pad flag (which every %d call site passes as false — base-10
-/// space-pads even for "%05d", matching dollar_display.cxx).
+/// `width`, with the fill the caller asks for.  The %d call sites all
+/// pass false — base 10 space-pads even for "%05d", matching
+/// dollar_display.cxx — and the 2/8/16 sites ask for zero fill unless
+/// left justification has moved the padding to the right.
 fn fmt_val_into(
     out: &mut String,
     v: &Value,
@@ -90,7 +91,9 @@ fn fmt_val_into(
     signed: bool,
 ) {
     let w = width.unwrap_or(0);
-    let pad = if zero_pad || base != 10 { '0' } else { ' ' };
+    // Zero fill is the caller's choice, not the base's: '-' declines it
+    // so the padding can move to the right as spaces.
+    let pad = if zero_pad { '0' } else { ' ' };
     if v.width <= 64 {
         // allocation-free path: digit count first, pad, then digits
         let x = v.as_u64();
@@ -173,7 +176,7 @@ pub fn format_args_into(
             }
             Arg::Val(v, sg) => {
                 fmt_val_into(
-                    out, v, default_base, false,
+                    out, v, default_base, default_base != 10,
                     Some(max_width(v.width, default_base, *sg)), *sg,
                 );
                 i += 1;
@@ -184,7 +187,7 @@ pub fn format_args_into(
                 errs.push("unexpected real number argument\n".to_string());
                 let v = Value::from_u64(64, (*r as i64) as u64);
                 fmt_val_into(
-                    out, &v, default_base, false,
+                    out, &v, default_base, default_base != 10,
                     Some(max_width(64, default_base, true)), true,
                 );
                 i += 1;
@@ -257,7 +260,7 @@ pub fn format_sformat(
             Arg::Str(text) => out.push_str(text),
             Arg::Val(v, sg) => {
                 fmt_val_into(
-                    &mut out, v, default_base, false,
+                    &mut out, v, default_base, default_base != 10,
                     Some(max_width(v.width, default_base, *sg)), *sg,
                 );
             }
@@ -265,7 +268,7 @@ pub fn format_sformat(
                 errs.push("unexpected real number argument\n".to_string());
                 let v = Value::from_u64(64, (*r as i64) as u64);
                 fmt_val_into(
-                    &mut out, &v, default_base, false,
+                    &mut out, &v, default_base, default_base != 10,
                     Some(max_width(64, default_base, true)), true,
                 );
             }
@@ -346,7 +349,21 @@ fn c_format_real(spec: char, width: Option<usize>, prec: Option<usize>, v: f64) 
             s.to_string()
         }
     }
-    let s = match spec {
+    // A non-finite value has no mantissa to split from an exponent, and no
+    // exponent to compare against the precision, so neither %e nor %g can
+    // be computed from one.  C printf renders all three conversions the
+    // same way here, and still pads to the field width.
+    let s = if !v.is_finite() {
+        let t = if v.is_nan() {
+            "nan"
+        } else if v.is_sign_positive() {
+            "inf"
+        } else {
+            "-inf"
+        };
+        t.to_string()
+    } else {
+        match spec {
         'f' => format!("{:.*}", prec.unwrap_or(6), v),
         'e' => c_e(v, prec.unwrap_or(6)),
         _ => {
@@ -362,6 +379,7 @@ fn c_format_real(spec: char, width: Option<usize>, prec: Option<usize>, v: f64) 
                 let decs = (p as i32 - 1 - exp).max(0) as usize;
                 trim_g(&format!("{:.*}", decs, v))
             }
+        }
         }
     };
     let w = width.unwrap_or(0);
@@ -398,7 +416,8 @@ fn format_str(
     args: &[Arg],
     i: &mut usize,
     out: &mut String,
-    now: u64,
+    // carried by the whole formatting API; nothing in here reports time
+    _now: u64,
     loc: &str,
     errs: &mut Vec<String>,
 ) {
@@ -422,6 +441,14 @@ fn format_str(
         // parse %[0][width]spec
         let mut zero_pad = false;
         let mut width: Option<usize> = None;
+        // '-' left-justifies within the field (C/Verilog printf).  It may
+        // precede the zero flag; zero padding is meaningless when left
+        // justified, so '-' wins, as it does in C.
+        let mut left_justify = false;
+        while cs.peek() == Some(&'-') {
+            left_justify = true;
+            cs.next();
+        }
         if cs.peek() == Some(&'0') {
             zero_pad = true;
             cs.next();
@@ -452,6 +479,8 @@ fn format_str(
         // "%0d" means minimal width (the 0 is a width of zero), while a
         // bare "%d" means the maximal column width
         let explicit_min = zero_pad && width.is_none();
+        // where this conversion's output begins, so '-' can re-align it
+        let field_start = out.len();
         match spec.to_ascii_lowercase() {
             '%' => out.push('%'),
             'd' | 'u' => {
@@ -470,7 +499,7 @@ fn format_str(
                 } else {
                     width.or(Some(max_width(v.width, 16, false)))
                 };
-                fmt_val_into(out, &v, 16, true, w, false);
+                fmt_val_into(out, &v, 16, !left_justify, w, false);
             }
             'o' => {
                 let (v, _) = next_val(args, i, errs);
@@ -479,7 +508,7 @@ fn format_str(
                 } else {
                     width.or(Some(max_width(v.width, 8, false)))
                 };
-                fmt_val_into(out, &v, 8, true, w, false);
+                fmt_val_into(out, &v, 8, !left_justify, w, false);
             }
             'b' => {
                 let (v, _) = next_val(args, i, errs);
@@ -488,7 +517,7 @@ fn format_str(
                 } else {
                     width.or(Some(max_width(v.width, 2, false)))
                 };
-                fmt_val_into(out, &v, 2, true, w, false);
+                fmt_val_into(out, &v, 2, !left_justify, w, false);
             }
             'c' => {
                 let (v, _) = next_val(args, i, errs);
@@ -557,7 +586,44 @@ fn format_str(
             }
             '0' => { /* %0 alone: nothing */ }
             'm' => out.push_str(loc),
-            other => panic!("trs-interp: unimplemented format %{other} (now={now})"),
+            // An unrecognized conversion is not fatal: the reference
+            // engine copies the spec through as literal text and leaves
+            // the argument to whatever formats it next, so no format
+            // string a design can write ends the simulation.
+            _ => {
+                out.push('%');
+                if left_justify {
+                    out.push('-');
+                }
+                if zero_pad {
+                    out.push('0');
+                }
+                if let Some(w) = width {
+                    push_u64_digits(out, w as u64, 10);
+                }
+                if let Some(pr) = prec {
+                    out.push('.');
+                    push_u64_digits(out, pr as u64, 10);
+                }
+                out.push(spec);
+            }
+        }
+        // Left justify by rotating the field: the conversions pad on the
+        // left, so the spaces they added move to the end.  Only spaces are
+        // moved -- a value's own leading zeros are part of the digits, and
+        // zero_pad is already off in this branch.
+        if left_justify {
+            let field = &out[field_start..];
+            let body = field.trim_start_matches(' ');
+            let padding = field.len() - body.len();
+            if padding > 0 {
+                let body = body.to_string();
+                out.truncate(field_start);
+                out.push_str(&body);
+                for _ in 0..padding {
+                    out.push(' ');
+                }
+            }
         }
     }
 }
@@ -580,6 +646,86 @@ mod tests {
         assert_eq!(s, "v=7");
         let s = format_args(&[Arg::Str("v=%h".into()), v(8, 7)], 10, 0, "", &mut e);
         assert_eq!(s, "v=07");
+    }
+
+    #[test]
+    fn unknown_spec_is_not_fatal() {
+        // The reference copies an unrecognized conversion through as text
+        // and leaves the argument for the next one; nothing aborts.
+        let mut e = Vec::new();
+        let s = format_args(
+            &[Arg::Str("A %v B".into()), v(16, 0)],
+            10, 0, "", &mut e,
+        );
+        assert_eq!(s, "A %v B    0");
+        // flags, width and precision are echoed as written, case included
+        let s = format_args(&[Arg::Str("%-7z|%0.3Q".into())], 10, 0, "", &mut e);
+        assert_eq!(s, "%-7z|%0.3Q");
+    }
+
+    #[test]
+    fn non_finite_reals() {
+        // No mantissa to split from an exponent: C printf renders these
+        // the same for every conversion, and still pads to the width.
+        let mut e = Vec::new();
+        for spec in ["%f", "%e", "%g"] {
+            let s = format_args(
+                &[Arg::Str(spec.into()), Arg::Real(f64::NAN)],
+                10, 0, "", &mut e,
+            );
+            assert_eq!(s, "nan", "{spec} of NaN");
+            let s = format_args(
+                &[Arg::Str(spec.into()), Arg::Real(f64::INFINITY)],
+                10, 0, "", &mut e,
+            );
+            assert_eq!(s, "inf", "{spec} of +inf");
+            let s = format_args(
+                &[Arg::Str(spec.into()), Arg::Real(f64::NEG_INFINITY)],
+                10, 0, "", &mut e,
+            );
+            assert_eq!(s, "-inf", "{spec} of -inf");
+        }
+        let s = format_args(
+            &[Arg::Str("%10e".into()), Arg::Real(f64::INFINITY)],
+            10, 0, "", &mut e,
+        );
+        assert_eq!(s, "       inf");
+    }
+
+    #[test]
+    fn left_justify() {
+        let mut e = Vec::new();
+        // the report shape that found this: %5d/%-5d
+        let s = format_args(
+            &[Arg::Str("%5d/%-5d".into()), v(32, 12), v(32, 12)],
+            10, 0, "", &mut e,
+        );
+        assert_eq!(s, "   12/12   ");
+        // no padding to move when the value fills the field
+        let s = format_args(&[Arg::Str("%-3d".into()), v(32, 123)], 10, 0, "", &mut e);
+        assert_eq!(s, "123");
+        // wider than the field: nothing is truncated
+        let s = format_args(&[Arg::Str("%-2d".into()), v(32, 12345)], 10, 0, "", &mut e);
+        assert_eq!(s, "12345");
+        // '-' beats '0', as in C
+        let s = format_args(&[Arg::Str("%-05d".into()), v(32, 42)], 10, 0, "", &mut e);
+        assert_eq!(s, "42   ");
+        // an explicit width replaces the natural column width, so the whole
+        // field pads right (C printf: "%-6x" of 0x2f is "2f    ")
+        let s = format_args(&[Arg::Str("%-6h".into()), v(16, 0x2f)], 10, 0, "", &mut e);
+        assert_eq!(s, "2f    ");
+        // with no width, %h still zero-fills to the value's column width
+        let s = format_args(&[Arg::Str("%h".into()), v(16, 0x2f)], 10, 0, "", &mut e);
+        assert_eq!(s, "002f");
+        // %s ignores the width field altogether (so does "%6s"), which
+        // leaves '-' nothing to re-align; pinned so a future width fix for
+        // strings has to revisit this deliberately
+        let s = format_args(
+            &[Arg::Str("[%-6s]".into()), Arg::Str("ab".into())],
+            10, 0, "", &mut e,
+        );
+        assert_eq!(s, "[ab]");
+        assert!(e.is_empty(), "unexpected errors: {e:?}");
     }
 
     #[test]

--- a/src/trs/crates/trs-interp/src/format.rs
+++ b/src/trs/crates/trs-interp/src/format.rs
@@ -148,12 +148,11 @@ fn fmt_val_into(
 pub fn format_args(
     args: &[Arg],
     default_base: u32,
-    now: u64,
     loc: &str,
     errs: &mut Vec<String>,
 ) -> String {
     let mut out = String::new();
-    format_args_into(&mut out, args, default_base, now, loc, errs);
+    format_args_into(&mut out, args, default_base, loc, errs);
     out
 }
 
@@ -163,7 +162,6 @@ pub fn format_args_into(
     out: &mut String,
     args: &[Arg],
     default_base: u32,
-    now: u64,
     loc: &str,
     errs: &mut Vec<String>,
 ) {
@@ -172,7 +170,7 @@ pub fn format_args_into(
         match &args[i] {
             Arg::Str(fmt) => {
                 i += 1;
-                format_str(fmt, args, &mut i, out, now, loc, errs);
+                format_str(fmt, args, &mut i, out, loc, errs);
             }
             Arg::Val(v, sg) => {
                 fmt_val_into(
@@ -227,7 +225,6 @@ fn unpack_str(v: &Value) -> String {
 pub fn format_sformat(
     args: &[Arg],
     default_base: u32,
-    now: u64,
     loc: &str,
     fmt_first: bool,
     errs: &mut Vec<String>,
@@ -235,7 +232,7 @@ pub fn format_sformat(
     if !fmt_first {
         // $swrite*: format("d", ..., restricted=false) — the $display
         // engine exactly
-        return format_args(args, default_base, now, loc, errs);
+        return format_args(args, default_base, loc, errs);
     }
     // $sformat: format("d", ..., restricted=true) — ONLY the first
     // argument is a format (a string, or a bit-packed string value);
@@ -246,12 +243,12 @@ pub fn format_sformat(
     match args.first() {
         Some(Arg::Str(f)) => {
             i = 1;
-            format_str(f, args, &mut i, &mut out, now, loc, errs);
+            format_str(f, args, &mut i, &mut out, loc, errs);
         }
         Some(Arg::Val(v, _)) => {
             i = 1;
             let fmt = unpack_str(v);
-            format_str(&fmt, args, &mut i, &mut out, now, loc, errs);
+            format_str(&fmt, args, &mut i, &mut out, loc, errs);
         }
         _ => {}
     }
@@ -416,8 +413,6 @@ fn format_str(
     args: &[Arg],
     i: &mut usize,
     out: &mut String,
-    // carried by the whole formatting API; nothing in here reports time
-    _now: u64,
     loc: &str,
     errs: &mut Vec<String>,
 ) {
@@ -640,11 +635,11 @@ mod tests {
     fn verilog_column_widths() {
         // 8-bit %d pads to 3 columns
         let mut e = Vec::new();
-        let s = format_args(&[Arg::Str("v=%d".into()), v(8, 7)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("v=%d".into()), v(8, 7)], 10, "", &mut e);
         assert_eq!(s, "v=  7");
-        let s = format_args(&[Arg::Str("v=%0d".into()), v(8, 7)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("v=%0d".into()), v(8, 7)], 10, "", &mut e);
         assert_eq!(s, "v=7");
-        let s = format_args(&[Arg::Str("v=%h".into()), v(8, 7)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("v=%h".into()), v(8, 7)], 10, "", &mut e);
         assert_eq!(s, "v=07");
     }
 
@@ -655,11 +650,11 @@ mod tests {
         let mut e = Vec::new();
         let s = format_args(
             &[Arg::Str("A %v B".into()), v(16, 0)],
-            10, 0, "", &mut e,
+            10, "", &mut e,
         );
         assert_eq!(s, "A %v B    0");
         // flags, width and precision are echoed as written, case included
-        let s = format_args(&[Arg::Str("%-7z|%0.3Q".into())], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%-7z|%0.3Q".into())], 10, "", &mut e);
         assert_eq!(s, "%-7z|%0.3Q");
     }
 
@@ -671,23 +666,23 @@ mod tests {
         for spec in ["%f", "%e", "%g"] {
             let s = format_args(
                 &[Arg::Str(spec.into()), Arg::Real(f64::NAN)],
-                10, 0, "", &mut e,
+                10, "", &mut e,
             );
             assert_eq!(s, "nan", "{spec} of NaN");
             let s = format_args(
                 &[Arg::Str(spec.into()), Arg::Real(f64::INFINITY)],
-                10, 0, "", &mut e,
+                10, "", &mut e,
             );
             assert_eq!(s, "inf", "{spec} of +inf");
             let s = format_args(
                 &[Arg::Str(spec.into()), Arg::Real(f64::NEG_INFINITY)],
-                10, 0, "", &mut e,
+                10, "", &mut e,
             );
             assert_eq!(s, "-inf", "{spec} of -inf");
         }
         let s = format_args(
             &[Arg::Str("%10e".into()), Arg::Real(f64::INFINITY)],
-            10, 0, "", &mut e,
+            10, "", &mut e,
         );
         assert_eq!(s, "       inf");
     }
@@ -698,31 +693,31 @@ mod tests {
         // the report shape that found this: %5d/%-5d
         let s = format_args(
             &[Arg::Str("%5d/%-5d".into()), v(32, 12), v(32, 12)],
-            10, 0, "", &mut e,
+            10, "", &mut e,
         );
         assert_eq!(s, "   12/12   ");
         // no padding to move when the value fills the field
-        let s = format_args(&[Arg::Str("%-3d".into()), v(32, 123)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%-3d".into()), v(32, 123)], 10, "", &mut e);
         assert_eq!(s, "123");
         // wider than the field: nothing is truncated
-        let s = format_args(&[Arg::Str("%-2d".into()), v(32, 12345)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%-2d".into()), v(32, 12345)], 10, "", &mut e);
         assert_eq!(s, "12345");
         // '-' beats '0', as in C
-        let s = format_args(&[Arg::Str("%-05d".into()), v(32, 42)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%-05d".into()), v(32, 42)], 10, "", &mut e);
         assert_eq!(s, "42   ");
         // an explicit width replaces the natural column width, so the whole
         // field pads right (C printf: "%-6x" of 0x2f is "2f    ")
-        let s = format_args(&[Arg::Str("%-6h".into()), v(16, 0x2f)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%-6h".into()), v(16, 0x2f)], 10, "", &mut e);
         assert_eq!(s, "2f    ");
         // with no width, %h still zero-fills to the value's column width
-        let s = format_args(&[Arg::Str("%h".into()), v(16, 0x2f)], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("%h".into()), v(16, 0x2f)], 10, "", &mut e);
         assert_eq!(s, "002f");
         // %s ignores the width field altogether (so does "%6s"), which
         // leaves '-' nothing to re-align; pinned so a future width fix for
         // strings has to revisit this deliberately
         let s = format_args(
             &[Arg::Str("[%-6s]".into()), Arg::Str("ab".into())],
-            10, 0, "", &mut e,
+            10, "", &mut e,
         );
         assert_eq!(s, "[ab]");
         assert!(e.is_empty(), "unexpected errors: {e:?}");
@@ -731,14 +726,14 @@ mod tests {
     #[test]
     fn bare_args_default_base() {
         let mut e = Vec::new();
-        let s = format_args(&[v(4, 5)], 10, 0, "", &mut e);
+        let s = format_args(&[v(4, 5)], 10, "", &mut e);
         assert_eq!(s, " 5"); // 4-bit max is 15 -> 2 columns
     }
 
     #[test]
     fn escapes() {
         let mut e = Vec::new();
-        let s = format_args(&[Arg::Str("a\\nb".into())], 10, 0, "", &mut e);
+        let s = format_args(&[Arg::Str("a\\nb".into())], 10, "", &mut e);
         assert_eq!(s, "a\nb");
     }
 }

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -2324,7 +2324,7 @@ impl Interp {
         // console/file/finish core first (quiet and post-$finish
         // suppression live there too); what it declines is design-
         // coupled — the $dump* family (VCD writer) and BDPI imports
-        if self.fe.action(name, args, self.now, loc) {
+        if self.fe.action(name, args, loc) {
             return;
         }
         match name {

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -465,7 +465,7 @@ unsafe extern "C" fn runcore_foreign_cb(
         loc.push_str(p);
     }
     if ret_width == 0 {
-        if !rc.fe.action(&name, &argv, rc.now, &loc) {
+        if !rc.fe.action(&name, &argv, &loc) {
             if name != "srand" {
                 panic!(
                     "trs runcore: action task {name:?} reached the boot \


### PR DESCRIPTION
Continues the stack: base is `trs/44-string-cleanup` (#162).

`$display`'s `-` flag was unimplemented, and reaching it aborted the
simulation rather than degrading. The panic surfaces inside
`jit_foreign_cb`, an `extern "C"` frame that cannot unwind, so it
escalates to `panic_cannot_unwind` and takes the process down. A format
string is design input; no spelling of one should be able to do that.

### What changed

- **`-` left-justifies.** Matches VCS byte for byte across `%d`, `%h`, `%b`.
- **The catch-all no longer aborts.** Any unrecognized conversion is
  copied through as literal text, leaving the argument to whatever
  formats it next — the reference engine's behaviour.
- **Non-finite reals.** `%e`/`%g` split an exponent off a formatted
  double; `nan`, `inf` and `-inf` have none, so the unwrap panicked. All
  three conversions now render them as C `printf` does, width included.
  This also corrects `%f`, which was not panicking but printed Rust's
  `NaN`/`inf` instead of C's lowercase.
- **Zero fill is the caller's choice**, not the base's, so `-` can move
  padding to the right without the non-decimal conversions forcing zeros.

### Divergence worth knowing about

Reference Bluesim does not implement `-` at all: it copies the spec
through as text and prints the argument afterwards in the default base.
So this moves trs *towards VCS and away from Bluesim*, and byte-parity
sweeps against Bluesim will see it. Three-way, for `[%-8h][%8h][%-6b]`:

| | `%-8h` | `%8h` | `%-6b` |
|---|---|---|---|
| VCS | `0       ` | `00000000` | `0     ` |
| trs (this PR) | `0       ` | `00000000` | `0     ` |
| iverilog | `0000    ` | `    0000` | `0000  ` |
| Bluesim | echoes `%-8h` | `    0000` | echoes `%-6b` |

### Not addressed

- `%v` is a real Verilog conversion (net strength) that VCS implements.
  Echoing it is a placeholder, not the finished behaviour.
- A huge field width (`%2000000000d`) still exhausts memory. Reference
  Bluesim honours the same width, so the semantics match and changing it
  would be a divergence; trs materialises the field where Bluesim
  streams, so it dies where Bluesim survives. Separate decision.

### Testing

- Two new unit tests, `unknown_spec_is_not_fatal` and `non_finite_reals`;
  all 6 format tests pass.
- Output byte-identical to reference Bluesim for a string mixing `%v`,
  `%q`, `%-7z` and `%0.3Q` — where trs previously aborted.
- Byte-identical to VCS X-2025.06-SP2-1 for the `-` cases.
- Unblocks `REBroadcastCsrLatencyReport` under trs, which aborted at
  cycle 7150 on `%-`; it now passes.