### PR TITLE
trs-bir: build at -O2, the level src/comp uses (export 108s -> 46s)

### DIFF
--- a/src/trs/trs-bir/Makefile
+++ b/src/trs/trs-bir/Makefile
@@ -46,7 +46,15 @@ GHCINCLUDES = \
 	-i../../Parsec \
 	$(SAT_INCLUDES)
 
+# This program is built from bsc's own modules, and src/comp builds them
+# at -O2; without an -O flag GHC's default is -O0, which more than doubles
+# the export (measured 108s -> 46s on a large design, byte-identical .bir)
+# and triples its allocation.  ?= so a GHC whose optimiser has a bug can be
+# worked around from the command line, the way src/comp does for 9.2.1.
+GHCOPTLEVEL ?= -O2
+
 GHCFLAGS = \
+	$(GHCOPTLEVEL) \
 	-hide-all-packages \
 	-fasm \
 	-Wall \


### PR DESCRIPTION
Continues the stack: base is `trs/46-export-sort` (#166).

## Why

`trs-bir` is built from bsc's own modules but with its own flag set, and
that set has no `-O` — so GHC's default `-O0` applies, while
`src/comp/Makefile` builds the same modules at `-O2`. Nothing seems to
have chosen this; the flag list in `src/trs/trs-bir/Makefile` was written
from scratch and the opt level was simply never in it.

Worth stating plainly that this is a constant factor, not a fix: #166
removed the quadratic that made the export slow. This is what is left
once the algorithm is right.

## Numbers

Exporting a large internal MatX design, on top of #166:

| | -O0 (today) | -O2 |
|---|---|---|
| wall | 108.08s | **46.64s** (2.4x) |
| allocated | 133.8 GB | 45.4 GB (2.9x less) |
| peak RSS | 4.81 GB | 3.17 GB |

The exported `.bir` is byte-identical (48,354,307 B), so this is purely
a build-flag change with no effect on output.

## The `?=`

`GHCOPTLEVEL ?= -O2`, so a GHC whose optimiser has a bug can be worked
around with `make GHCOPTLEVEL=-O0`. `src/comp/Makefile` does exactly
that for GHC 9.2.1 (issue 20639): it sets `GHCOPTLEVEL ?= -O0` early for
that version, then `?= -O2` later, and the earlier assignment wins.

This Makefile does not compute `GHCVERSION` and stays deliberately
minimal, so it does not replicate the version test — the override is
manual. Say the word if you would rather it probe.

## Not addressed

`trs-bir`'s Makefile calls `../../comp/update-build-version.sh` directly
rather than through `src/comp/Makefile`, which is what exports
`NOGIT ?= 0`; on a fresh worktree with no `BuildVersion.hs` the
standalone build dies on `NOGIT: unbound variable`. Also carried in #166.

-- Claude (via Claude Code)