### PR TITLE
trs-bir: carry the ready set instead of rescanning for it (large-design export 77m38s -> 1m48s)

### DIFF
--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -43,6 +43,7 @@ import Data.List (foldl', nub, sortBy)
 import Data.Maybe (mapMaybe, isJust)
 
 import ErrorUtil (internalError)
+import Util (stableOrdNub)
 import Id (Id, getIdBaseString, getIdQualString, isSignedId,
            mkIdCanFire, mkIdWillFire, mkRdyId, cmpIdByName)
 import IntLit (IntLit(..))
@@ -429,7 +430,7 @@ encComposition instToMod msis topGates ss = do
             -- topologically sort those; the BIR.md section 4 argument
             -- (cross-instance constraints only attach at method cut
             -- points) makes this projection acyclic.
-            units = nub (mapMaybe resolve order)
+            units = stableOrdNub (mapMaybe resolve order)
             firstPos = M.fromList
                 (reverse [ (u, p)
                          | (p, Just u) <- zip [(0 :: Int) ..] (map resolve order) ])
@@ -522,25 +523,35 @@ encComposition instToMod msis topGates ss = do
             indeg0 = M.fromListWith (+)
                        ([ (u, 0 :: Int) | u <- units ]
                         ++ [ (b, 1) | (_, b) <- S.toList unitEdges ])
-            pickNext ready = case ready of
-                [] -> Nothing
-                _  -> Just (snd (minimum
-                        [ (M.findWithDefault maxBound u firstPos, u)
-                        | u <- ready ]))
-            kahn indeg done
-                | Just u <- pickNext
-                    [ v | (v, d) <- M.toList indeg, d == 0 ] =
-                    let indeg' = M.delete u indeg
-                        indeg'' = foldl' (\m v -> M.adjust (subtract 1) v m)
-                                         indeg' (succsOf u)
-                    in  kahn indeg'' (u : done)
-                | M.null indeg = reverse done
-                | otherwise = internalError
-                    ("SimExportIR: cyclic segment graph; a module boundary is "
-                     ++ "interleaved below method granularity (or ME ordering "
-                     ++ "constraints interlock two multi-node segments): "
-                     ++ show (M.keys indeg))
-            entries = kahn indeg0 []
+            -- The ready set is carried, not rediscovered.  Scanning the
+            -- indegree map for its zeroes at every step costs a pass over
+            -- everything still unplaced, which is quadratic in the unit
+            -- count; a large design reaches tens of thousands of units
+            -- and that scan becomes the whole export.  Keying the set by
+            -- (first appearance, unit) puts the tie-break in the ordering,
+            -- so the minimum is the head rather than a search, and a unit
+            -- moves out of `indeg` exactly when its last predecessor is
+            -- placed.
+            readyKey u = (M.findWithDefault maxBound u firstPos, u)
+            (zeroes, blocked) = M.partition (== 0) indeg0
+            ready0 = S.fromList (map readyKey (M.keys zeroes))
+            release (m, rs) v = case M.lookup v m of
+                Just 1 -> (M.delete v m, S.insert (readyKey v) rs)
+                Just d -> (M.insert v (d - 1) m, rs)
+                Nothing -> (m, rs)
+            kahn indeg ready done = case S.minView ready of
+                Just ((_, u), ready') ->
+                    let (indeg', ready'') =
+                          foldl' release (indeg, ready') (succsOf u)
+                    in  kahn indeg' ready'' (u : done)
+                Nothing
+                    | M.null indeg -> reverse done
+                    | otherwise -> internalError
+                        ("SimExportIR: cyclic segment graph; a module boundary is "
+                         ++ "interleaved below method granularity (or ME ordering "
+                         ++ "constraints interlock two multi-node segments): "
+                         ++ show (M.keys indeg))
+            entries = kahn blocked ready0 []
 
             dups = length entries /= S.size (S.fromList entries)
 


### PR DESCRIPTION
Continues the stack: base is `trs/45-format-specs` (#165).

## Why

Exporting an internal MatX design took **77m38s** in `trs-bir`. Reading
the 538 `.ba` it starts from (217 MB) was 0.5% of that. The export was
quadratic, twice, in `encComposition.deriveComp`.

A `-fprof-auto` profile of one 36,973-unit sub-design of it (18m51s on
its own) puts 96.7% of the run in three adjacent bindings:

| cost centre | %time | %alloc |
|---|---|---|
| `deriveComp.pickNext` | 79.6 | 12.2 |
| `deriveComp.units` | 15.1 | 0.0 |
| `deriveComp.kahn` | 2.0 | 49.7 |

GC was 2.4%; productivity 97.6%. The allocation rate was 172 MB/s
against ~1 GB/s on a small design — the mutator was traversing, not
allocating.

## What changed

**The ready set is carried, not rediscovered.** `kahn` rebuilt it every
step: `M.toList indeg` walked everything still unplaced looking for
zeroes, and `pickNext` took a `minimum` over the result. That is a full
pass per placed unit — ~7e8 probes at 37k units, and it is where
`kahn`'s 49.7% of allocation went too (a fresh list per step). The set
is now kept, keyed by `(first appearance, unit)` so the tie-break lives
in the ordering and `S.minView` *is* the pick; a unit leaves `indeg`
exactly when its last predecessor is placed.

**`units` uses `Util.stableOrdNub`.** `nub` costs O(n × distinct), and
here almost every element is distinct. Same first-occurrence-wins
semantics, through a `Set`.

## Output is unchanged, deliberately

The emitted order is part of the BIR contract, so the rewrite preserves
the selection rule exactly rather than merely producing *a* valid
topological order.

- The exported `.bir` is **byte-identical** to the unpatched exporter's
  on both designs measured (36,704,916 B and 48,354,307 B) — same
  `bsc`, same `.ba`, only the exporter differs.
- Transcribing the two implementations and running them against 4000
  generated graphs — including units absent from `firstPos`, edge
  endpoints absent from `units`, and cyclic graphs both must reject —
  gives identical output on every case. Removing the tie-break from the
  new one drops it to 2830 mismatches, so the check discriminates.

## Numbers

| | baseline | this PR | |
|---|---|---|---|
| 36,973-unit sub-design export | 18m51s | 50.3s | 22.5x |
| full design export | 77m38s | 1m48s | 43x |
| whole `TrsLink` action (export + `trs link`) | ~83m | 7m42s | 10.8x |

Allocation on the sub-design falls 190 GB → 68.7 GB; peak RSS is
unchanged (3.05 → 3.08 GB). `trs link` is untouched and is now the bulk
of the action.

## Not addressed

- `qualsOf`'s `nub` (same `deriveComp`) is left alone: its output is
  small, so its O(n × distinct) is not quadratic in practice — measured
  at 0.0%.
- `src/trs/trs-bir/Makefile` passes no `-O`, where `src/comp/Makefile`
  uses `-O2`, so `trs-bir` is an -O0 build. Worth a separate look, but
  it is a constant factor and this was not.
- `trs-bir`'s Makefile also calls `../../comp/update-build-version.sh`
  directly rather than through `src/comp/Makefile`, which is what
  exports `NOGIT ?= 0`; on a fresh worktree with no `BuildVersion.hs`
  the standalone build dies on `NOGIT: unbound variable`.

-- Claude (via Claude Code)