### PR TITLE
trs: scope fragment identifiers, and give generated names ids

### DIFF
--- a/src/trs/crates/trs-capi/src/lib.rs
+++ b/src/trs/crates/trs-capi/src/lib.rs
@@ -133,7 +133,7 @@ enum SymKind {
     /// a method port (EN_/arg/RDY_/result — SYM_PORT semantics)
     MethPort {
         inst: usize,
-        method: trs_ir::StrId,
+        method: trs_ir::MethRef,
         kind: trs_interp::MethPortKind,
     },
     Rule,

--- a/src/trs/crates/trs-codegen/src/abi.rs
+++ b/src/trs/crates/trs-codegen/src/abi.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use trs_ir::{Design, Expr, StrId};
+use trs_ir::{GlobalStrId, MethRef, ModuleStrId, Design, Expr, StrId};
 
 /// Callback for foreign statements inside compiled bodies (the
 /// $display family and value/ActionValue tasks): compiled code
@@ -90,7 +90,7 @@ pub static BRAM_WARN: std::sync::OnceLock<fn(block: usize, addr: u64)> =
 pub struct PrimCallSpec {
     /// global instance index of the prim
     pub inst: usize,
-    pub method: StrId,
+    pub method: GlobalStrId,
     /// port the call addresses, for a multi-ported prim method
     pub port: u32,
     /// argument widths, in order (marshaled as consecutive word runs)
@@ -197,7 +197,7 @@ pub struct InstEnv {
     /// TRACED artifacts only: method name -> recording slots for its
     /// VCD ports (EN time / args / result), stored by inlined call
     /// sites.  Part of the exec dedup signature.
-    pub rec_meths: HashMap<StrId, RecMeth>,
+    pub rec_meths: HashMap<MethRef, RecMeth>,
 }
 
 /// Arena recording slots for one user-module method's VCD ports
@@ -236,8 +236,6 @@ pub struct PlanEnv<'a> {
 pub struct AfSpec {
     /// method index in the TOP module's method list
     pub method_idx: usize,
-    /// method name — EN_<m>/RDY_<m> sibling lookups
-    pub method: StrId,
     /// constant argument values in method-arg order:
     /// (width, limbs normalized to ceil(width/64) words)
     pub argv: Vec<(u32, Vec<u64>)>,
@@ -286,7 +284,7 @@ pub struct RuleSpec {
 pub struct ForeignSpec {
     /// instance for $display location reporting
     pub inst: usize,
-    pub func: StrId,
+    pub func: GlobalStrId,
     /// result width (0 = plain action, no result)
     pub ret_width: u32,
     pub args: Vec<FArgSpec>,
@@ -360,14 +358,14 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
         w(o, v.len() as u32);
         for f in v {
             w(o, f.inst as u32);
-            w(o, f.func);
+            w(o, f.func.0);
             w(o, f.ret_width);
             w(o, f.args.len() as u32);
             for a in &f.args {
                 match a {
                     FArgSpec::Str(sid) => {
                         w(o, 0);
-                        w(o, *sid);
+                        w(o, sid.0);
                         w(o, 0);
                     }
                     FArgSpec::Num { width, signed } => {
@@ -393,7 +391,7 @@ pub fn encode_protos(protos: &[FnProtos]) -> Vec<u8> {
         w(o, v.len() as u32);
         for pc in v {
             w(o, pc.inst as u32);
-            w(o, pc.method);
+            w(o, pc.method.0);
             w(o, pc.port);
             w(o, pc.ret_width);
             w(o, pc.is_action as u32);
@@ -448,14 +446,14 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
                 // buffer walk desynchronizes on a garbage width
                 // (review finding: unknown tags fell open as Num)
                 args.push(match tag {
-                    0 => FArgSpec::Str(a),
+                    0 => FArgSpec::Str(ModuleStrId(a)),
                     1 => FArgSpec::Num { width: a, signed: sg != 0 },
                     2 => FArgSpec::Real,
                     3 => FArgSpec::StrDyn,
                     _ => return None,
                 });
             }
-            v.push(ForeignSpec { inst, func, ret_width, args });
+            v.push(ForeignSpec { inst, func: GlobalStrId(func), ret_width, args });
         }
         Some(v)
     }
@@ -479,7 +477,7 @@ pub fn decode_protos(b: &[u8]) -> Option<Vec<FnProtos>> {
             for _ in 0..argc {
                 arg_widths.push(r(b, i)?);
             }
-            v.push(PrimCallSpec { inst, method, port, arg_widths, ret_width, is_action });
+            v.push(PrimCallSpec { inst, method: GlobalStrId(method), port, arg_widths, ret_width, is_action });
         }
         Some(v)
     }
@@ -518,13 +516,13 @@ impl Drop for AotModeGuard {
 }
 /// Sentinel method id in a PrimCallSpec: not a method call — the
 /// trampoline answers the prim's gate_out() (compiled Expr::Gate).
-pub const GATE_OUT_METHOD: StrId = u32::MAX;
+pub const GATE_OUT_METHOD: GlobalStrId = GlobalStrId(u32::MAX);
 
 /// Sentinel func id in a ForeignSpec: not a foreign function — the
 /// callback concatenates its (StrDyn) arguments' texts and interns the
 /// result, returning the new string id (compiled PrimOp::StringConcat,
 /// mirroring the interp's per-evaluation intern_dyn).
-pub const STRING_CONCAT_FUNC: StrId = u32::MAX - 1;
+pub const STRING_CONCAT_FUNC: GlobalStrId = GlobalStrId(u32::MAX - 1);
 /// Boundary-tax experiment (sharding rung, step 1): request one
 /// module TYPE's methods be emitted as standalone functions on the
 /// proposed slot ABI (arena, env, inst_base, token_base, args...) and
@@ -543,8 +541,8 @@ pub struct BoundaryReq {
     pub exemplar: usize,
     /// method index in the module's methods table
     pub mi: usize,
-    /// method name id
-    pub method: StrId,
+    /// the reference call sites use to reach this method
+    pub method: MethRef,
     /// BK_* kind: 0 = value result fn, 1 = action body fn,
     /// 2 = actionvalue body+result fn, 3 = actionvalue result-only fn
     pub kind: u8,
@@ -558,7 +556,7 @@ pub struct BoundaryReq {
 /// (result widths are known only at lowering): call sites consult it
 /// to divert.  Keyed (mir, method, kind).
 pub type BoundaryMap =
-    HashMap<(usize, StrId, u8), (String, u32, Vec<(StrId, u32)>)>;
+    HashMap<(usize, MethRef, u8), (String, u32, Vec<(StrId, u32)>)>;
 
 /// AOT layout revision, baked into every artifact: bump whenever slot
 /// allocation, token layout, or callback ABI changes so a stale .so is

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -5424,7 +5424,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         if !m.always_enabled || m.args.len() != af.argv.len() {
             return nope("auto-fire spec out of step with the method");
         }
-        let (margs, body, mname) = (m.args.clone(), m.body.clone(), m.name);
+        let (margs, body, mname, men) =
+            (m.args.clone(), m.body.clone(), m.name, m.en);
         // sibling RDY lookup — same rule as the interp's always_en_rdy
         // and the parent-call inline: no RDY method exported = constant
         // ready
@@ -5436,12 +5437,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 .find(|(_, mm)| mm.name == id)
                 .map(|(mi, mm)| (mi, mm.result.clone()))
         });
-        let en_slot = {
-            let en_name =
-                format!("EN_{}", self.env.d.strings[mname as usize]);
-            self.env.d.str_id(&en_name)
-                .and_then(|id| ie.en_slot.get(&(id as StrId)).copied())
-        };
+        let en_slot = men.and_then(|id| ie.en_slot.get(&id).copied());
         // callee frame on the top itself, args bound to the baked
         // constants (limbs pre-normalized to ceil(width/64) words)
         let mut cf = self.child_frame(f, f.inst, Some(af.method_idx))?;
@@ -6269,10 +6265,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             };
                             let margs = m.args.clone();
                             let body = m.body.clone();
-                            let en_name =
-                                format!("EN_{}", self.env.d.strings[*method as usize]);
-                            let en_slot = self.env.d.str_id(&en_name)
-                                .and_then(|id| cie.en_slot.get(&(id as StrId)).copied());
+                            let en_slot =
+                                m.en.and_then(|id| cie.en_slot.get(&id).copied());
                             let mut cf = self.child_frame(f, child, Some(mi))?;
                             let wc = self.expr_width(f, cond)?;
                             let c = self.expr(f, cond)?;
@@ -7473,9 +7467,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let margs = m.args.clone();
                 let body = m.body.clone();
-                let en_name = format!("EN_{}", self.env.d.strings[*method as usize]);
-                let en_slot = self.env.d.str_id(&en_name)
-                    .and_then(|id| cie.en_slot.get(&(id as StrId)).copied());
+                let en_slot = m.en.and_then(|id| cie.en_slot.get(&id).copied());
 
                 let mut cf = self.child_frame(f, child, Some(mi))?;
                 for (a, pa) in args.iter().zip(&margs) {

--- a/src/trs/crates/trs-codegen/src/lower.rs
+++ b/src/trs/crates/trs-codegen/src/lower.rs
@@ -29,7 +29,7 @@
 
 use std::collections::HashMap;
 
-use trs_ir::{Action, Design, Expr, PrimOp, Stmt, StrId};
+use trs_ir::{Action, Design, Expr, GlobalStrId, MethRef, ModuleStrId, PrimOp, Stmt, StrId};
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
@@ -2858,7 +2858,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             Some(_) => Ok(0), // zero-width def: the empty bit-vector
             None => Err(Ineligible(format!(
                 "unknown def (width): {}",
-                self.env.d.strings[name as usize]
+                self.env.d.name(name)
             ))),
         }
     }
@@ -3168,7 +3168,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         "trs: BUG: enable port '{}' was pruned by the \
                          fast-plan liveness walk but is read by compiled \
                          lowering — report this (rung-40 EN pruning)",
-                        self.env.d.strings[*p as usize]
+                        self.env.d.name(*p)
                     );
                 }
                 if let Some(&(w, v)) = ie.port_consts.get(p) {
@@ -3272,7 +3272,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 match self.emit_prim_call(
                     f,
                     child,
-                    GATE_OUT_METHOD,
+                    MethRef::Prim(GATE_OUT_METHOD),
                     0,
                     &[],
                     1,
@@ -3389,7 +3389,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 // load the join-safe slot when the task has one — valid
                 // from any block, unlike the tphi value, which only
                 // dominates its own arm
-                if let Some(&(p, vw)) = f.av_slots.get(&(0x8000_0000u32 | *cookie)) {
+                if let Some(&(p, vw)) = f.av_slots.get(&ModuleStrId(0x8000_0000u32 | *cookie)) {
                     let v = self
                         .builder
                         .build_load(self.ity(vw), p, "tval")
@@ -3423,7 +3423,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         &mut self,
         f: &mut Frame<'ctx>,
         width: u32,
-        func: StrId,
+        func: GlobalStrId,
         args: &[Expr],
     ) -> Result<IntValue<'ctx>, Ineligible> {
         let Some(ff) = self.bdpi_import(func) else {
@@ -3451,7 +3451,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
 
     /// The design's BDPI import for `func`, if any (system tasks and
     /// unknown names return None).
-    fn bdpi_import(&self, func: StrId) -> Option<trs_ir::ForeignFunc> {
+    fn bdpi_import(&self, func: GlobalStrId) -> Option<trs_ir::ForeignFunc> {
         self.env.d.foreign_funcs.iter().find(|ff| ff.name == func).cloned()
     }
 
@@ -3466,7 +3466,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     ) -> Result<IntValue<'ctx>, Ineligible> {
         use trs_ir::ForeignType as FT;
         let ff = ff.clone();
-        let c_name = self.env.d.strings[ff.c_name as usize].clone();
+        let c_name = self.env.d.global_name(ff.c_name).to_string();
         let i64t = self.ctx.i64_type();
         let i32t = self.ctx.i32_type();
         let ptrt = self.ctx.ptr_type(AddressSpace::default());
@@ -3641,7 +3641,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     let Expr::Str(sid) = &args[k] else {
                         return nope("BDPI string arg not a literal");
                     };
-                    let text = self.env.d.strings[*sid as usize].clone();
+                    let text = self.env.d.name(*sid).to_string();
                     let gname = format!("trs_bdpistr_{sid}");
                     let g = self.module.get_global(&gname).unwrap_or_else(|| {
                         let arr = self.ctx.const_string(text.as_bytes(), true);
@@ -3724,12 +3724,19 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         f: &mut Frame<'ctx>,
         width: u32,
         instance: StrId,
-        method: StrId,
+        method: MethRef,
         port: u32,
         args: &[Expr],
     ) -> Result<IntValue<'ctx>, Ineligible> {
         let ie = self.ie(f.inst)?;
-        let mname = self.env.d.strings[method as usize].clone();
+        // the slot maps below hold primitive children, whose methods are
+        // named in the vocabulary every design shares; a call on a user
+        // module carries an index instead and takes the inline path past
+        // them, where no name is wanted
+        let mname = match method {
+            MethRef::Prim(g) => self.env.d.global_name(g).to_string(),
+            MethRef::User(_) => String::new(),
+        };
         if let Some(&(base, rw)) = ie.reg_slot.get(&instance) {
             if !matches!(mname.as_str(), "read" | "get" | "_read") || !args.is_empty() {
                 return nope("non-read register method in expression");
@@ -3996,12 +4003,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         }
         let cie = self.ie(child)?;
         let cmod = &self.env.d.modules[cie.mir];
-        let Some((mi, m)) = cmod
-            .methods
-            .iter()
-            .enumerate()
-            .find(|(_, m)| m.name == method)
-        else {
+        let Some((mi, m)) = cmod.meth(method) else {
             return nope("unknown method on child");
         };
         // the interp's call_value evaluates the method's RESULT expr
@@ -4140,17 +4142,20 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     return None;
                 }
                 let ie = self.ie(f.inst).ok()?;
-                let mname = &self.env.d.strings[*method as usize];
+                let mname = match method {
+                    MethRef::Prim(g) => self.env.d.global_name(*g),
+                    MethRef::User(_) => "",
+                };
                 let ok = (ie.reg_slot.contains_key(instance)
                     || ie.creg_slot.contains_key(instance))
-                    && matches!(mname.as_str(), "read" | "get" | "_read")
+                    && matches!(mname, "read" | "get" | "_read")
                     || ie.wire_slot.contains_key(instance)
-                        && matches!(mname.as_str(), "whas" | "wget")
+                        && matches!(mname, "whas" | "wget")
                     || ie.bypass_slot.contains_key(instance)
-                        && matches!(mname.as_str(), "whas" | "wget" | "read")
+                        && matches!(mname, "whas" | "wget" | "read")
                     || ie.fifo_slot.contains_key(instance)
                         && matches!(
-                            mname.as_str(),
+                            mname,
                             "first" | "notFull" | "notEmpty" | "i_notFull" | "i_notEmpty"
                         );
                 ok.then_some(2)
@@ -4231,12 +4236,15 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         &mut self,
         f: &mut Frame<'ctx>,
         prim_inst: usize,
-        method: StrId,
+        method: MethRef,
         port: u32,
         args: &[Expr],
         ret_width: u32,
         is_action: bool,
     ) -> Result<Option<IntValue<'ctx>>, Ineligible> {
+        let MethRef::Prim(method) = method else {
+            return nope("user-module method reached the primitive call path");
+        };
         let Some(envp) = f.envp else {
             return nope("prim call without env pointer");
         };
@@ -4435,8 +4443,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     // result closure only
                     let cm = &self.env.d.modules[ce.mir];
                     return cm
-                        .method_idx(*method)
-                        .and_then(|mi| cm.methods[mi].result.as_ref())
+                        .meth(*method)
+                        .and_then(|(_, mm)| mm.result.as_ref())
                         .is_some_and(|r| self.effectful_expr(child, r, seen));
                 }
                 // prim child: dynamic-arg value reads may warn —
@@ -4619,7 +4627,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         &mut self,
         cf: &Frame<'ctx>,
         child: usize,
-        method: StrId,
+        method: MethRef,
         argv: &[(IntValue<'ctx>, u32)],
     ) -> Result<(), Ineligible> {
         let rm = match self.ie(child)?.rec_meths.get(&method) {
@@ -4642,7 +4650,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         &mut self,
         cf: &Frame<'ctx>,
         child: usize,
-        method: StrId,
+        method: MethRef,
         v: IntValue<'ctx>,
     ) -> Result<(), Ineligible> {
         let res = match self.ie(child)?.rec_meths.get(&method) {
@@ -4730,7 +4738,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             }
             return Err(Ineligible(format!(
                 "def escaped conditional arm: {}",
-                self.env.d.strings[n as usize]
+                self.env.d.name(n)
             )));
         }
         // whole-edge SSA cache: a value latched (CF/WF/eager at its
@@ -4857,11 +4865,11 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             let chain: Vec<&str> = f
                 .expanding
                 .iter()
-                .map(|&x| self.env.d.strings[x as usize].as_str())
+                .map(|&x| self.env.d.name(x))
                 .collect();
             return Err(Ineligible(format!(
                 "unknown def (expand): {} in {} (exec={} args={} chain={})",
-                self.env.d.strings[n as usize],
+                self.env.d.name(n),
                 self.spec.label,
                 f.is_exec,
                 f.args.len(),
@@ -5431,10 +5439,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         // ready
         let rdy = m.rdy.and_then(|id| {
             self.env.d.modules[mir]
-                .methods
-                .iter()
-                .enumerate()
-                .find(|(_, mm)| mm.name == id)
+                .meth(id)
                 .map(|(mi, mm)| (mi, mm.result.clone()))
         });
         let en_slot = men.and_then(|id| ie.en_slot.get(&id).copied());
@@ -5455,7 +5460,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             .iter()
             .filter_map(|pa| cf.args.get(&pa.name).copied())
             .collect();
-        self.rec_meth_call(&cf, f.inst, mname, &rec_argv)?;
+        self.rec_meth_call(&cf, f.inst, MethRef::User(af.method_idx as u32), &rec_argv)?;
         let sk_bb = self.ctx.append_basic_block(func, "afsk");
         match rdy {
             Some((mi_r, Some(res))) => {
@@ -5572,7 +5577,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     fn boundary_hit(
         &self,
         mir: usize,
-        method: StrId,
+        method: MethRef,
         kind: u8,
     ) -> Option<(String, u32, Vec<(StrId, u32)>)> {
         BOUNDARY.with(|b| {
@@ -5914,10 +5919,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     ) -> Result<IntValue<'ctx>, Ineligible> {
         let i64t = self.ctx.i64_type();
         match e {
-            Expr::Str(sid) => Ok(i64t.const_int(*sid as u64, false)),
+            Expr::Str(sid) => Ok(i64t.const_int(sid.0 as u64, false)),
             Expr::Param(p) | Expr::Port(p) => {
                 match self.ie(f.inst)?.str_consts.get(p) {
-                    Some(&sid) => Ok(i64t.const_int(sid as u64, false)),
+                    Some(&sid) => Ok(i64t.const_int(sid.0 as u64, false)),
                     None => nope("non-string port in string context"),
                 }
             }
@@ -6038,7 +6043,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
     fn emit_foreign(
         &mut self,
         f: &mut Frame<'ctx>,
-        func_id: StrId,
+        func_id: GlobalStrId,
         args: &[Expr],
         signed: &[bool],
         ret_width: u32,
@@ -6240,12 +6245,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                             }
                             let cie = self.ie(child)?;
                             let cmod = &self.env.d.modules[cie.mir];
-                            let Some((mi, m)) = cmod
-                                .methods
-                                .iter()
-                                .enumerate()
-                                .find(|(_, m)| m.name == *method)
-                            else {
+                            let Some((mi, m)) = cmod.meth(*method) else {
                                 return nope("unknown actionvalue method on child");
                             };
                             if m.kind != trs_ir::MethodKind::ActionValue {
@@ -6628,7 +6628,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         else {
                             continue;
                         };
-                        let name = self.env.d.strings[tf5 as usize].clone();
+                        let name = self.env.d.global_name(tf5).to_string();
                         let v = if matches!(name.as_str(), "$time" | "$stime") {
                             let now = self.load_word(f, self.env.now_slot);
                             self.to_w(now, 64, width.max(1), false)
@@ -6659,7 +6659,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         &mut self,
         f: &mut Frame<'ctx>,
         func: FunctionValue<'ctx>,
-        tf: StrId,
+        tf: GlobalStrId,
         cookie: u32,
         temp: Option<StrId>,
         width: u32,
@@ -6675,7 +6675,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         // happen only on the TAKEN path (review finding: the old
         // unconditional store of the phi wrote 0 over undet on skip)
         let ck = 0x8000_0000u32 | cookie;
-        let cp = self.av_slot(f, ck, w);
+        let cp = self.av_slot(f, ModuleStrId(ck), w);
         let tp = temp.map(|t| self.av_slot(f, t, w));
         let wc = self.expr_width(f, cond)?;
         let c = self.expr(f, cond)?;
@@ -6766,7 +6766,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
             )
         }
         fn bound(
-            strings: &[String],
+            d: &Design,
             list: &[Stmt],
             dead: &mut Vec<StrId>,
             stable: &mut Vec<(StrId, Action)>,
@@ -6776,7 +6776,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                     Stmt::Def { name, .. } => dead.push(*name),
                     Stmt::AvAction { def, action } => match action {
                         Action::Task { func, .. }
-                            if idempotent(strings[*func as usize].as_str()) =>
+                            if idempotent(d.global_name(*func)) =>
                         {
                             stable.push((*def, action.clone()));
                         }
@@ -6787,8 +6787,8 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                         _ => dead.push(*def),
                     },
                     Stmt::Cond { then_, else_, .. } => {
-                        bound(strings, then_, dead, stable);
-                        bound(strings, else_, dead, stable);
+                        bound(d, then_, dead, stable);
+                        bound(d, else_, dead, stable);
                     }
                     _ => {}
                 }
@@ -6801,7 +6801,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         f.ssa = saved;
         let mut dead = Vec::new();
         let mut stable = Vec::new();
-        bound(&self.env.d.strings, list, &mut dead, &mut stable);
+        bound(&self.env.d, list, &mut dead, &mut stable);
         for n in dead {
             f.dead_defs.insert(n);
         }
@@ -6837,7 +6837,10 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
         match a {
             Action::MethCall { instance, method, port, cond, args } => {
                 let ie = self.ie(f.inst)?;
-                let mname = self.env.d.strings[*method as usize].clone();
+                let mname = match method {
+                    MethRef::Prim(g) => self.env.d.global_name(*g).to_string(),
+                    MethRef::User(_) => String::new(),
+                };
                 let wc = self.expr_width(f, cond)?;
                 let c = self.expr(f, cond)?;
                 let cz = self.nonzero(c, wc);
@@ -7439,12 +7442,7 @@ impl<'a, 'ctx> Lower<'a, 'ctx> {
                 }
                 let cie = self.ie(child)?;
                 let cmod = &self.env.d.modules[cie.mir];
-                let Some((mi, m)) = cmod
-                    .methods
-                    .iter()
-                    .enumerate()
-                    .find(|(_, m)| m.name == *method)
-                else {
+                let Some((mi, m)) = cmod.meth(*method) else {
                     return nope("unknown action method on child");
                 };
                 // a plain Action call may target an ActionValue method
@@ -7639,6 +7637,8 @@ pub fn llvm_smoke_test() -> Result<u64, String> {
 
 #[cfg(test)]
 mod tests {
+    use trs_ir::{GlobalStrId, ModuleStrId};
+
     #[test]
     fn jit_round_trip() {
         assert_eq!(super::llvm_smoke_test().unwrap(), 42);
@@ -7650,10 +7650,10 @@ mod tests {
         let protos = vec![FnProtos {
             sched_foreign: vec![ForeignSpec {
                 inst: 3,
-                func: 7,
+                func: GlobalStrId(7),
                 ret_width: 64,
                 args: vec![
-                    FArgSpec::Str(11),
+                    FArgSpec::Str(ModuleStrId(11)),
                     FArgSpec::Num { width: 0, signed: false },
                     FArgSpec::Num { width: 65, signed: true },
                     FArgSpec::Real,
@@ -7668,7 +7668,7 @@ mod tests {
         let back = decode_protos(&bytes).expect("round trip");
         assert_eq!(back.len(), 1);
         let args = &back[0].sched_foreign[0].args;
-        assert!(matches!(args[0], FArgSpec::Str(11)));
+        assert!(matches!(args[0], FArgSpec::Str(ModuleStrId(11))));
         assert!(matches!(args[1], FArgSpec::Num { width: 0, signed: false }));
         assert!(matches!(args[2], FArgSpec::Num { width: 65, signed: true }));
         assert!(matches!(args[3], FArgSpec::Real));

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -7327,8 +7327,7 @@ impl Interp {
                 std::collections::HashSet::new();
             for sp in specs {
                 if let Some(af) = &sp.autofire {
-                    let en = format!("EN_{}", self.s(af.method));
-                    if let Some(&id) = sid.get(en.as_str()) {
+                    if let Some(id) = self.en_id_at(sp.inst, af.method) {
                         stay1.insert((sp.inst, id));
                     }
                     continue;
@@ -7361,8 +7360,7 @@ impl Interp {
                     let Some(&ci) = env.children.get(instance) else {
                         continue;
                     };
-                    let en = format!("EN_{}", self.s(*method));
-                    if let Some(&id) = sid.get(en.as_str()) {
+                    if let Some(id) = self.en_id_at(ci, *method) {
                         stay1.insert((ci, id));
                     }
                 }

--- a/src/trs/crates/trs-interp/src/jit.rs
+++ b/src/trs/crates/trs-interp/src/jit.rs
@@ -158,9 +158,10 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         };
         *out = g;
     } else if is_action {
-        interp.call_action(inst, method, port, &argv);
+        interp.call_action(inst, MethRef::Prim(method), port, &argv);
     } else {
-        let v = interp.call_value(inst, method, port, &argv, ret_width);
+        let v =
+            interp.call_value(inst, MethRef::Prim(method), port, &argv, ret_width);
         let words = ((ret_width.max(1) as usize) + 63) / 64;
         let dst = std::slice::from_raw_parts_mut(out, words);
         for (i, d) in dst.iter_mut().enumerate() {
@@ -175,7 +176,7 @@ pub(crate) unsafe extern "C" fn jit_prim_cb(
         let meth = if method == trs_codegen::abi::GATE_OUT_METHOD {
             "$gate_out".to_string()
         } else {
-            interp.s(method).to_string()
+            interp.gs(method).to_string()
         };
         // keyed Class.method: the class decides the fix shape (e.g.
         // BypassWire has no arena kind — every access bounces by
@@ -541,7 +542,7 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
             FArgSpec::Str(sid) => {
                 // Arc-interned once per distinct string id: a clone is
                 // a refcount bump, not a heap copy
-                argv.push(Arg::Str(interp.arg_str(sid)));
+                argv.push(Arg::Str(interp.arg_str(StrRef::Static(sid))));
             }
             FArgSpec::Num { width, signed } => {
                 let w = width;
@@ -566,7 +567,7 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
                 // -> the interp's Arg::Str, through the same Arc cache
                 // (dyn ids are stable once interned)
                 let word = *args.add(off);
-                argv.push(Arg::Str(interp.arg_str(word as u32)));
+                argv.push(Arg::Str(interp.arg_str(StrRef::from_word(word))));
                 off += 1;
             }
         }
@@ -582,7 +583,7 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
             }
         }
         let id = interp.intern_dyn(text);
-        *out = id as u64;
+        *out = StrRef::Dyn(id).to_word();
         argv.clear();
         interp.foreign_argv = argv;
         if let Some(t0) = _t0 {
@@ -597,7 +598,7 @@ pub(crate) unsafe extern "C" fn jit_foreign_cb(
     // both copied into scratch because foreign_action takes &mut self)
     let mut fname = std::mem::take(&mut interp.fname_buf);
     fname.clear();
-    fname.push_str(interp.s(func));
+    fname.push_str(interp.gs(func));
     let mut loc = std::mem::take(&mut interp.loc_buf);
     loc.clear();
     loc.push_str("top");
@@ -812,7 +813,10 @@ impl<'a> ConeAnalyzer<'a> {
                 for a in args {
                     sub!(a);
                 }
-                let mname = self.d.strings[*method as usize].clone();
+                let mname = match method {
+                    MethRef::Prim(g) => self.d.global_name(*g).to_string(),
+                    MethRef::User(_) => String::new(),
+                };
                 match (self.kind)(mir, *instance) {
                     ChildRef::Prim(c) => {
                         let (ok, st) = match c {
@@ -838,9 +842,8 @@ impl<'a> ConeAnalyzer<'a> {
                     }
                     ChildRef::User(cmir) => {
                         let mm = self.d.modules[cmir]
-                            .methods
-                            .iter()
-                            .find(|m| m.name == *method);
+                            
+                            .meth(*method).map(|(_, mm)| mm);
                         match mm {
                             Some(m) if m.body.is_empty() && m.result.is_some() => {
                                 let aset: std::collections::HashSet<StrId> =
@@ -865,7 +868,7 @@ impl<'a> ConeAnalyzer<'a> {
                             }
                             None => {
                                 if std::env::var_os("TRS_JIT_SPLIT_WHY").is_some() {
-                                    eprintln!("why: method-not-found {}", self.d.strings[*method as usize]);
+                                    eprintln!("why: method-not-found {method:?}");
                                 }
                                 outl = false;
                                 stab = false;
@@ -874,7 +877,7 @@ impl<'a> ConeAnalyzer<'a> {
                     }
                     ChildRef::Opaque => {
                         if std::env::var_os("TRS_JIT_SPLIT_WHY").is_some() {
-                            eprintln!("why: opaque-child {}", self.d.strings[*instance as usize]);
+                            eprintln!("why: opaque-child {}", self.d.name(*instance));
                         }
                         outl = false;
                         stab = false;
@@ -1147,7 +1150,7 @@ fn aot_emit(
                     if !quiet {
                         eprintln!(
                             "trs boundary: {} stays inline: always_enabled",
-                            env.d.strings[m.name as usize]
+                            env.d.name(m.name)
                         );
                     }
                     continue;
@@ -1167,7 +1170,7 @@ fn aot_emit(
                         mir,
                         exemplar,
                         mi,
-                        method: m.name,
+                        method: MethRef::User(mi as u32),
                         kind,
                         sym: format!("trs_bnd{mir}_{mi}_{kind}"),
                         args: args.clone(),
@@ -1200,7 +1203,7 @@ fn aot_emit(
                         .filter(|&i| i < env.d.modules.len())
                         .or_else(|| {
                             env.d.modules.iter().position(|m| {
-                                env.d.strings[m.name as usize] == sel
+                                env.d.global_name(m.name) == sel
                             })
                         });
                     let Some(mir) = mir else {
@@ -1218,7 +1221,7 @@ fn aot_emit(
                         eprintln!(
                             "trs boundary: module {} (mir {mir}), {} method fns \
                              requested",
-                            env.d.strings[env.d.modules[mir].name as usize],
+                            env.d.global_name(env.d.modules[mir].name),
                             reqs.len()
                         );
                     }
@@ -2097,7 +2100,7 @@ impl Interp {
         &mut self,
         rcomps: &[RComp],
         sources: &[crate::ClockSource],
-        clocks: &[StrId],
+        clocks: &[GlobalStrId],
         driver_clock: &HashMap<usize, usize>,
     ) {
         let Some(mut img) = self.runcore_pending.take() else { return };
@@ -2131,7 +2134,7 @@ impl Interp {
         // the boot PANICS on an unexpected task rather than fall back,
         // so this gate must make that unreachable.
         let lib_only = self.d.foreign_funcs.iter().all(|f| {
-            let (n, c) = (self.s(f.name), self.s(f.c_name));
+            let (n, c) = (self.gs(f.name), self.gs(f.c_name));
             (n == "rand32" && c == "rand32") || (n == "srand" && c == "srand")
         });
         if !lib_only {
@@ -3178,7 +3181,7 @@ impl Interp {
         let specs_lite: Vec<(usize, usize)> =
             specs.iter().map(|sp| (sp.inst, sp.rule_idx)).collect();
         let specs_lite = &specs_lite[..];
-        use trs_ir::{Action as A, Expr as E, InstanceKind, Primitive as P, Stmt};
+        use trs_ir::{MethRef, Action as A, Expr as E, InstanceKind, Primitive as P, Stmt};
         use std::collections::HashSet;
 
         #[derive(Clone)]
@@ -3226,7 +3229,7 @@ impl Interp {
         // the exporter ships prims as Other{name} (prim.rs classifies
         // by the same strings); the enum variants are matched too in
         // case the exporter ever starts using them
-        fn cat(p: &P, s: &dyn Fn(StrId) -> String) -> &'static str {
+        fn cat(p: &P, s: &dyn Fn(GlobalStrId) -> String) -> &'static str {
             match p {
                 P::Reg { .. } => "reg",
                 P::ConfigReg { .. } => "configreg",
@@ -3305,7 +3308,7 @@ impl Interp {
             inst_envs: &'a HashMap<usize, InstEnv>,
             prim_cat: HashMap<usize, &'static str>,
             cone_memo: HashMap<(usize, StrId), Cone>,
-            write_memo: HashMap<(usize, StrId), HashSet<usize>>,
+            write_memo: HashMap<(usize, MethRef), HashSet<usize>>,
         }
 
         fn walk_expr(cx: &mut Ctx, inst: usize, e: &E, out: &mut Cone) {
@@ -3321,10 +3324,14 @@ impl Interp {
                     }
                     match child(&cx.itp.d, cx.inst_envs, inst, *instance) {
                         Some((gi, InstanceKind::Prim(p))) => {
-                            let s = |n: StrId| cx.itp.s(n).to_string();
+                            let s = |n: GlobalStrId| cx.itp.gs(n).to_string();
                             let pc = cat(p, &s);
                             cx.prim_cat.insert(gi, pc);
-                            if !stable_read(pc, cx.itp.s(*method)) {
+                            let mname = match method {
+                                        MethRef::Prim(g) => cx.itp.gs(*g),
+                                        MethRef::User(_) => "",
+                                    };
+                                    if !stable_read(pc, mname) {
                                 out.reads.insert(gi);
                             }
                             out.reads_all.insert(gi);
@@ -3348,9 +3355,8 @@ impl Interp {
                             // evaluates (over-poisoning; Ravi's catch)
                             let cmir = cx.inst_envs[&gi].mir;
                             let mm = cx.itp.d.modules[cmir]
-                                .methods
-                                .iter()
-                                .find(|m| m.name == *method)
+                                
+                                .meth(*method).map(|(_, mm)| mm)
                                 .cloned();
                             if let Some(mm) = mm {
                                 if let Some(res) = &mm.result {
@@ -3443,9 +3449,8 @@ impl Interp {
                         {
                             let cmir = cx.inst_envs[&gi].mir;
                             let mm = cx.itp.d.modules[cmir]
-                                .methods
-                                .iter()
-                                .find(|m| m.name == *method)
+                                
+                                .meth(*method).map(|(_, mm)| mm)
                                 .cloned();
                             if let Some(mm) = mm {
                                 for st2 in &mm.body {
@@ -3513,7 +3518,7 @@ impl Interp {
                         if let A::MethCall { instance, method, .. } = a {
                             match child(&cx.itp.d, cx.inst_envs, inst, *instance) {
                                 Some((gi, InstanceKind::Prim(p))) => {
-                                    let s = |n: StrId| cx.itp.s(n).to_string();
+                                    let s = |n: GlobalStrId| cx.itp.gs(n).to_string();
                                     cx.prim_cat.insert(gi, cat(p, &s));
                                     out.insert(gi);
                                 }
@@ -3525,9 +3530,8 @@ impl Interp {
                                         cx.write_memo.insert(key, HashSet::new());
                                         let cmir = cx.inst_envs[&gi].mir;
                                         let mm = cx.itp.d.modules[cmir]
-                                            .methods
-                                            .iter()
-                                            .find(|m| m.name == *method)
+                                            
+                                            .meth(*method).map(|(_, mm)| mm)
                                             .cloned();
                                         let mut w = HashSet::new();
                                         if let Some(mm) = mm {
@@ -4338,8 +4342,8 @@ impl Interp {
                         .d
                         .foreign_funcs
                         .iter()
-                        .find(|ff| self.s(ff.name) == n)
-                        .map(|ff| self.s(ff.c_name).to_string())
+                        .find(|ff| self.gs(ff.name) == n)
+                        .map(|ff| self.gs(ff.c_name).to_string())
                         .unwrap_or_else(|| n.clone());
                     (c, a)
                 })
@@ -4837,10 +4841,10 @@ impl Interp {
             // never-evaluated default), plus per-method port blocks —
             // EN time (u64::MAX = never), every argument, the result
             let mut rec_defs: HashMap<StrId, (u32, u32)> = HashMap::new();
-            let mut rec_meths: HashMap<StrId, RecMeth> = HashMap::new();
+            let mut rec_meths: HashMap<MethRef, RecMeth> = HashMap::new();
             if let Some(mv) = rec_mvs.get(&module) {
                 let irm = &self.d.modules[mir];
-                let mut meth_names: Vec<StrId> = Vec::new();
+                let mut meth_names: Vec<MethRef> = Vec::new();
                 for var in mv.members.iter().chain(mv.ports.iter()) {
                     match &var.src {
                         crate::VcdSrc::Def(n) => {
@@ -4863,7 +4867,7 @@ impl Interp {
                     }
                 }
                 for mn in meth_names {
-                    let Some(me) = irm.methods.iter().find(|me| me.name == mn)
+                    let Some((_, me)) = irm.meth(mn)
                     else {
                         continue;
                     };
@@ -5429,7 +5433,7 @@ impl Interp {
             for (afi, (mname, argv)) in
                 self.autofire.clone().iter().enumerate()
             {
-                let Some(mi) = self.d.modules[tmir].method_idx(*mname) else {
+                let Some((mi, _)) = self.d.modules[tmir].meth(*mname) else {
                     if trace {
                         eprintln!("trs jit: off (autofire method missing)");
                     }
@@ -5463,7 +5467,6 @@ impl Interp {
                     token_base: (o as u64) << 17,
                     autofire: Some(trs_codegen::abi::AfSpec {
                         method_idx: mi,
-                        method: *mname,
                         argv: av,
                     }),
                 });
@@ -5884,8 +5887,8 @@ impl Interp {
                                     .d
                                     .foreign_funcs
                                     .iter()
-                                    .find(|ff| self.s(ff.name) == n)
-                                    .map(|ff| self.s(ff.c_name).to_string())
+                                    .find(|ff| self.gs(ff.name) == n)
+                                    .map(|ff| self.gs(ff.c_name).to_string())
                                     .unwrap_or_else(|| n.clone());
                                 (format!("trs_bdpi_{c}"), a)
                             })
@@ -6160,7 +6163,7 @@ impl Interp {
                     .d
                     .foreign_funcs
                     .iter()
-                    .map(|f| self.s(f.c_name).to_string())
+                    .map(|f| self.gs(f.c_name).to_string())
                     .filter(|n| !crate::is_lib_bdpi(n))
                     .collect();
                 v.sort_unstable();
@@ -6774,7 +6777,7 @@ struct LcWalk<'a> {
     /// memo key carries is_action (lockstep with LcRank): a value
     /// visit walks ready+result only and must not suppress a later
     /// action visit's body walk
-    seen_meths: std::collections::HashSet<(usize, StrId, bool)>,
+    seen_meths: std::collections::HashSet<(usize, MethRef, bool)>,
     /// (slot base, word footprint, class): 0 = prim data, 1 = indexed
     /// prim (bounded), 2 = def/fire-signal slot
     out: Vec<(u32, u32, u8)>,
@@ -6828,7 +6831,7 @@ impl<'a> LcWalk<'a> {
         &mut self,
         inst: usize,
         child: StrId,
-        method: StrId,
+        method: MethRef,
         args: &[trs_ir::Expr],
         is_action: bool,
     ) {
@@ -6850,7 +6853,7 @@ impl<'a> LcWalk<'a> {
                 let Some(cenv) = self.envs.get(&ci) else { return };
                 let it = self.it;
                 let m = &it.d.modules[cenv.mir];
-                if let Some(me) = m.methods.iter().find(|me| me.name == method)
+                if let Some((_, me)) = m.meth(method)
                 {
                     if let Some(r) = &me.ready {
                         self.expr(ci, r);
@@ -7321,13 +7324,13 @@ impl Interp {
                 .strings
                 .iter()
                 .enumerate()
-                .map(|(i, s)| (s.as_str(), i as StrId))
+                .map(|(i, s)| (s.as_str(), ModuleStrId(i as u32)))
                 .collect();
             let mut stay1: std::collections::HashSet<(usize, StrId)> =
                 std::collections::HashSet::new();
             for sp in specs {
                 if let Some(af) = &sp.autofire {
-                    if let Some(id) = self.en_id_at(sp.inst, af.method) {
+                    if let Some(id) = self.en_id_at(sp.inst, MethRef::User(af.method_idx as u32)) {
                         stay1.insert((sp.inst, id));
                     }
                     continue;
@@ -7480,7 +7483,7 @@ struct LcRank<'a> {
     /// memo key carries is_action: a value visit walks ready+result
     /// only, so it must not suppress a later ACTION visit's body walk
     /// (the body's EN reads would be invisibly pruned)
-    seen_meths: std::collections::HashSet<(usize, StrId, bool)>,
+    seen_meths: std::collections::HashSet<(usize, MethRef, bool)>,
     /// rung 40: EN ports the walked cones actually load — the fast
     /// tier allocates slots only for these (keyed by mir: twin
     /// instances must stay layout-identical for dedup)
@@ -7506,7 +7509,7 @@ impl<'a> LcRank<'a> {
         &mut self,
         inst: usize,
         child: StrId,
-        method: StrId,
+        method: MethRef,
         args: &[trs_ir::Expr],
         is_action: bool,
     ) {
@@ -7530,7 +7533,7 @@ impl<'a> LcRank<'a> {
                 }
                 let it = self.it;
                 let m = &it.d.modules[cmir];
-                if let Some(me) = m.methods.iter().find(|me| me.name == method)
+                if let Some((_, me)) = m.meth(method)
                 {
                     if let Some(r) = &me.ready {
                         self.expr(ci, r);
@@ -7753,7 +7756,17 @@ impl Interp {
                             w.expr(inst, ex);
                         }
                     }
-                } else if !w.seen_meths.insert((mir, r, true)) {
+                } else if {
+                    let mref = it.d.modules[mir]
+                        .methods
+                        .iter()
+                        .position(|m| m.name == r)
+                        .map(|i| MethRef::User(i as u32));
+                    match mref {
+                        Some(mr) => !w.seen_meths.insert((mir, mr, true)),
+                        None => false,
+                    }
+                } {
                     // twin instance: this type's exec body walked
                     continue;
                 } else {
@@ -7803,7 +7816,7 @@ impl Interp {
                 continue;
             }
             if let Some(me) =
-                self.d.modules[top_mir].methods.iter().find(|m| m.name == *mname)
+                self.d.modules[top_mir].meth(*mname).map(|(_, mm)| mm)
             {
                 if let Some(r) = &me.ready {
                     w.expr(0, r);
@@ -7881,11 +7894,7 @@ impl Interp {
                 if !aw.seen_meths.insert((top_mir, *mname, true)) {
                     continue;
                 }
-                if let Some(me) = self.d.modules[top_mir]
-                    .methods
-                    .iter()
-                    .find(|m| m.name == *mname)
-                {
+                if let Some((_, me)) = self.d.modules[top_mir].meth(*mname) {
                     if let Some(r) = &me.ready {
                         aw.expr(0, r);
                     }
@@ -7910,8 +7919,8 @@ impl Interp {
                 .map(|&(mir, p)| {
                     format!(
                         "{}.{}",
-                        self.d.strings[self.d.modules[mir].name as usize],
-                        self.d.strings[p as usize]
+                        self.d.global_name(self.d.modules[mir].name),
+                        self.d.name(p)
                     )
                 })
                 .collect();

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -19,7 +19,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BinaryHeap, HashMap, HashSet};
 
 use trs_ir as ir;
-use trs_ir::{Action, Design, Expr, PrimOp, SchedNode, Stmt, StrId};
+use trs_ir::{Action, Design, Expr, GlobalStrId, MethRef, ModuleStrId, PrimOp, SchedNode, Stmt, StrId};
 
 mod bdpi;
 mod census;
@@ -40,7 +40,7 @@ mod runcore;
 use foreign::ForeignEnv;
 use format::Arg;
 use prim::Prim;
-use value::Value;
+use value::{DynStrId, StrRef, Value};
 
 #[cfg(feature = "aot")]
 use jit::JitPlans;
@@ -150,7 +150,7 @@ pub struct Interp {
     /// (jit.rs run-mode gate honors this flag too)
     pub(crate) jit_armed: bool,
     mods: Vec<ModIx>,
-    mod_by_name: HashMap<StrId, usize>,
+    mod_by_name: HashMap<GlobalStrId, usize>,
     /// instance path -> instance state index
     inst_by_path: HashMap<String, usize>,
     /// name -> interned id.  Design::strings is the id->name direction;
@@ -159,7 +159,7 @@ pub struct Interp {
     /// method -> EN_<method> / RDY_<method>.  Asked once per method
     /// call, and the answer is a property of the design, so the derived
     /// name is built once rather than on every call.
-    en_id_of_meth: HashMap<(usize, StrId), Option<StrId>>,
+    en_id_of_meth: HashMap<(usize, MethRef), Option<StrId>>,
     insts: Vec<Inst>,
     cycle: u64,
     /// current simulation time (the time of the executing clock edge)
@@ -213,10 +213,12 @@ pub struct Interp {
     loc_buf: String,
     /// string id -> Arc'd text for Arg::Str: interned once, cloned as
     /// a refcount bump on every later call
-    arg_strs: HashMap<u32, std::sync::Arc<str>>,
+    arg_strs: HashMap<DynStrId, std::sync::Arc<str>>,
     /// dense Arc cache for design-table string ids (the hot format
     /// strings on the foreign bounce path); dyn ids stay on arg_strs
     arg_strs_vec: Vec<Option<std::sync::Arc<str>>>,
+    /// The same, for link-level names.
+    global_arg_strs: Vec<Option<std::sync::Arc<str>>>,
     /// Emit requests stash the serialized PlanA here for the meta
     /// object (prime derives it; the aot_emit call site reads it)
     #[cfg(feature = "aot")]
@@ -242,10 +244,10 @@ pub struct Interp {
     vcd_def_vals: HashMap<(usize, StrId), Value>,
     /// last (edge time, args) of each user-module method call, for the
     /// EN_<m>/<m>_<arg> port values
-    vcd_meth_calls: HashMap<(usize, StrId), (u64, Vec<Value>)>,
+    vcd_meth_calls: HashMap<(usize, MethRef), (u64, Vec<Value>)>,
     /// last returned value of each user-module value-method call, for
     /// result-port values (C++ assigns PORT_<m> at call time)
-    vcd_meth_results: HashMap<(usize, StrId), Value>,
+    vcd_meth_results: HashMap<(usize, MethRef), Value>,
     /// per-instance kernel clock index (from the composition that runs it)
     vcd_inst_clock: Vec<usize>,
     /// (instance, module clock domain) -> kernel clock index
@@ -324,7 +326,7 @@ pub struct Interp {
     jit_rec_defs: HashMap<(usize, StrId), (u32, u32)>,
     /// TRACED artifact only: (instance, method) -> recording slots for
     /// the method's VCD ports (EN time / args / result)
-    jit_rec_meths: HashMap<(usize, StrId), RecSlots>,
+    jit_rec_meths: HashMap<(usize, MethRef), RecSlots>,
     /// per-engine $random/$srandom stream (library rand32/srand BDPI)
     rng: GlibcRandom,
     /// identity salt of the top-level bindings (topbind); folded into
@@ -336,7 +338,7 @@ pub struct Interp {
     consumed_plus: Vec<String>,
     /// always_enabled Action methods of the top auto-fired in batch
     /// mode (interface order), each with its constant argument values
-    autofire: Vec<(StrId, Vec<Value>)>,
+    autofire: Vec<(MethRef, Vec<Value>)>,
     /// (composition index, entry index) -> autofire indices to invoke
     /// after that entry's nodes — the methods' Exec cut positions
     /// (resolved by topbind::resolve; keys line up with rcomps)
@@ -412,11 +414,11 @@ enum VcdSrc {
     /// member def: last computed value (write_undet pattern initially)
     Def(StrId),
     /// EN_<m>: 1 when the method executed at the clock's last posedge
-    PortEn(StrId),
+    PortEn(MethRef),
     /// method argument port: value from the last call
-    PortArg(StrId, usize),
+    PortArg(MethRef, usize),
     /// value/RDY method result port: evaluated on demand
-    PortRes(StrId),
+    PortRes(MethRef),
 }
 
 /// One module-scope $var: display name, value source, width, and whether
@@ -552,7 +554,7 @@ struct RAlt {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct PlanA {
     version: u32,
-    clocks: Vec<StrId>,
+    clocks: Vec<GlobalStrId>,
     sources: Vec<ClockSource>,
     driver_clock: Vec<(usize, usize)>,
     rcomps: Vec<RComp>,
@@ -654,7 +656,7 @@ impl StopCond {
 
 struct Stepper {
     /// distinct clocks in first-appearance order, default clock first
-    clocks: Vec<StrId>,
+    clocks: Vec<GlobalStrId>,
     sources: Vec<ClockSource>,
     /// clock-driver prim instance -> clock index, for routing triggered
     /// edges after ticks
@@ -770,7 +772,7 @@ impl Interp {
             .strings
             .iter()
             .enumerate()
-            .map(|(i, s)| (s.as_str(), i as StrId))
+            .map(|(i, s)| (s.as_str(), ModuleStrId(i as u32)))
             .collect();
         let mods: Vec<ModIx> = d
             .modules
@@ -801,7 +803,7 @@ impl Interp {
                 methods: m.methods.iter().enumerate().map(|(k, x)| (x.name, k)).collect(),
             })
             .collect();
-        let mod_by_name: HashMap<StrId, usize> =
+        let mod_by_name: HashMap<GlobalStrId, usize> =
             d.modules.iter().enumerate().map(|(i, m)| (m.name, i)).collect();
 
         let mut it = Interp {
@@ -835,6 +837,7 @@ impl Interp {
             loc_buf: String::new(),
             arg_strs: HashMap::new(),
             arg_strs_vec: Vec::new(),
+            global_arg_strs: Vec::new(),
             #[cfg(feature = "aot")]
             plan_a_bytes: None,
             trace_wf: std::env::var_os("TRS_TRACE_WF").is_some(),
@@ -911,16 +914,29 @@ impl Interp {
     }
 
     fn s(&self, id: StrId) -> &str {
-        let n = self.d.strings.len();
-        if (id as usize) < n {
-            &self.d.strings[id as usize]
-        } else {
-            &self.dyn_strs[id as usize - n]
+        self.d.name(id)
+    }
+
+    /// The display name of a link-level id.
+    fn gs(&self, id: GlobalStrId) -> &str {
+        self.d.global_name(id)
+    }
+
+    fn dyn_text(&self, id: DynStrId) -> &str {
+        &self.dyn_strs[id.idx()]
+    }
+
+    /// The text a string-valued marker stands for, from whichever space
+    /// holds it.
+    fn str_text(&self, r: StrRef) -> &str {
+        match r {
+            StrRef::Static(i) => self.s(i),
+            StrRef::Dyn(i) => self.dyn_text(i),
         }
     }
 
     /// Intern a runtime-created string (StringConcat) into the arena.
-    pub(crate) fn intern_dyn(&mut self, text: String) -> StrId {
+    pub(crate) fn intern_dyn(&mut self, text: String) -> DynStrId {
         // window-time interning shifts every later dyn string id and
         // leaves baked slots holding ids a RunCore boot cannot resolve
         // (adversarial-panel finding) — any bake-window intern makes
@@ -929,7 +945,7 @@ impl Interp {
             prim::note_window_effect();
         }
         self.dyn_strs.push(text);
-        (self.d.strings.len() + self.dyn_strs.len() - 1) as StrId
+        DynStrId((self.dyn_strs.len() - 1) as u32)
     }
 
     /// The string id bound to a string-valued parameter of an instance,
@@ -1003,7 +1019,7 @@ impl Interp {
                     let cmod = *self
                         .mod_by_name
                         .get(&mname)
-                        .unwrap_or_else(|| panic!("unknown module {:?}", self.s(mname)));
+                        .unwrap_or_else(|| panic!("unknown module {:?}", self.gs(mname)));
                     // bind the child's parameters: its inputs align
                     // positionally with the instantiation args
                     let cmir = self.mods[cmod].ir;
@@ -1091,7 +1107,7 @@ impl Interp {
                 }
                 ir::InstanceKind::Prim(p) => {
                     let pname = match &p {
-                        ir::Primitive::Other { name } => self.s(*name).to_string(),
+                        ir::Primitive::Other { name } => self.gs(*name).to_string(),
                         other => panic!("structured primitive kinds not exported yet: {other:?}"),
                     };
                     // evaluate instantiation args in the parent context
@@ -1114,8 +1130,8 @@ impl Interp {
                                 let v = self.eval(slot, &mut c, a);
                                 // computed strings (e.g. StringConcat of
                                 // parameters) are string args, not consts
-                                match v.as_str_id() {
-                                    Some(id) => strs.push(self.s(id).to_string()),
+                                match v.as_str_ref() {
+                                    Some(r) => strs.push(self.str_text(r).to_string()),
                                     None => consts.push(v),
                                 }
                             }
@@ -1356,7 +1372,7 @@ impl Interp {
     }
 
     /// Record a method-fired timestamp (EN port), preserving prior args.
-    fn vcd_rec_meth_time(&mut self, callee: usize, method: StrId) {
+    fn vcd_rec_meth_time(&mut self, callee: usize, method: MethRef) {
         let now = self.now;
         if !self.jit_arena_ptr.is_null() {
             if let Some(rs) = self.jit_rec_meths.get(&(callee, method)) {
@@ -1371,7 +1387,7 @@ impl Interp {
     }
 
     /// Record a method call: timestamp + argument port values.
-    fn vcd_rec_meth_call(&mut self, callee: usize, method: StrId, argv: &[Value]) {
+    fn vcd_rec_meth_call(&mut self, callee: usize, method: MethRef, argv: &[Value]) {
         let now = self.now;
         if !self.jit_arena_ptr.is_null() {
             if let Some(rs) = self.jit_rec_meths.get(&(callee, method)).cloned() {
@@ -1387,7 +1403,7 @@ impl Interp {
     }
 
     /// Record a value/AV method's returned value (result port).
-    fn vcd_rec_meth_result(&mut self, callee: usize, method: StrId, v: &Value) {
+    fn vcd_rec_meth_result(&mut self, callee: usize, method: MethRef, v: &Value) {
         if !self.jit_arena_ptr.is_null() {
             if let Some(rs) = self.jit_rec_meths.get(&(callee, method)) {
                 if let Some((base, w)) = rs.res {
@@ -1429,7 +1445,7 @@ impl Interp {
     fn eval(&mut self, inst: usize, ctx: &mut Ctx, e: &Expr) -> Value {
         match e {
             Expr::Const { width, limbs } => Value::from_limbs32(*width, limbs),
-            Expr::Str(sid) => Value::str_ref(*sid),
+            Expr::Str(sid) => Value::str_ref(StrRef::Static(*sid)),
             Expr::Def(name) => {
                 if let Some(v) = ctx.locals.get(name) {
                     return v.clone();
@@ -1503,7 +1519,7 @@ impl Interp {
                     // string parameters flow as marker values so dynamic
                     // muxes over them still resolve at task boundaries
                     if let Some(&sid) = str_params.get(name) {
-                        return Value::str_ref(sid);
+                        return Value::str_ref(StrRef::Static(sid));
                     }
                 }
                 // module input ports outside a method frame: clock gates and
@@ -1589,7 +1605,7 @@ impl Interp {
                                      pruned by the fast-plan liveness \
                                      walk but read interp-side — report \
                                      this (rung-40 EN pruning)",
-                                    self.d.strings[*name as usize]
+                                    self.d.name(*name)
                                 );
                             }
                         }
@@ -1621,7 +1637,7 @@ impl Interp {
             }
             Expr::ForeignCall { width, func, args } => {
                 // Arc clone, not a String: this runs per evaluated call
-                let fname = self.arg_str(*func);
+                let fname = self.global_arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .map(|a| self.eval_arg(inst, ctx, a, false))
@@ -1812,13 +1828,13 @@ impl Interp {
                 let mut text = String::new();
                 for a in args {
                     let v = self.eval(inst, ctx, a);
-                    match v.as_str_id() {
-                        Some(id) => text.push_str(self.s(id)),
+                    match v.as_str_ref() {
+                        Some(r) => text.push_str(self.str_text(r)),
                         None => panic!("StringConcat of a non-string value"),
                     }
                 }
                 let id = self.intern_dyn(text);
-                Value::str_ref(id)
+                Value::str_ref(StrRef::Dyn(id))
             }
         }
     }
@@ -1847,8 +1863,8 @@ impl Interp {
         if let Some(r) = v.as_real() {
             return Arg::Real(r);
         }
-        match v.as_str_id() {
-            Some(id) => Arg::Str(self.s(id).into()),
+        match v.as_str_ref() {
+            Some(r) => Arg::Str(self.str_text(r).into()),
             None => Arg::Val(v, signed),
         }
     }
@@ -1866,37 +1882,55 @@ impl Interp {
         }
     }
 
+    /// Arg::Str text for a link-level name -- a task or foreign symbol --
+    /// Arc-interned on first use, like `arg_str` for the module scope.
+    pub(crate) fn global_arg_str(&mut self, id: GlobalStrId) -> std::sync::Arc<str> {
+        if self.global_arg_strs.is_empty() {
+            self.global_arg_strs = vec![None; self.d.strings.len()];
+        }
+        if let Some(a) = &self.global_arg_strs[id.idx()] {
+            return a.clone();
+        }
+        let a: std::sync::Arc<str> = std::sync::Arc::from(self.gs(id));
+        self.global_arg_strs[id.idx()] = Some(a.clone());
+        a
+    }
+
     /// Arg::Str text for a string id, Arc-interned on first use (the
     /// per-event-tax audit: an Arc clone per call replaces a String
     /// alloc per call on the $display path).
-    pub(crate) fn arg_str(&mut self, id: u32) -> std::sync::Arc<str> {
-        // design-table ids take a dense index (no per-call hashing);
-        // dyn ids (appended past the table) stay on the map
-        let n = self.d.strings.len();
-        if (id as usize) < n {
-            if self.arg_strs_vec.is_empty() {
-                self.arg_strs_vec = vec![None; n];
+    pub(crate) fn arg_str(&mut self, r: StrRef) -> std::sync::Arc<str> {
+        // a table id takes a dense index, so the common case does no
+        // hashing; the run's own strings are sparse and take the map
+        match r {
+            StrRef::Static(id) => {
+                let n = self.d.strings.len();
+                if self.arg_strs_vec.is_empty() {
+                    self.arg_strs_vec = vec![None; n];
+                }
+                if let Some(a) = &self.arg_strs_vec[id.idx()] {
+                    return a.clone();
+                }
+                let a: std::sync::Arc<str> = std::sync::Arc::from(self.s(id));
+                self.arg_strs_vec[id.idx()] = Some(a.clone());
+                a
             }
-            if let Some(a) = &self.arg_strs_vec[id as usize] {
-                return a.clone();
+            StrRef::Dyn(id) => {
+                if let Some(a) = self.arg_strs.get(&id) {
+                    return a.clone();
+                }
+                let a: std::sync::Arc<str> =
+                    std::sync::Arc::from(self.dyn_text(id));
+                self.arg_strs.insert(id, a.clone());
+                a
             }
-            let a: std::sync::Arc<str> =
-                std::sync::Arc::from(self.d.strings[id as usize].as_str());
-            self.arg_strs_vec[id as usize] = Some(a.clone());
-            return a;
         }
-        if let Some(a) = self.arg_strs.get(&id) {
-            return a.clone();
-        }
-        let a: std::sync::Arc<str> = std::sync::Arc::from(self.s(id));
-        self.arg_strs.insert(id, a.clone());
-        a
     }
 
     fn call_value(
         &mut self,
         callee: usize,
-        method: StrId,
+        method: MethRef,
         port: u32,
         argv: &[Value],
         w: u32,
@@ -1916,7 +1950,10 @@ impl Interp {
                 // value path, and a String alloc per call showed in
                 // the FloatTest malloc profile (disjoint fields, so
                 // the &mut prim borrow tolerates it)
-                let mname: &str = &self.d.strings[method as usize];
+                let MethRef::Prim(mg) = method else {
+                    panic!("user-module method reference on a primitive");
+                };
+                let mname: &str = self.d.global_name(mg);
                 let r = p.value_method(mname, port, argv, self.now);
                 if self.trace_events {
                     let path = self.insts[callee].path.clone();
@@ -1927,10 +1964,10 @@ impl Interp {
             }
             InstKind::User { module, .. } => {
                 let module = *module;
-                let mi = *self.mods[module]
-                    .methods
-                    .get(&method)
-                    .unwrap_or_else(|| panic!("unknown method {:?}", self.s(method)));
+                let MethRef::User(mi) = method else {
+                    panic!("primitive method reference on a user module");
+                };
+                let mi = mi as usize;
                 let mir = self.mods[module].ir;
                 let result = self.d.modules[mir].methods[mi].result.clone();
                 let mut ctx = self.method_ctx(module, mi, argv, true);
@@ -1948,10 +1985,13 @@ impl Interp {
         }
     }
 
-    fn call_action(&mut self, callee: usize, method: StrId, port: u32, argv: &[Value]) {
+    fn call_action(&mut self, callee: usize, method: MethRef, port: u32, argv: &[Value]) {
         if self.trace_events {
             if let InstKind::Prim(_) = &self.insts[callee].kind {
-                let mname = self.d.strings[method as usize].clone();
+                let MethRef::Prim(mg) = method else {
+                    panic!("user-module method reference on a primitive");
+                };
+                let mname = self.d.global_name(mg).to_string();
                 let args: Vec<String> = argv.iter().map(|v| v.to_hex_string()).collect();
                 eprintln!("[{}] {}.{}({})", self.cycle, self.insts[callee].path,
                           mname, args.join(","));
@@ -1968,15 +2008,18 @@ impl Interp {
             InstKind::Prim(p) => {
                 // borrow, don't clone (same disjoint-fields fix as
                 // call_value; per-event-tax audit finding 3)
-                let mname: &str = &self.d.strings[method as usize];
+                let MethRef::Prim(mg) = method else {
+                    panic!("user-module method reference on a primitive");
+                };
+                let mname: &str = self.d.global_name(mg);
                 p.action_method(mname, port, argv, self.now);
             }
             InstKind::User { module, .. } => {
                 let module = *module;
-                let mi = *self.mods[module]
-                    .methods
-                    .get(&method)
-                    .unwrap_or_else(|| panic!("unknown method {:?}", self.s(method)));
+                let MethRef::User(mi) = method else {
+                    panic!("primitive method reference on a user module");
+                };
+                let mi = mi as usize;
                 self.latch_method_en(callee, method);
                 if self.vcd_trace {
                     self.vcd_rec_meth_call(callee, method, argv);
@@ -2002,19 +2045,15 @@ impl Interp {
 
     /// The interned id of a method's companion EN_ signal, or None where
     /// the design exports no such signal.
-    pub(crate) fn en_id_at(&self, inst: usize, method: StrId) -> Option<StrId> {
+    pub(crate) fn en_id_at(&self, inst: usize, method: MethRef) -> Option<StrId> {
         let InstKind::User { module, .. } = &self.insts[inst].kind else {
             return None;
         };
         let mir = self.mods[*module].ir;
-        self.d.modules[mir]
-            .methods
-            .iter()
-            .find(|m| m.name == method)
-            .and_then(|m| m.en)
+        self.d.modules[mir].meth(method).and_then(|(_, m)| m.en)
     }
 
-    fn en_id_of(&mut self, callee: usize, method: StrId) -> Option<StrId> {
+    fn en_id_of(&mut self, callee: usize, method: MethRef) -> Option<StrId> {
         let InstKind::User { module, .. } = &self.insts[callee].kind else {
             return None;
         };
@@ -2032,12 +2071,12 @@ impl Interp {
     /// — the always_enabled method's own `ready` expr can reference defs
     /// bsc dropped along with the caller-side condition.  No RDY method
     /// exported = constant ready.
-    fn always_en_rdy(&mut self, callee: usize, module: usize, method: StrId) -> bool {
+    fn always_en_rdy(&mut self, callee: usize, module: usize, method: MethRef) -> bool {
         let mir = self.mods[module].ir;
-        let Some(&mi) = self.mods[module].methods.get(&method) else {
+        let Some((_, me)) = self.d.modules[mir].meth(method) else {
             return true;
         };
-        let Some(id) = self.d.modules[mir].methods[mi].rdy else {
+        let Some(id) = me.rdy else {
             return true;
         };
         self.call_value(callee, id, 0, &[], 1).as_u64() & 1 == 1
@@ -2047,7 +2086,7 @@ impl Interp {
     /// schedule zeroes every EN_* at the top of the pass and sets it when
     /// the method executes, and WILL_FIRE urgency inhibitors of
     /// conflicting rules read it later in the same pass.
-    fn latch_method_en(&mut self, callee: usize, method: StrId) {
+    fn latch_method_en(&mut self, callee: usize, method: MethRef) {
         if self.vcd_trace {
             self.vcd_rec_meth_time(callee, method);
         }
@@ -2067,18 +2106,21 @@ impl Interp {
         }
     }
 
-    fn call_actionvalue(&mut self, callee: usize, method: StrId, argv: &[Value]) -> Value {
+    fn call_actionvalue(&mut self, callee: usize, method: MethRef, argv: &[Value]) -> Value {
         match &mut self.insts[callee].kind {
             InstKind::Prim(p) => {
-                let mname: &str = &self.d.strings[method as usize];
+                let MethRef::Prim(mg) = method else {
+                    panic!("user-module method reference on a primitive");
+                };
+                let mname: &str = self.d.global_name(mg);
                 p.actionvalue_method(mname, argv, self.now)
             }
             InstKind::User { module, .. } => {
                 let module = *module;
-                let mi = *self.mods[module]
-                    .methods
-                    .get(&method)
-                    .unwrap_or_else(|| panic!("unknown method {:?}", self.s(method)));
+                let MethRef::User(mi) = method else {
+                    panic!("primitive method reference on a user module");
+                };
+                let mi = mi as usize;
                 self.latch_method_en(callee, method);
                 if self.vcd_trace {
                     self.vcd_rec_meth_call(callee, method, argv);
@@ -2212,7 +2254,7 @@ impl Interp {
                     return;
                 }
                 // Arc clone, not a String: this runs per evaluated call
-                let fname = self.arg_str(*func);
+                let fname = self.global_arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .zip(signed.iter().chain(std::iter::repeat(&false)))
@@ -2226,7 +2268,7 @@ impl Interp {
                     return;
                 }
                 // Arc clone, not a String: this runs per evaluated call
-                let fname = self.arg_str(*func);
+                let fname = self.global_arg_str(*func);
                 let argv: Vec<Arg> = args
                     .iter()
                     .zip(signed.iter().chain(std::iter::repeat(&false)))
@@ -2257,8 +2299,8 @@ impl Interp {
             .d
             .foreign_funcs
             .iter()
-            .filter(|f| !is_lib_bdpi(self.s(f.c_name)))
-            .map(|f| (self.s(f.name).to_string(), self.s(f.c_name).to_string()))
+            .filter(|f| !is_lib_bdpi(self.gs(f.c_name)))
+            .map(|f| (self.gs(f.name).to_string(), self.gs(f.c_name).to_string()))
             .collect();
         self.bdpi = Some(bdpi::Bdpi::load(std::path::Path::new(path), &funcs)?);
         Ok(())
@@ -2272,7 +2314,7 @@ impl Interp {
         self.d
             .foreign_funcs
             .iter()
-            .any(|f| !is_lib_bdpi(self.s(f.c_name)))
+            .any(|f| !is_lib_bdpi(self.gs(f.c_name)))
     }
 
     /// Dispatch a non-builtin task name as a BDPI import, if the design
@@ -2282,13 +2324,13 @@ impl Interp {
             .d
             .foreign_funcs
             .iter()
-            .find(|f| self.s(f.name) == name)?
+            .find(|f| self.gs(f.name) == name)?
             .clone();
         // library BDPI: reference Bluesim links libbsprim.a (with
         // rand32.cxx) into every executable, so these imports resolve
         // without any user C files; provide them natively with the same
         // glibc calls for bit-identical streams
-        match self.s(ff.c_name) {
+        match self.gs(ff.c_name) {
             "rand32" => {
                 // rand32.cxx: return (unsigned int)random(); ours is
                 // the same glibc stream, per-engine (see GlibcRandom)
@@ -2547,14 +2589,14 @@ impl Interp {
         }
         // rule body functions
         for r in &m.rules {
-            let fk = (1u8, r.name, 0u32);
+            let fk = (1u8, r.name.0, 0u32);
             let mut seen = std::collections::HashSet::new();
             mark_stmts(&r.body, fk, &m, &defs_by_name, &mut usage, &mut seen);
         }
         // method functions (RDY_<m> methods are separate entries, so the
         // C++ METH_RDY_<m> function falls out naturally)
         for me in &m.methods {
-            let fk = (2u8, me.name, 0u32);
+            let fk = (2u8, me.name.0, 0u32);
             let mut seen = std::collections::HashSet::new();
             // NOTE: me.ready is NOT marked — the readiness cone lives in
             // the separate RDY_<m> method entry (its own C++ function)
@@ -2584,10 +2626,13 @@ impl Interp {
 
         // member selection
         // the action method each WILL_FIRE def belongs to
-        let wf_owner: HashMap<StrId, StrId> = m
+        let wf_owner: HashMap<StrId, MethRef> = m
             .methods
             .iter()
-            .filter_map(|me| me.will_fire.map(|wf| (wf, me.name)))
+            .enumerate()
+            .filter_map(|(mi, me)| {
+                me.will_fire.map(|wf| (wf, MethRef::User(mi as u32)))
+            })
             .collect();
         let mut members: Vec<ModVar> = Vec::new();
         for rst in &m.resets {
@@ -2640,7 +2685,7 @@ impl Interp {
 
         // port selection
         let mut ports: Vec<ModVar> = Vec::new();
-        for me in &m.methods {
+        for (mei, me) in m.methods.iter().enumerate() {
             let is_action = me.kind != ir::MethodKind::Value;
             if is_action {
                 if let Some(en_id) = me.en {
@@ -2648,7 +2693,7 @@ impl Interp {
                     if n_fns >= 2 || (self.d.keep_fires && n_fns >= 1) {
                         ports.push(ModVar {
                             name: self.s(en_id).to_string(),
-                            src: VcdSrc::PortEn(me.name),
+                            src: VcdSrc::PortEn(MethRef::User(mei as u32)),
                             width: 1,
                             clocked: true,
                             domain: Some(me.clock_domain),
@@ -2661,7 +2706,7 @@ impl Interp {
                 if n_fns >= 2 || a.width > 64 || (self.d.keep_fires && n_fns >= 1) {
                     ports.push(ModVar {
                         name: self.s(a.name).to_string(),
-                        src: VcdSrc::PortArg(me.name, ai),
+                        src: VcdSrc::PortArg(MethRef::User(mei as u32), ai),
                         width: a.width,
                         clocked: true,
                         domain: Some(me.clock_domain),
@@ -2690,7 +2735,7 @@ impl Interp {
                 if n_fns >= 2 || w > 64 || (self.d.keep_fires && n_fns >= 1) {
                     ports.push(ModVar {
                         name: self.s(me.name).to_string(),
-                        src: VcdSrc::PortRes(me.name),
+                        src: VcdSrc::PortRes(MethRef::User(mei as u32)),
                         width: w.max(1),
                         clocked: true,
                         domain: Some(me.clock_domain),
@@ -2736,7 +2781,7 @@ impl Interp {
 
         // FST records the scope's MODULE TYPE as its component field
         // (the fstscopes correlation surface); VCD ignores it
-        let mtype = self.s(self.d.modules[mir].name).to_string();
+        let mtype = self.gs(self.d.modules[mir].name).to_string();
         w.scope_start(name, Some(&mtype));
         let base = w.reserve_ids((mv.members.len() + mv.ports.len() + prims.len()) as u32);
 
@@ -2850,9 +2895,9 @@ impl Interp {
         }
         // input clock port: chase the parent's binding expression
         if let InstKind::User { clk_binds, .. } = &self.insts[inst].kind {
-            let pid = self.d.str_id(wire).map(|i| i as usize);
+            let pid = self.d.str_id(wire);
             if let Some(pid) = pid {
-                if let Some((owner, e)) = clk_binds.get(&(pid as StrId)) {
+                if let Some((owner, e)) = clk_binds.get(&pid) {
                     let (owner, e) = (*owner, e.clone());
                     let osc = match &e {
                         Expr::Clock { osc, .. } => osc.as_ref().clone(),
@@ -3090,7 +3135,7 @@ impl Interp {
                         panic!(
                             "no schedule for domain {} in {:?}",
                             e.domain,
-                            self.s(self.d.modules[mir].name)
+                            self.gs(self.d.modules[mir].name)
                         )
                     });
                 REntry {
@@ -3155,7 +3200,7 @@ impl Interp {
 
     /// The instance an interned path names.
     fn inst_of_path(&self, path: StrId) -> usize {
-        let p: &str = &self.d.strings[path as usize];
+        let p: &str = self.d.name(path);
         *self
             .inst_by_path
             .get(p)
@@ -3397,11 +3442,11 @@ impl Interp {
     /// edges); interface output clocks and input clock ports chase
     /// through ifc_clocks / instantiation bindings to their oscillator;
     /// noClock and non-default top input clocks never fire.
-    fn resolve_source(&self, clock: StrId) -> ClockSource {
+    fn resolve_source(&self, clock: GlobalStrId) -> ClockSource {
         if Some(clock) == self.d.default_clock {
             return Self::default_wave();
         }
-        let name = self.s(clock).to_string();
+        let name = self.gs(clock).to_string();
         self.resolve_clock_at(0, &name)
     }
 
@@ -3447,7 +3492,7 @@ impl Interp {
         let mir = self.mods[module].ir;
         if self.insts[inst].path.is_empty() {
             if let Some(dc) = self.d.default_clock {
-                if self.s(dc) == wire {
+                if self.gs(dc) == wire {
                     return Self::default_wave();
                 }
             }
@@ -3697,7 +3742,7 @@ impl Interp {
         // distinct clocks in first-appearance order, with the default
         // clock first: the kernel defines it before derived clocks, and
         // VCD clock ids follow definition order (CLK = id 0 = '!')
-        let mut clocks: Vec<StrId> = Vec::new();
+        let mut clocks: Vec<GlobalStrId> = Vec::new();
         if let Some(dc) = self.d.default_clock {
             if comps.iter().any(|c| c.clock == dc) {
                 clocks.push(dc);
@@ -3743,7 +3788,7 @@ impl Interp {
                     }
                     ClockSource::Never => "never".to_string(),
                 };
-                eprintln!("clock[{ci}] {:?}: {k}", self.s(c));
+                eprintln!("clock[{ci}] {:?}: {k}", self.gs(c));
             }
         }
         // clock-driver prim instance -> clock index, for routing triggered
@@ -3806,7 +3851,7 @@ impl Interp {
                             .get(&ppath)
                             .unwrap_or_else(|| panic!("unknown tick instance {ppath:?}"));
                         let owner = *self.inst_by_path.get(&ipath).unwrap_or(&0);
-                        let pname = self.d.strings[tk.port as usize].clone();
+                        let pname = self.d.name(tk.port).to_string();
                         (ii, pname, tk.reset, owner, tk.gate.clone())
                     })
                     // no-op ticks (Reg/ConfigReg/FIFO clock ticks) cost a
@@ -3896,7 +3941,7 @@ impl Interp {
                 .iter()
                 .enumerate()
                 .map(|(ci, &c)| VcdClock {
-                    name: self.s(c).to_string(),
+                    name: self.gs(c).to_string(),
                     vcd_id: 0,
                     cur: match &sources[ci] {
                         ClockSource::Wave(w) => w.init_high,
@@ -3986,7 +4031,7 @@ impl Interp {
         }
         // clock-source prims alias the clock they DRIVE (CLK_OUT)
         for (ci, &c) in clocks.iter().enumerate() {
-            let cname = self.s(c).to_string();
+            let cname = self.gs(c).to_string();
             if let Some(cpath) = cname.strip_suffix("$CLK_OUT") {
                 if let Some(&pi) = self.inst_by_path.get(cpath) {
                     self.vcd_inst_clock[pi] = ci;
@@ -5107,7 +5152,7 @@ pub(crate) fn emit_output_errors(errs: &[String]) {
 
 fn cookie_key(cookie: u32) -> StrId {
     // cookies live in a synthetic key space far above real string ids
-    0x8000_0000 | cookie
+    ModuleStrId(0x8000_0000 | cookie)
 }
 
 /// Outcome of a trs link Emit request.
@@ -5377,22 +5422,23 @@ impl Interp {
     pub fn method_port_symbols(
         &self,
         i: usize,
-    ) -> Vec<(String, u32, StrId, MethPortKind)> {
+    ) -> Vec<(String, u32, MethRef, MethPortKind)> {
         let InstKind::User { module, .. } = &self.insts[i].kind else {
             return Vec::new();
         };
         let mir = self.mods[*module].ir;
         let mut out = Vec::new();
-        for m in &self.d.modules[mir].methods {
+        for (mi, m) in self.d.modules[mir].methods.iter().enumerate() {
+            let mref = MethRef::User(mi as u32);
             let mname = self.s(m.name).to_string();
             if let Some(en) = m.en {
-                out.push((self.s(en).to_string(), 1, m.name, MethPortKind::En));
+                out.push((self.s(en).to_string(), 1, mref, MethPortKind::En));
             }
             for (k, a) in m.args.iter().enumerate() {
                 out.push((
                     self.s(a.name).to_string(),
                     a.width.max(1),
-                    m.name,
+                    mref,
                     MethPortKind::Arg(k),
                 ));
             }
@@ -5400,7 +5446,7 @@ impl Interp {
             // RDY port to register (interim until the exporter carries
             // the surviving methodPorts set)
             if !matches!(m.ready, Some(Expr::Const { .. }) | None) {
-                out.push((format!("RDY_{mname}"), 1, m.name, MethPortKind::Rdy));
+                out.push((format!("RDY_{mname}"), 1, mref, MethPortKind::Rdy));
             }
             if m.result.is_some() {
                 let w = match m.result.as_ref().unwrap() {
@@ -5412,7 +5458,7 @@ impl Interp {
                         .unwrap_or(1),
                     e => e.width().max(1),
                 };
-                out.push((mname, w.max(1), m.name, MethPortKind::Result));
+                out.push((mname, w.max(1), mref, MethPortKind::Result));
             }
         }
         out
@@ -5424,7 +5470,7 @@ impl Interp {
     pub fn method_port_peek(
         &mut self,
         i: usize,
-        method: StrId,
+        method: MethRef,
         kind: MethPortKind,
         width: u32,
     ) -> Value {
@@ -5438,7 +5484,7 @@ impl Interp {
                 let id = self.en_id_at(i, method);
                 let mut set = match (&self.insts[i].kind, id) {
                     (InstKind::User { latched, .. }, Some(id)) => {
-                        latched.contains_key(&(id as StrId))
+                        latched.contains_key(&id)
                     }
                     _ => false,
                 };
@@ -5446,7 +5492,7 @@ impl Interp {
                 // boxed latch map
                 if !set && !self.jit_arena_ptr.is_null() {
                     if let Some(id) = id {
-                        if let Some(&slot) = self.jit_en_slots.get(&(i, id as StrId))
+                        if let Some(&slot) = self.jit_en_slots.get(&(i, id))
                         {
                             set = unsafe { *self.jit_arena_ptr.add(slot as usize) }
                                 != 0;
@@ -5490,9 +5536,9 @@ impl Interp {
                     .unwrap_or_else(|| Value::zero(width.max(1)))
             }
             MethPortKind::Rdy => {
-                let mi = match self.mods[module].methods.get(&method) {
-                    Some(&mi) => mi,
-                    None => return Value::zero(width.max(1)),
+                let Some(mi) = self.d.modules[mir].meth(method).map(|(i, _)| i)
+                else {
+                    return Value::zero(width.max(1));
                 };
                 let m = &self.d.modules[mir].methods[mi];
                 let e = m.ready.clone();
@@ -5733,7 +5779,7 @@ impl Interp {
 
     /// Top module name (the new_MODEL_<top> shim symbol).
     pub fn top_name(&self) -> &str {
-        self.s(self.d.top)
+        self.gs(self.d.top)
     }
 
     /// Stage a +arg (without the '+') for $test$plusargs/$value$plusargs.

--- a/src/trs/crates/trs-interp/src/lib.rs
+++ b/src/trs/crates/trs-interp/src/lib.rs
@@ -159,7 +159,7 @@ pub struct Interp {
     /// method -> EN_<method> / RDY_<method>.  Asked once per method
     /// call, and the answer is a property of the design, so the derived
     /// name is built once rather than on every call.
-    en_id_of_meth: HashMap<StrId, Option<StrId>>,
+    en_id_of_meth: HashMap<(usize, StrId), Option<StrId>>,
     insts: Vec<Inst>,
     cycle: u64,
     /// current simulation time (the time of the executing clock edge)
@@ -790,9 +790,8 @@ impl Interp {
                             .iter()
                             .map(|a| (a.name, (a.width, a.kind)))
                             .chain(
-                                str_ids
-                                    .get(format!("EN_{}", d.strings[me.name as usize]).as_str())
-                                    .map(|&en| (en, (1, ir::PortKind::MethodEnable))),
+                                me.en
+                                    .map(|en| (en, (1, ir::PortKind::MethodEnable))),
                             )
                             .collect::<Vec<_>>()
                     }))
@@ -2003,13 +2002,28 @@ impl Interp {
 
     /// The interned id of a method's companion EN_ signal, or None where
     /// the design exports no such signal.
-    fn en_id_of(&mut self, method: StrId) -> Option<StrId> {
-        if let Some(v) = self.en_id_of_meth.get(&method).copied() {
+    pub(crate) fn en_id_at(&self, inst: usize, method: StrId) -> Option<StrId> {
+        let InstKind::User { module, .. } = &self.insts[inst].kind else {
+            return None;
+        };
+        let mir = self.mods[*module].ir;
+        self.d.modules[mir]
+            .methods
+            .iter()
+            .find(|m| m.name == method)
+            .and_then(|m| m.en)
+    }
+
+    fn en_id_of(&mut self, callee: usize, method: StrId) -> Option<StrId> {
+        let InstKind::User { module, .. } = &self.insts[callee].kind else {
+            return None;
+        };
+        let mir = self.mods[*module].ir;
+        if let Some(v) = self.en_id_of_meth.get(&(mir, method)).copied() {
             return v;
         }
-        let name = format!("EN_{}", self.s(method));
-        let v = self.d.str_id(&name);
-        self.en_id_of_meth.insert(method, v);
+        let v = self.en_id_at(callee, method);
+        self.en_id_of_meth.insert((mir, method), v);
         v
     }
 
@@ -2037,7 +2051,7 @@ impl Interp {
         if self.vcd_trace {
             self.vcd_rec_meth_time(callee, method);
         }
-        if let Some(en_id) = self.en_id_of(method) {
+        if let Some(en_id) = self.en_id_of(callee, method) {
             if let Some(c) = self.census.as_mut() {
                 c.exec_latch(callee, en_id, &Value::from_u64(1, 1));
             }
@@ -2549,8 +2563,7 @@ impl Interp {
                 mark_expr(res, fk, &m, &defs_by_name, &mut usage, &mut seen);
             }
             // the method function writes its own EN/arg/result ports
-            let en = format!("EN_{}", self.s(me.name));
-            if let Some(en_id) = self.d.str_id(&en) {
+            if let Some(en_id) = me.en {
                 usage.entry(en_id).or_default().insert(fk);
             }
             for a in &me.args {
@@ -2630,12 +2643,11 @@ impl Interp {
         for me in &m.methods {
             let is_action = me.kind != ir::MethodKind::Value;
             if is_action {
-                let en = format!("EN_{}", self.s(me.name));
-                if let Some(en_id) = self.d.str_id(&en) {
+                if let Some(en_id) = me.en {
                     let n_fns = usage.get(&en_id).map(|s| s.len()).unwrap_or(0);
                     if n_fns >= 2 || (self.d.keep_fires && n_fns >= 1) {
                         ports.push(ModVar {
-                            name: en,
+                            name: self.s(en_id).to_string(),
                             src: VcdSrc::PortEn(me.name),
                             width: 1,
                             clocked: true,
@@ -5373,13 +5385,8 @@ impl Interp {
         let mut out = Vec::new();
         for m in &self.d.modules[mir].methods {
             let mname = self.s(m.name).to_string();
-            if m.kind != trs_ir::MethodKind::Value {
-                out.push((
-                    format!("EN_{mname}"),
-                    1,
-                    m.name,
-                    MethPortKind::En,
-                ));
+            if let Some(en) = m.en {
+                out.push((self.s(en).to_string(), 1, m.name, MethPortKind::En));
             }
             for (k, a) in m.args.iter().enumerate() {
                 out.push((
@@ -5428,8 +5435,7 @@ impl Interp {
         let mir = self.mods[module].ir;
         match kind {
             MethPortKind::En => {
-                let en = format!("EN_{}", self.s(method));
-                let id = self.d.str_id(&en).map(|i| i as usize);
+                let id = self.en_id_at(i, method);
                 let mut set = match (&self.insts[i].kind, id) {
                     (InstKind::User { latched, .. }, Some(id)) => {
                         latched.contains_key(&(id as StrId))

--- a/src/trs/crates/trs-interp/src/runcore.rs
+++ b/src/trs/crates/trs-interp/src/runcore.rs
@@ -23,6 +23,8 @@
 //! decode, no Interp, no reflection: precisely the prims the compiled
 //! code can bounce on, nothing else.
 
+use crate::value::{DynStrId, StrRef};
+use trs_ir::GlobalStrId;
 use std::collections::HashMap;
 
 use crate::foreign::ForeignEnv;
@@ -326,7 +328,7 @@ struct RunCore {
     buf: Vec<u8>,
     strings: Vec<(u32, u32)>,
     dyn_strs: Vec<String>,
-    arg_strs: HashMap<u32, std::sync::Arc<str>>,
+    arg_strs: HashMap<DynStrId, std::sync::Arc<str>>,
     paths: Vec<(u32, u32)>,
     protos: Vec<FnProtos>,
     /// $random/$srandom (library rand32/srand BDPI): same fresh glibc
@@ -351,38 +353,43 @@ struct RunCore {
 }
 
 impl RunCore {
-    fn s(&self, id: u32) -> &str {
-        let n = self.strings.len();
-        if (id as usize) < n {
-            table_str(&self.buf, self.strings[id as usize])
-        } else {
-            &self.dyn_strs[id as usize - n]
-        }
+    fn gs(&self, id: GlobalStrId) -> &str {
+        table_str(&self.buf, self.strings[id.idx()])
     }
-    fn arg_str(&mut self, id: u32) -> std::sync::Arc<str> {
-        // design-table ids take a dense index (no per-call hashing);
-        // dyn ids (appended past the table) stay on the map
-        let n = self.strings.len();
-        if (id as usize) < n {
-            if self.arg_strs_vec.is_empty() {
-                self.arg_strs_vec = vec![None; n];
+
+    fn dyn_text(&self, id: DynStrId) -> &str {
+        &self.dyn_strs[id.idx()]
+    }
+
+    fn arg_str(&mut self, r: StrRef) -> std::sync::Arc<str> {
+        // a table id takes a dense index, so the common case does no
+        // hashing; the run's own strings are sparse and take the map
+        match r {
+            StrRef::Static(id) => {
+                let n = self.strings.len();
+                if self.arg_strs_vec.is_empty() {
+                    self.arg_strs_vec = vec![None; n];
+                }
+                if let Some(a) = &self.arg_strs_vec[id.idx()] {
+                    return a.clone();
+                }
+                let a: std::sync::Arc<str> = std::sync::Arc::from(table_str(
+                    &self.buf,
+                    self.strings[id.idx()],
+                ));
+                self.arg_strs_vec[id.idx()] = Some(a.clone());
+                a
             }
-            if let Some(a) = &self.arg_strs_vec[id as usize] {
-                return a.clone();
+            StrRef::Dyn(id) => {
+                if let Some(a) = self.arg_strs.get(&id) {
+                    return a.clone();
+                }
+                let a: std::sync::Arc<str> =
+                    std::sync::Arc::from(self.dyn_text(id));
+                self.arg_strs.insert(id, a.clone());
+                a
             }
-            let a: std::sync::Arc<str> = std::sync::Arc::from(table_str(
-                &self.buf,
-                self.strings[id as usize],
-            ));
-            self.arg_strs_vec[id as usize] = Some(a.clone());
-            return a;
         }
-        if let Some(a) = self.arg_strs.get(&id) {
-            return a.clone();
-        }
-        let a: std::sync::Arc<str> = std::sync::Arc::from(self.s(id));
-        self.arg_strs.insert(id, a.clone());
-        a
     }
 }
 
@@ -417,7 +424,7 @@ unsafe extern "C" fn runcore_foreign_cb(
     let mut off = 0usize;
     for a in &fs.args {
         match *a {
-            FArgSpec::Str(sid) => argv.push(Arg::Str(rc.arg_str(sid))),
+            FArgSpec::Str(sid) => argv.push(Arg::Str(rc.arg_str(StrRef::Static(sid)))),
             FArgSpec::Num { width, signed } => {
                 let words = ((width.max(1) as usize) + 63) / 64;
                 let limbs = std::slice::from_raw_parts(args.add(off), words);
@@ -433,7 +440,7 @@ unsafe extern "C" fn runcore_foreign_cb(
             }
             FArgSpec::StrDyn => {
                 let word = *args.add(off);
-                argv.push(Arg::Str(rc.arg_str(word as u32)));
+                argv.push(Arg::Str(rc.arg_str(StrRef::from_word(word))));
                 off += 1;
             }
         }
@@ -446,16 +453,16 @@ unsafe extern "C" fn runcore_foreign_cb(
                 text.push_str(s);
             }
         }
-        let id = rc.strings.len() + rc.dyn_strs.len();
         rc.dyn_strs.push(text);
-        *out = id as u64;
+        let id = DynStrId((rc.dyn_strs.len() - 1) as u32);
+        *out = StrRef::Dyn(id).to_word();
         argv.clear();
         rc.foreign_argv = argv;
         return 0;
     }
     let mut name = std::mem::take(&mut rc.fname_buf);
     name.clear();
-    name.push_str(rc.s(func));
+    name.push_str(rc.gs(func));
     let mut loc = std::mem::take(&mut rc.loc_buf);
     loc.clear();
     loc.push_str("top");
@@ -554,7 +561,7 @@ unsafe extern "C" fn runcore_prim_cb(
         let name: &str = table_str(
             &rc.buf,
             *rc.strings
-                .get(pc.method as usize)
+                .get(pc.method.idx())
                 .expect("prim method id outside the design string table"),
         );
         p.action_method(name, pc.port, &argv, rc.now);
@@ -562,7 +569,7 @@ unsafe extern "C" fn runcore_prim_cb(
         let name: &str = table_str(
             &rc.buf,
             *rc.strings
-                .get(pc.method as usize)
+                .get(pc.method.idx())
                 .expect("prim method id outside the design string table"),
         );
         let v = p.value_method(name, pc.port, &argv, rc.now);

--- a/src/trs/crates/trs-interp/src/topbind.rs
+++ b/src/trs/crates/trs-interp/src/topbind.rs
@@ -73,7 +73,7 @@ pub(crate) struct ResolvedBinds {
     pub params: Vec<(ir::StrId, Value)>,
     /// always_enabled Action methods to auto-fire, in interface
     /// order, each with its constant argument values.
-    pub autofire: Vec<(ir::StrId, Vec<Value>)>,
+    pub autofire: Vec<(ir::MethRef, Vec<Value>)>,
     /// (composition index, entry index) -> autofire indices to invoke
     /// after that entry's nodes: each method's EXEC schedule position.
     /// A method's Exec node cuts the top's own schedule at the LAST
@@ -199,7 +199,8 @@ pub(crate) fn resolve(
         .iter()
         .find(|m| m.name == d.top)
         .ok_or_else(|| "top module not found".to_string())?;
-    let s = |id: ir::StrId| d.strings[id as usize].as_str();
+    let s = |id: ir::StrId| d.name(id);
+    let gs = |id: ir::GlobalStrId| d.global_name(id);
 
     // ---- bindable surface ----
     // top-level arguments/parameters: the module's MethodArg inputs
@@ -210,9 +211,9 @@ pub(crate) fn resolve(
         .map(|p| (p.name, p.width))
         .collect();
     // always_enabled methods (arm even with no bindings on the CLI)
-    let mut autofire: Vec<(ir::StrId, Vec<(ir::StrId, Option<ir::StrId>, u32)>)> =
+    let mut autofire: Vec<(ir::MethRef, Vec<(ir::StrId, Option<ir::StrId>, u32)>)> =
         Vec::new();
-    for m in &top.methods {
+    for (mi, m) in top.methods.iter().enumerate() {
         if !m.always_enabled {
             continue;
         }
@@ -234,7 +235,7 @@ pub(crate) fn resolve(
         // reference to a constant def — chase the chain rather than
         // pattern-matching one shape.
         if let Some(rdy_id) = m.rdy {
-            if let Some(rm) = top.methods.iter().find(|x| x.name == rdy_id) {
+            if let Some((_, rm)) = top.meth(rdy_id) {
                 let const_true = match &rm.result {
                     None => true,
                     Some(e) => {
@@ -252,7 +253,7 @@ pub(crate) fn resolve(
             }
         }
         autofire.push((
-            m.name,
+            ir::MethRef::User(mi as u32),
             m.args.iter().map(|a| (a.name, a.base, a.width)).collect(),
         ));
     }
@@ -321,11 +322,15 @@ pub(crate) fn resolve(
         .iter()
         .map(|&(n, w)| (s(n).to_string(), n, w))
         .collect();
-    for (mname, args) in &autofire {
+    for (mref, args) in &autofire {
+        let mname = match top.meth(*mref) {
+            Some((_, m)) => m.name,
+            None => continue,
+        };
         for &(an, abase, aw) in args {
             // the binding key is the user-facing "<method>.<arg>"
             let disp = abase.map(|b| s(b)).unwrap_or(s(an));
-            surface.push((format!("{}.{}", s(*mname), disp), an, aw));
+            surface.push((format!("{}.{}", s(mname), disp), an, aw));
         }
     }
 
@@ -386,17 +391,15 @@ pub(crate) fn resolve(
         return Err(format!(
             "top-level module `{}' requires bindings for: {} \
              (supply +NAME=value, or --bind NAME=value)",
-            s(d.top),
+            gs(d.top),
             missing.join(", ")
         ));
     }
 
     // EN_<m> reads constant 1 for auto-fired methods (tied high)
-    let mut af: Vec<(ir::StrId, Vec<Value>)> = Vec::new();
-    for (mname, args) in &autofire {
-        if let Some(en) =
-            top.methods.iter().find(|m| m.name == *mname).and_then(|m| m.en)
-        {
+    let mut af: Vec<(ir::MethRef, Vec<Value>)> = Vec::new();
+    for (mref, args) in &autofire {
+        if let Some(en) = top.meth(*mref).and_then(|(_, m)| m.en) {
             params.push((en, Value::from_u64(1, 1)));
         }
         let argv: Vec<Value> = args
@@ -409,7 +412,7 @@ pub(crate) fn resolve(
                     .expect("auto-fire arg bound above")
             })
             .collect();
-        af.push((*mname, argv));
+        af.push((*mref, argv));
     }
 
     let salt = if bound.is_empty() && af.is_empty() {
@@ -442,9 +445,8 @@ pub(crate) fn resolve(
             .collect();
         for (mi, _) in af.iter().enumerate() {
             let m = top
-                .methods
-                .iter()
-                .find(|x| x.name == af[mi].0)
+                .meth(af[mi].0)
+                .map(|(_, mm)| mm)
                 .expect("autofire method exists");
             if body_calls_user_child(top, &m.body, &user_children) {
                 return Err(format!(
@@ -462,7 +464,7 @@ pub(crate) fn resolve(
                 .entries
                 .iter()
                 .enumerate()
-                .filter(|(_, e)| d.strings[e.instance as usize].is_empty())
+                .filter(|(_, e)| d.name(e.instance).is_empty())
                 .map(|(ei, e)| (ei, e.domain, e.segment))
                 .collect();
             if tops.is_empty() {
@@ -470,8 +472,9 @@ pub(crate) fn resolve(
             }
             // placement per method: (anchor, cut segment, pos in cut)
             let mut placed: Vec<(Option<usize>, u32, usize, usize)> = Vec::new();
-            for (mi, (mname, _)) in af.iter().enumerate() {
-                let meth = top.methods.iter().find(|x| x.name == *mname).unwrap();
+            for (mi, (mref, _)) in af.iter().enumerate() {
+                let meth = top.meth(*mref).map(|(_, m)| m).unwrap();
+                let mname_of = Some(meth.name);
                 let dm = meth.clock_domain;
                 let Some(ms) = top
                     .schedule
@@ -497,7 +500,7 @@ pub(crate) fn resolve(
                     .find_map(|(k, seg)| {
                         seg.cut
                             .iter()
-                            .position(|c| c == mname)
+                            .position(|c| Some(*c) == mname_of)
                             .map(|p| (k as u32, p))
                     })
                 else {
@@ -529,7 +532,9 @@ pub(crate) fn resolve(
                 "top-level always_enabled method `{}' has no schedule \
                  anchor: v1 auto-firing requires a top-level rule in \
                  the method's clock domain",
-                s(af[mi].0)
+                top.meth(af[mi].0)
+                    .map(|(_, m)| s(m.name))
+                    .unwrap_or("?")
             ));
         }
     }

--- a/src/trs/crates/trs-interp/src/topbind.rs
+++ b/src/trs/crates/trs-interp/src/topbind.rs
@@ -97,19 +97,6 @@ pub(crate) struct ResolvedBinds {
     pub consumed_plus: Vec<String>,
 }
 
-/// name -> interned id, the other direction from `Design::strings`.
-/// Built once per resolve: the callers ask for derived names
-/// (`RDY_<m>`, `EN_<m>`) once per top-level method, and scanning the
-/// table for each is O(methods * strings) for an answer a map gives
-/// directly.
-fn str_index(d: &ir::Design) -> std::collections::HashMap<&str, ir::StrId> {
-    d.strings
-        .iter()
-        .enumerate()
-        .map(|(i, s)| (s.as_str(), i as ir::StrId))
-        .collect()
-}
-
 /// Resolve an expression to a constant u64 by chasing def references
 /// (bounded depth).  None = not (provably) constant.
 fn resolve_const(m: &ir::Module, e: &ir::Expr, depth: u32) -> Option<u64> {
@@ -213,7 +200,6 @@ pub(crate) fn resolve(
         .find(|m| m.name == d.top)
         .ok_or_else(|| "top module not found".to_string())?;
     let s = |id: ir::StrId| d.strings[id as usize].as_str();
-    let sidx = str_index(d);
 
     // ---- bindable surface ----
     // top-level arguments/parameters: the module's MethodArg inputs
@@ -224,7 +210,8 @@ pub(crate) fn resolve(
         .map(|p| (p.name, p.width))
         .collect();
     // always_enabled methods (arm even with no bindings on the CLI)
-    let mut autofire: Vec<(ir::StrId, Vec<(ir::StrId, u32)>)> = Vec::new();
+    let mut autofire: Vec<(ir::StrId, Vec<(ir::StrId, Option<ir::StrId>, u32)>)> =
+        Vec::new();
     for m in &top.methods {
         if !m.always_enabled {
             continue;
@@ -266,7 +253,7 @@ pub(crate) fn resolve(
         }
         autofire.push((
             m.name,
-            m.args.iter().map(|a| (a.name, a.width)).collect(),
+            m.args.iter().map(|a| (a.name, a.base, a.width)).collect(),
         ));
     }
 
@@ -335,12 +322,9 @@ pub(crate) fn resolve(
         .map(|&(n, w)| (s(n).to_string(), n, w))
         .collect();
     for (mname, args) in &autofire {
-        for &(an, aw) in args {
-            // arg ports export as "<method>_<arg>"; the binding key
-            // is the user-facing "<method>.<arg>"
-            let disp = s(an)
-                .strip_prefix(&format!("{}_", s(*mname)))
-                .unwrap_or(s(an));
+        for &(an, abase, aw) in args {
+            // the binding key is the user-facing "<method>.<arg>"
+            let disp = abase.map(|b| s(b)).unwrap_or(s(an));
             surface.push((format!("{}.{}", s(*mname), disp), an, aw));
         }
     }
@@ -410,12 +394,14 @@ pub(crate) fn resolve(
     // EN_<m> reads constant 1 for auto-fired methods (tied high)
     let mut af: Vec<(ir::StrId, Vec<Value>)> = Vec::new();
     for (mname, args) in &autofire {
-        if let Some(&en) = sidx.get(format!("EN_{}", s(*mname)).as_str()) {
+        if let Some(en) =
+            top.methods.iter().find(|m| m.name == *mname).and_then(|m| m.en)
+        {
             params.push((en, Value::from_u64(1, 1)));
         }
         let argv: Vec<Value> = args
             .iter()
-            .map(|&(an, _)| {
+            .map(|&(an, _, _)| {
                 params
                     .iter()
                     .find(|(p, _)| *p == an)

--- a/src/trs/crates/trs-interp/src/value.rs
+++ b/src/trs/crates/trs-interp/src/value.rs
@@ -80,6 +80,52 @@ impl std::ops::DerefMut for Limbs {
     }
 }
 
+/// A string built while the design runs: an index into the engine's own
+/// arena.  It belongs to no module, so it is numbered on its own and not
+/// as a position in anyone's table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DynStrId(pub u32);
+
+impl DynStrId {
+    #[inline]
+    pub fn idx(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// What a string-valued marker denotes: a literal a module interned, or
+/// a string the run produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StrRef {
+    Static(trs_ir::ModuleStrId),
+    Dyn(DynStrId),
+}
+
+/// Distinguishes the two spaces in a single word.  Both ids are 32 bits,
+/// so the tag sits above them and neither space constrains the other's
+/// numbering.
+const DYN_TAG: u64 = 1 << 32;
+
+impl StrRef {
+    /// The form the arena and the marker value carry.
+    #[inline]
+    pub fn to_word(self) -> u64 {
+        match self {
+            StrRef::Static(i) => i.0 as u64,
+            StrRef::Dyn(i) => DYN_TAG | i.0 as u64,
+        }
+    }
+
+    #[inline]
+    pub fn from_word(w: u64) -> StrRef {
+        if w & DYN_TAG != 0 {
+            StrRef::Dyn(DynStrId(w as u32))
+        } else {
+            StrRef::Static(trs_ir::ModuleStrId(w as u32))
+        }
+    }
+}
+
 /// Marker width for string-valued `Value`s (see `Value::str_ref`).
 pub const STR_MARKER: u32 = u32::MAX;
 pub const REAL_MARKER: u32 = u32::MAX - 1;
@@ -488,13 +534,13 @@ impl Value {
     /// A dynamically selected string value: carries an interned string id
     /// instead of bits.  Only valid as a task argument; the marker width
     /// keeps it inert through muxes and def stores.
-    pub fn str_ref(id: u32) -> Value {
-        Value { width: STR_MARKER, limbs: Limbs::S([id as u64]) }
+    pub fn str_ref(r: StrRef) -> Value {
+        Value { width: STR_MARKER, limbs: Limbs::S([r.to_word()]) }
     }
 
-    pub fn as_str_id(&self) -> Option<u32> {
+    pub fn as_str_ref(&self) -> Option<StrRef> {
         if self.width == STR_MARKER {
-            Some(self.limbs[0] as u32)
+            Some(StrRef::from_word(self.limbs[0]))
         } else {
             None
         }
@@ -622,6 +668,23 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
+    /// The two string spaces share one word across the compiled
+    /// boundary and one marker value, so the tag has to survive both
+    /// directions for every id either space can hold.
+    #[test]
+    fn str_ref_word_round_trip() {
+        for n in [0u32, 1, 0x7fff_ffff, 0x8000_0000, u32::MAX] {
+            let stat = StrRef::Static(trs_ir::ModuleStrId(n));
+            let dynr = StrRef::Dyn(DynStrId(n));
+            assert_eq!(StrRef::from_word(stat.to_word()), stat, "static {n}");
+            assert_eq!(StrRef::from_word(dynr.to_word()), dynr, "dyn {n}");
+            assert_ne!(stat.to_word(), dynr.to_word(), "spaces collide at {n}");
+            // and through a marker value, which is how a mux carries one
+            assert_eq!(Value::str_ref(stat).as_str_ref(), Some(stat));
+            assert_eq!(Value::str_ref(dynr).as_str_ref(), Some(dynr));
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/src/trs/crates/trs-ir/src/expr.rs
+++ b/src/trs/crates/trs-ir/src/expr.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::StrId;
+use crate::{GlobalStrId, MethRef, StrId};
 
 /// A combinational expression.  Widths are explicit everywhere; values wider
 /// than 64 bits carry their constants as little-endian 32-bit limbs (matching
@@ -22,19 +22,19 @@ pub enum Expr {
     MethCall {
         width: u32,
         instance: StrId,
-        method: StrId,
+        method: MethRef,
         /// Port number for multi-ported methods.
         port: u32,
         args: Vec<Expr>,
     },
     /// The returned value of an ActionValue method; the action side carries
     /// the arguments (split as in `AMethValue`, `ASyntax.hs:1049`).
-    MethValue { width: u32, instance: StrId, method: StrId },
+    MethValue { width: u32, instance: StrId, method: MethRef },
     /// Value of an ActionValue foreign task, correlated by cookie
     /// (`ATaskValue`).
     TaskValue { width: u32, cookie: u32 },
     /// Foreign (BDPI) value function call.
-    ForeignCall { width: u32, func: StrId, args: Vec<Expr> },
+    ForeignCall { width: u32, func: GlobalStrId, args: Vec<Expr> },
     /// String literal (`ASStr`) — `$display` format strings and the like.
     Str(StrId),
     /// An abstract clock value (`ASClock`) — appears in instantiation
@@ -141,14 +141,14 @@ pub enum Action {
     /// Conditional action-method call: `if (cond) instance.method(args)`.
     MethCall {
         instance: StrId,
-        method: StrId,
+        method: MethRef,
         port: u32,
         cond: Expr,
         args: Vec<Expr>,
     },
     /// Foreign action call ($display-family or BDPI action).
     Foreign {
-        func: StrId,
+        func: GlobalStrId,
         cond: Expr,
         args: Vec<Expr>,
         /// Per-arg signed-display flags (`encodeArgs`'s "-" prefix,
@@ -158,7 +158,7 @@ pub enum Action {
     /// Foreign ActionValue task; `cookie` links to `Expr::TaskValue`,
     /// `temp` is the def receiving the value (`ATaskAction`).
     Task {
-        func: StrId,
+        func: GlobalStrId,
         cookie: u32,
         temp: Option<StrId>,
         width: u32,

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -26,7 +26,7 @@ pub use schedule::{
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 5;
+pub const BIR_VERSION: u32 = 6;
 
 /// magic(8) | BIR_VERSION le32(4) = 12 bytes, ahead of the CBOR body.
 ///
@@ -283,6 +283,10 @@ pub struct Port {
     pub name: StrId,
     pub width: u32,
     pub kind: PortKind,
+    /// A method argument's own name, without the method that qualifies
+    /// it in `name`.  The exporter records it so that reaching an
+    /// argument takes no knowledge of how the port name is composed.
+    pub base: Option<StrId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -412,6 +416,10 @@ pub struct Method {
     /// The def this method's function writes to record that it fired
     /// (cvtIFace wf_stmts).  Action and ActionValue methods only.
     pub will_fire: Option<StrId>,
+    /// The def carrying this method's enable, when the module has one.
+    /// The exporter names it, so nothing downstream spells the
+    /// convention.
+    pub en: Option<StrId>,
 }
 
 impl Module {

--- a/src/trs/crates/trs-ir/src/lib.rs
+++ b/src/trs/crates/trs-ir/src/lib.rs
@@ -26,7 +26,7 @@ pub use schedule::{
 
 /// Schema version; bumped on any incompatible change.  The bsc exporter
 /// writes it, `Design::decode` rejects mismatches.
-pub const BIR_VERSION: u32 = 6;
+pub const BIR_VERSION: u32 = 7;
 
 /// magic(8) | BIR_VERSION le32(4) = 12 bytes, ahead of the CBOR body.
 ///
@@ -69,8 +69,72 @@ pub fn fnv1a(bytes: &[u8]) -> u64 {
     h
 }
 
-/// Identifier interned per design; display names live in `Design::strings`.
-pub type StrId = u32;
+/// An identifier scoped to one module type: an index into that module's
+/// own string table.  Renumberable within a fragment, and meaningless
+/// against any other module.
+///
+/// Serializes as the bare integer it wraps.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct ModuleStrId(pub u32);
+
+/// How a call names the method it invokes.  A primitive's methods are a
+/// vocabulary every design shares, so a call on one names it; a user
+/// module's methods are its own, so a call on one names a position in
+/// the callee's method list and carries no identifier out of it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum MethRef {
+    Prim(GlobalStrId),
+    User(u32),
+}
+
+/// An identifier in the link-level table: the vocabulary fragments share.
+/// Module type names, instance paths, and any name one module writes for
+/// another module to resolve.
+///
+/// Serializes as the bare integer it wraps.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct GlobalStrId(pub u32);
+
+impl std::fmt::Display for ModuleStrId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Display for GlobalStrId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ModuleStrId {
+    /// The table position.  Every place an id leaves its type goes
+    /// through this, so those places can be found.
+    #[inline]
+    pub fn idx(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl GlobalStrId {
+    #[inline]
+    pub fn idx(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// One table backs both spaces, so the module scope is the default:
+/// `GlobalStrId` is written where a reference crosses a fragment
+/// boundary.
+pub type StrId = ModuleStrId;
 
 thread_local! {
     /// Snap ENCODE side-blob: while `Some`, `Lazy` fields serialize as
@@ -206,17 +270,17 @@ pub struct Design {
     /// string table cannot distinguish a call to `$dumpvars` from a
     /// string literal equal to it.
     pub uses_wave_tasks: bool,
-    pub top: StrId,
+    pub top: GlobalStrId,
     pub modules: Vec<Module>,
     /// Hierarchical instance path -> module name (`ssys_instmap` analogue).
-    pub instance_map: Vec<(StrId, StrId)>,
+    pub instance_map: Vec<(GlobalStrId, GlobalStrId)>,
     /// Per-(clock, edge) interleavings of instance segments — the design
     /// schedule, exported hierarchically (see `schedule` module docs).
     pub compositions: Vec<Composition>,
     /// Foreign (BDPI) function signatures used anywhere in the design.
     pub foreign_funcs: Vec<ForeignFunc>,
-    pub default_clock: Option<StrId>,
-    pub default_reset: Option<StrId>,
+    pub default_clock: Option<GlobalStrId>,
+    pub default_reset: Option<GlobalStrId>,
     /// bsc was invoked with -keep-fires: CAN_FIRE/WILL_FIRE defs and
     /// method ports are never demoted to stack locals, so they all get
     /// VCD variables (SimCOpt shouldMove's cfwfOkToMove/portOkToMove).
@@ -227,7 +291,7 @@ pub struct Design {
 /// One synthesized module (one `.ba` / one `SimPackage`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
-    pub name: StrId,
+    pub name: GlobalStrId,
     /// name -> index over `defs` and `methods`, so a reference resolves
     /// without a scan.  Read them through `def`/`def_idx`/`method_idx`.
     /// Derived, not serialized: the decode paths build them.
@@ -309,9 +373,9 @@ pub struct Instance {
     pub args: Vec<Expr>,
     /// Pairs (a, b) of methods where a must execute before b within one
     /// atomic action — the `sSB` relation (`MethodOrderMap`).
-    pub method_order: Vec<(StrId, StrId)>,
+    pub method_order: Vec<(MethRef, MethRef)>,
     /// Method name -> number of used ports (multi-ported methods).
-    pub port_counts: Vec<(StrId, u32)>,
+    pub port_counts: Vec<(MethRef, u32)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -319,7 +383,7 @@ pub enum InstanceKind {
     /// A primitive with codegen support (possibly fully inlined).
     Prim(Primitive),
     /// Another user module in this design.
-    Module(StrId),
+    Module(GlobalStrId),
 }
 
 /// Primitives the backend knows how to lay out or call into trs-rt.
@@ -344,7 +408,7 @@ pub enum Primitive {
     SyncReg { width: u32, stages: u8 },
     SyncFifo { width: u32, depth: u32 },
     /// Escape hatch during bring-up: named primitive handled by trs-rt.
-    Other { name: StrId },
+    Other { name: GlobalStrId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -412,7 +476,7 @@ pub struct Method {
     pub always_enabled: bool,
     /// The sibling method carrying this one's ready signal, when the
     /// module exports one; None = constant ready.
-    pub rdy: Option<StrId>,
+    pub rdy: Option<MethRef>,
     /// The def this method's function writes to record that it fired
     /// (cvtIFace wf_stmts).  Action and ActionValue methods only.
     pub will_fire: Option<StrId>,
@@ -435,6 +499,19 @@ impl Module {
 
     /// Index of a method by name, or None if this module has no such
     /// method.
+    /// The method a reference names in this module, with its position.
+    /// A primitive's methods are not listed here, so a reference to one
+    /// resolves to nothing.
+    pub fn meth(&self, r: MethRef) -> Option<(usize, &Method)> {
+        match r {
+            MethRef::User(i) => {
+                let i = i as usize;
+                self.methods.get(i).map(|m| (i, m))
+            }
+            MethRef::Prim(_) => None,
+        }
+    }
+
     pub fn method_idx(&self, name: StrId) -> Option<usize> {
         self.method_ix.get(&name).copied()
     }
@@ -451,8 +528,8 @@ pub enum MethodKind {
 /// exactly (DESIGN.md §5.4).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForeignFunc {
-    pub name: StrId,
-    pub c_name: StrId,
+    pub name: GlobalStrId,
+    pub c_name: GlobalStrId,
     pub ret: ForeignType,
     pub args: Vec<ForeignType>,
 }
@@ -630,7 +707,7 @@ impl Design {
             .strings
             .iter()
             .enumerate()
-            .map(|(i, s)| (s.clone(), i as StrId))
+            .map(|(i, s)| (s.clone(), ModuleStrId(i as u32)))
             .collect();
         for m in &mut self.modules {
             m.def_ix =
@@ -654,13 +731,62 @@ impl Design {
         out
     }
 
-    pub fn name(&self, id: StrId) -> &str {
-        &self.strings[id as usize]
+    /// The display name of a module-scoped id.  The parameter type is
+    /// the guard: a global id cannot be read against a module's table.
+    pub fn name(&self, id: ModuleStrId) -> &str {
+        &self.strings[id.idx()]
+    }
+
+    /// The display name a method reference stands for.  A primitive's
+    /// method is named in the shared vocabulary; a user module's is a
+    /// position in that module's own method list, so reading it takes
+    /// the module.
+    pub fn meth_name(&self, callee: usize, r: MethRef) -> &str {
+        match r {
+            MethRef::Prim(g) => self.global_name(g),
+            MethRef::User(i) => {
+                self.name(self.modules[callee].methods[i as usize].name)
+            }
+        }
+    }
+
+    /// The display name of a link-level id: a module type, a primitive,
+    /// a foreign symbol, or a name the design as a whole owns.
+    pub fn global_name(&self, id: GlobalStrId) -> &str {
+        &self.strings[id.idx()]
     }
 }
 
 #[cfg(test)]
 mod tests {
+    /// Both id spaces ride the wire as bare integers: the .bir is CBOR
+    /// and the snapshot is bincode, and an id occupies the same bytes in
+    /// each as the integer it wraps.
+    #[test]
+    fn ids_encode_as_bare_integers() {
+        for n in [0u32, 7, 0x8000_0000, u32::MAX] {
+            let mut plain = Vec::new();
+            ciborium::into_writer(&n, &mut plain).unwrap();
+            let mut m = Vec::new();
+            ciborium::into_writer(&ModuleStrId(n), &mut m).unwrap();
+            let mut g = Vec::new();
+            ciborium::into_writer(&GlobalStrId(n), &mut g).unwrap();
+            assert_eq!(plain, m, "cbor ModuleStrId({n})");
+            assert_eq!(plain, g, "cbor GlobalStrId({n})");
+
+            assert_eq!(
+                bincode::serialize(&n).unwrap(),
+                bincode::serialize(&ModuleStrId(n)).unwrap(),
+                "bincode ModuleStrId({n})"
+            );
+            assert_eq!(
+                bincode::serialize(&n).unwrap(),
+                bincode::serialize(&GlobalStrId(n)).unwrap(),
+                "bincode GlobalStrId({n})"
+            );
+        }
+    }
+
     use super::*;
 
     fn tiny_design() -> Design {
@@ -668,9 +794,9 @@ mod tests {
             strings: vec!["mkTop".into()],
             str_ids: HashMap::new(),
             uses_wave_tasks: false,
-            top: 0,
+            top: GlobalStrId(0),
             modules: vec![Module {
-                name: 0,
+                name: GlobalStrId(0),
                 def_ix: HashMap::new(),
                 method_ix: HashMap::new(),
                 content_hash: [0; 32],
@@ -700,7 +826,7 @@ mod tests {
         let d = tiny_design();
         let bytes = d.encode();
         let d2 = Design::decode(&bytes).unwrap();
-        assert_eq!(d2.name(d2.top), "mkTop");
+        assert_eq!(d2.global_name(d2.top), "mkTop");
         assert_eq!(d2.modules.len(), 1);
     }
 

--- a/src/trs/crates/trs-ir/src/schedule.rs
+++ b/src/trs/crates/trs-ir/src/schedule.rs
@@ -31,7 +31,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::expr::Expr;
-use crate::StrId;
+use crate::{GlobalStrId, StrId};
 
 /// `Sched r` computes r's fire conditions; `Exec r` runs r's body.
 /// (`SchedNode`, `AScheduleInfo.hs:218`.)
@@ -99,7 +99,7 @@ pub struct QualRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Composition {
     /// Interned name of this composition's canonical clock oscillator.
-    pub clock: StrId,
+    pub clock: GlobalStrId,
     pub posedge: bool,
     /// Ordered (instance, segment) references.  Each instance's segments
     /// appear in order; runs are maximized so the common case is one entry

--- a/src/trs/crates/trs-ir/src/verify.rs
+++ b/src/trs/crates/trs-ir/src/verify.rs
@@ -2,11 +2,11 @@
 //! only known rules, widths are sane.  This is the guard that makes BIR a
 //! contract rather than a hope (DESIGN.md §3.1).
 
-use crate::{Design, StrId};
+use crate::{Design, GlobalStrId};
 
 #[derive(Debug)]
 pub enum VerifyError {
-    BadStringRef { id: StrId, len: usize },
+    BadStringRef { at: usize, len: usize },
     NoTopModule { top: String },
     DuplicateModule { name: String },
 }
@@ -14,8 +14,8 @@ pub enum VerifyError {
 impl std::fmt::Display for VerifyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VerifyError::BadStringRef { id, len } => {
-                write!(f, "string id {id} out of range (table has {len} entries)")
+            VerifyError::BadStringRef { at, len } => {
+                write!(f, "string id {at} out of range (table has {len} entries)")
             }
             VerifyError::NoTopModule { top } => {
                 write!(f, "top module {top:?} not present in module list")
@@ -31,11 +31,11 @@ impl std::error::Error for VerifyError {}
 
 pub fn verify(design: &Design) -> Result<(), VerifyError> {
     let nstrings = design.strings.len();
-    let check = |id: StrId| -> Result<(), VerifyError> {
-        if (id as usize) < nstrings {
+    let check = |id: GlobalStrId| -> Result<(), VerifyError> {
+        if id.idx() < nstrings {
             Ok(())
         } else {
-            Err(VerifyError::BadStringRef { id, len: nstrings })
+            Err(VerifyError::BadStringRef { at: id.idx(), len: nstrings })
         }
     };
 
@@ -45,13 +45,13 @@ pub fn verify(design: &Design) -> Result<(), VerifyError> {
         check(m.name)?;
         if !seen.insert(m.name) {
             return Err(VerifyError::DuplicateModule {
-                name: design.strings[m.name as usize].clone(),
+                name: design.global_name(m.name).to_string(),
             });
         }
     }
     if !seen.contains(&design.top) {
         return Err(VerifyError::NoTopModule {
-            top: design.strings[design.top as usize].clone(),
+            top: design.global_name(design.top).to_string(),
         });
     }
     // TODO(P0): resolve every Def/Port/Param/instance/method reference in

--- a/src/trs/docs/FRAGMENT-IDS.md
+++ b/src/trs/docs/FRAGMENT-IDS.md
@@ -1,0 +1,134 @@
+# Fragment identifiers
+
+Per-module export means producing a module's BIR from that module's
+`.ba` and its children's interface summaries, with no view of the design
+it will be linked into.  A fragment produced that way is cacheable: the
+same module source yields the same bytes whatever design instantiates
+it, and a design that changes one module relinks rather than re-exports.
+
+Every identifier a fragment writes has to mean something without a view
+of the whole design.  This note describes the identifier model that
+makes that true — the scopes, what crosses between them, and the
+invariants the hashes depend on.
+
+## Three scopes
+
+**Module scope — `ModuleStrId`.**  Names meaningful against one module
+type: its defs, rules, methods, ports, clock domains, resets, and the
+names it gives its own instances.  A fragment carries the table these
+index, so they can be renumbered freely within it and mean the same
+thing after the fragment moves.  This is the default: `StrId` is an
+alias for `ModuleStrId`, so an identifier is module-scoped unless it
+says otherwise.
+
+**Link scope — `GlobalStrId`.**  The vocabulary fragments share, and the
+only names one fragment can write for another to read: module type
+names, instance paths, and the primitive method names every design
+agrees on.  A fragment cannot mint a link-scoped name for something
+design-specific, because it does not know where it will be instantiated
+or under what path; the link assembles this table from what the
+fragments declare.
+
+**Runtime scope — `DynStrId`.**  Strings that exist only while a design
+runs, in an arena the interpreter owns: the results of string-producing
+expressions, `$sformat` output, values read back from BDPI.  These have
+no place in a fragment, because they are not properties of the module.
+A `StrRef` is the tagged union of the two spaces a running program
+reaches for — a static id into the design's table, or a dynamic id into
+the arena.  It packs into one word (`DYN_TAG` distinguishing the two)
+so a string-valued `Value` stays a scalar.
+
+Distinct types rather than a bare `u32` alias, because the failure they
+prevent is a silent wrong answer, not a crash: name lookup returns the
+first match, so a rule name repeated across modules resolves to
+whichever module interned it first.  A misuse is now a compile error.
+
+## What crosses a fragment boundary
+
+A reference that leaves a fragment names a **position** in the target,
+not a name to be resolved against it.  A position is meaningful the
+moment the callee's shape is known, needs no shared string space, and
+cannot silently bind to the wrong entry.
+
+**`MethRef`** is the shape this takes for method calls, and it is
+split because the two cases genuinely differ.  `MethRef::User(u32)` is
+an index into the callee's method list — a user module's methods are its
+own, so a call carries no identifier out of the callee's scope at all.
+`MethRef::Prim(GlobalStrId)` names a primitive's method, which is
+vocabulary every design shares and so belongs in the link table.
+
+**`Instance::kind = Module(GlobalStrId)`** is the one identifier class
+that stays a name.  Type names are how fragments refer to each other, so
+they are the link-scoped vocabulary by definition, and they are the edge
+along which the interface hash propagates.
+
+**`Instance::method_order` and `port_counts`** describe the *child's*
+methods from inside the parent.  The parent cannot express these in its
+own scope, and with positions it does not need to: they are the child's
+method list read positionally.
+
+**`Composition`, `QualifiedTick`, `SchedAlt::guard`, `cross_inhibits`.**
+These are the design superstructure holding module-scoped content — an
+instance path (link-scoped) beside a segment, domain, or rule index
+(module-scoped), and in `guard`'s case a whole `Expr` written in the
+scope of the module at `guard_inst`.  They are read by resolving the
+instance first and then reading the module-scoped part against the
+module that instance points to; the pairing is what makes them
+readable, so neither half may be separated from the other.
+
+## Generated names carry ids, not spellings
+
+A name the compiler generates — an enable signal, a ready signal, a
+method's argument port — is recorded once, at the point of generation,
+as an id.  Everything downstream takes the id.  No consumer reconstructs
+the name from a convention, and no consumer strips a prefix back off.
+
+`Method::en` holds the enable port's id, `Method::rdy` a `MethRef` to
+the ready method, and `Port::base` the argument's own name with the
+`<method>_` qualifier already removed by the exporter.
+
+Two reasons this matters more than it looks.  A reconstructed name is a
+lookup by string in a space that is about to become per-module, so every
+such site is a link-time scan that has to be deleted before the tables
+can split.  And the convention is duplicated at every site that spells
+it, so it is only as stable as the least-examined copy.
+
+## The fragment's table is hashed content
+
+`Module::content_hash` is the field a fragment cache keys on.  It is
+reserved in the format and written as zeros; what it will cover is the
+fragment's own bytes, and those include its string table, so the table
+is part of what is hashed.  Two rules follow, and they constrain the
+exporter now rather than when the hash is filled.
+
+**Interning is canonical.**  The exporter interns in a deterministic
+order derived from the module, not in encounter order, or the same
+module hashes differently depending on which fields the encoder happened
+to walk first.
+
+**The hash covers names, not what they name.**  A `$readmemh` filename
+is content: change only which file a module reads and the hash must
+differ, or a cached fragment loads the wrong data at runtime.  The
+*contents* of that file are not part of the fragment.
+
+A second hash over a module together with its children is what makes a
+change anywhere below a module invalidate it while an unrelated
+sibling's change does not.  It composes from `content_hash`, so it
+waits on the same thing.
+
+## Where this stands
+
+The scopes are types and the boundary-crossing references carry
+positions.  One table still backs both `ModuleStrId` and `GlobalStrId`,
+so the distinction is enforced by the compiler but not yet reflected in
+the format: splitting `Design::strings` into a link-level table plus one
+table per fragment is the next break, and it is what `content_hash`
+waits on.  Hashing a table that embeds design-global positions would
+give a hash that differs per design, so the cache would serve relink and
+not reuse across designs — which is most of the reason to have one.
+
+Instance paths are still dotted strings.  Replacing them with structured
+references — an instance index against a parent — is the remaining
+link-scoped name that a fragment cannot mint and therefore the remaining
+obstacle to a fragment that names its children without knowing the
+design.

--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -39,13 +39,13 @@ import qualified Codec.CBOR.Encoding as C
 import qualified Codec.CBOR.Write as CW
 
 import Data.Char (isDigit)
-import Data.List (foldl', nub, sortBy)
+import Data.List (foldl', nub, sortBy, stripPrefix)
 import Data.Maybe (mapMaybe, isJust)
 
 import ErrorUtil (internalError)
 import Util (stableOrdNub)
 import Id (Id, getIdBaseString, getIdQualString, isSignedId,
-           mkIdCanFire, mkIdWillFire, mkRdyId, cmpIdByName)
+           mkEnableId, mkIdCanFire, mkIdWillFire, mkRdyId, cmpIdByName)
 import IntLit (IntLit(..))
 import PPrint (ppReadable)
 import Prim (PrimOp(..))
@@ -66,7 +66,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 5
+birVersion = 6
 
 -- ===============
 -- String interning
@@ -766,7 +766,18 @@ encModule pkgNames msi symSet pkg = do
     nameId <- idE (sp_name pkg)
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
-    insEnc <- concat <$> mapM encInput (sp_inputs pkg)
+    insEnc0 <- concat <$> mapM encInput (sp_inputs pkg)
+    -- A method with actions is driven by an enable port unless it is
+    -- always enabled, in which case bsc ties it high and drops it.  The
+    -- port is the module's, so the module lists it: the reader reaches a
+    -- method's enable through the id on the method, never by spelling
+    -- the name again.
+    enInsEnc <- sequence
+      [ do n <- idE (mkEnableId (aif_name f))
+           return (encPortRaw n 1 "MethodEnable")
+      | f <- sp_interface pkg
+      , hasEnablePort pkg f ]
+    let insEnc = insEnc0 ++ enInsEnc
     -- construction order matters for load-time output (RegFileLoad gap
     -- warnings): match the C++ backend's alphabetization (raw_avis)
     let avis = sortBy (\a b -> avi_vname a `cmpIdByName` avi_vname b)
@@ -968,16 +979,34 @@ encInput (AAI_Inout {}) =
     internalError "SimExportIR.encInput: Inout not supported by Bluesim"
 
 encPort :: (Id, AType) -> String -> EncM C.Encoding
-encPort (i, t) kind = do
+encPort it kind = encPortOf it kind Nothing
+
+-- | A port, with the bare name of the method argument it carries when it
+-- is one.  bsc composes an argument's port name as <method>_<arg>; this
+-- is the one place that knows it, so the reader never takes the name
+-- apart to find the argument.
+encPortOf :: (Id, AType) -> String -> Maybe Id -> EncM C.Encoding
+encPortOf (i, t) kind mmeth = do
     n <- idE i
-    return $ encPortRaw n (aTypeWidth t) kind
+    baseEnc <- traverse strE (mmeth >>= argBaseName i)
+    return $ encPortRawBase n (aTypeWidth t) kind (encMaybe id baseEnc)
+
+-- | The argument's own name: the port name with its method's prefix off.
+argBaseName :: Id -> Id -> Maybe String
+argBaseName arg meth =
+    stripPrefix (getIdBaseString meth ++ "_") (getIdBaseString arg)
 
 encPortRaw :: C.Encoding -> Word32 -> String -> C.Encoding
 encPortRaw nameEnc w kind =
+    encPortRawBase nameEnc w kind (encMaybe id Nothing)
+
+encPortRawBase :: C.Encoding -> Word32 -> String -> C.Encoding -> C.Encoding
+encPortRawBase nameEnc w kind baseEnc =
     encStruct
       [ ("name", nameEnc)
       , ("width", encW32 w)
       , ("kind", encUnitVariant kind)
+      , ("base", baseEnc)
       ]
 
 encInstance :: S.Set String -> MethodOrderMap -> AVInst -> EncM C.Encoding
@@ -1214,7 +1243,8 @@ encMethodStructAV :: Siblings -> SimPackage -> Id -> [AInput] -> Maybe APred
 encMethodStructAV sibs pkg name inputs mpred body retdef props = do
     nameId <- idE name
     (rdyEnc, wfEnc) <- encSiblings sibs name True
-    argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
+    enEnc <- encEnableId pkg name True
+    argsEnc <- mapM (\it -> encPortOf it "MethodArg" (Just name)) inputs
     readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
                         (bodyStmts pkg name props (Just retdef) body)
@@ -1234,7 +1264,27 @@ encMethodStructAV sibs pkg name inputs mpred body retdef props = do
       , ("always_enabled", encBool (isAlwaysEn (sp_pps pkg) name))
       , ("rdy", rdyEnc)
       , ("will_fire", wfEnc)
+      , ("en", enEnc)
       ]
+
+-- | The id of a method's enable port, or nothing where it has none.
+-- Must agree with `hasEnablePort`, which decides whether the module
+-- lists the port at all.
+encEnableId :: SimPackage -> Id -> Bool -> EncM C.Encoding
+encEnableId pkg name hasActions = do
+    e <- traverse idE (if hasActions && not (isAlwaysEn (sp_pps pkg) name)
+                       then Just (mkEnableId name)
+                       else Nothing)
+    return (encMaybe id e)
+
+-- | Whether a method is driven by an enable port: it takes actions, and
+-- is not always enabled -- bsc ties those high and emits no port.
+hasEnablePort :: SimPackage -> AIFace -> Bool
+hasEnablePort pkg f = case f of
+    AIAction {}      -> notAlways
+    AIActionValue {} -> notAlways
+    _                -> False
+  where notAlways = not (isAlwaysEn (sp_pps pkg) (aif_name f))
 
 encMethodStruct :: Siblings -> SimPackage -> Id -> String -> [AInput]
                 -> Maybe APred -> [AAction] -> Maybe (AType, AExpr)
@@ -1242,7 +1292,8 @@ encMethodStruct :: Siblings -> SimPackage -> Id -> String -> [AInput]
 encMethodStruct sibs pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
     (rdyEnc, wfEnc) <- encSiblings sibs name (kind /= "Value")
-    argsEnc <- mapM (\it -> encPort it "MethodArg") inputs
+    enEnc <- encEnableId pkg name (kind /= "Value")
+    argsEnc <- mapM (\it -> encPortOf it "MethodArg" (Just name)) inputs
     readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
     bodyEnc <- encStmts (mkSignedOracle pkg)
                         (bodyStmts pkg name props Nothing body)
@@ -1263,6 +1314,7 @@ encMethodStruct sibs pkg name kind inputs mpred body mresult props = do
       , ("always_enabled", encBool ae)
       , ("rdy", rdyEnc)
       , ("will_fire", wfEnc)
+      , ("en", enEnc)
       ]
 
 -- ===============

--- a/src/trs/trs-bir/SimExportIR.hs
+++ b/src/trs/trs-bir/SimExportIR.hs
@@ -31,6 +31,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
+import Control.Monad.Reader (ReaderT, runReaderT, ask, local)
 import Control.Monad.State.Strict (State, runState, gets, modify)
 import Data.Bits (shiftR, (.&.))
 import Data.Word (Word32)
@@ -66,7 +67,7 @@ import SimPackage
 -- | Bumped on any change to the encoded shape; must equal BIR_VERSION in
 -- trs-ir/src/lib.rs.
 birVersion :: Word32
-birVersion = 6
+birVersion = 7
 
 -- ===============
 -- String interning
@@ -78,7 +79,36 @@ birVersion = 6
 
 data StrTable = StrTable !(M.Map String Word32) ![String] !Word32
 
-type EncM = State StrTable
+-- | What the encoding needs beyond the string table: which module each
+-- instance of the package being encoded is of, and where each module's
+-- methods sit in its own method list.  A call on a submodule names a
+-- position in the callee, so it takes both.
+data EncEnv = EncEnv
+    { envMethIx :: M.Map String (M.Map String Int)
+    , envInstMod :: M.Map String String
+    }
+
+type EncM = ReaderT EncEnv (State StrTable)
+
+-- | The reference a call carries: a position in the callee for a user
+-- module, and the shared name for a primitive, whose methods are a
+-- vocabulary rather than a list.
+encMethRef :: Id -> Id -> EncM C.Encoding
+encMethRef obj meth = do
+    env <- ask
+    case M.lookup (getIdBaseString obj) (envInstMod env) of
+      Just modName -> encMethRefIn modName meth
+      Nothing      -> encVariant "Prim" <$> idE meth
+
+-- | The same, where the callee's module is already known.
+encMethRefIn :: String -> Id -> EncM C.Encoding
+encMethRefIn modName meth = do
+    env <- ask
+    let ix = M.lookup modName (envMethIx env)
+               >>= M.lookup (getIdBaseString meth)
+    case ix of
+      Just i  -> return $ encVariant "User" (encW32 (fromIntegral i))
+      Nothing -> encVariant "Prim" <$> idE meth
 
 emptyStrTable :: StrTable
 emptyStrTable = StrTable M.empty [] 0
@@ -213,7 +243,17 @@ encDesign keepF symMap ssys =
             , ("uses_wave_tasks", encBool (designUsesWaveTasks pkgs))
             ]
 
-        (fields, finalTbl) = runState action emptyStrTable
+        -- a method's position in the list its module emits: encMethod
+        -- yields one entry per value/action/actionvalue face, in
+        -- interface order, and nothing for clocks, resets and inouts
+        methIx = M.fromList
+          [ ( getIdBaseString (sp_name p)
+            , M.fromList (zip [ getIdBaseString (aif_name f)
+                              | f <- sp_interface p, isMethodIfc f ]
+                              [0 ..]) )
+          | p <- pkgs ]
+        env0 = EncEnv { envMethIx = methIx, envInstMod = M.empty }
+        (fields, finalTbl) = runState (runReaderT action env0) emptyStrTable
         strsEnc = encList (map encStr (tableStrings finalTbl))
         fields' = [ (k, if k == "strings" then strsEnc else v)
                   | (k, v) <- fields ]
@@ -762,7 +802,10 @@ oscName clk = case aclock_osc clk of
 
 encModule :: S.Set String -> ModSchedInfo -> S.Set AId -> SimPackage
           -> EncM C.Encoding
-encModule pkgNames msi symSet pkg = do
+encModule pkgNames msi symSet pkg =
+  local (\e -> e { envInstMod = instMods }) $ do
+    -- which module each of this package's instances is of, so a call on
+    -- one resolves to a position in that module
     nameId <- idE (sp_name pkg)
     domsEnc <- mapM encClockDomain (sp_clock_domains pkg)
     rstsEnc <- mapM encReset (sp_reset_list pkg)
@@ -879,6 +922,11 @@ encModule pkgNames msi symSet pkg = do
       , ("methods", encList methodsEnc)
       , ("schedule", schedEnc)
       ]
+  where
+    instMods = M.fromList
+      [ ( getIdBaseString (avi_vname avi)
+        , getVNameString (vName (avi_vmi avi)) )
+      | avi <- M.elems (sp_state_instances pkg) ]
 
 encSchedule :: ModSchedInfo -> SimPackage -> EncM C.Encoding
 encSchedule msi pkg = do
@@ -1030,8 +1078,9 @@ encInstance pkgNames mom avi = do
     let morder = sortBy (\(a, b) (c, d) ->
                            (a `cmpIdByName` c) <> (b `cmpIdByName` d))
                         (S.toList (M.findWithDefault S.empty (avi_vname avi) mom))
-    morderEnc <- mapM (\(a, b) -> encPair <$> idE a <*> idE b) morder
-    portsEnc <- mapM (\(m, n) -> encPair <$> idE m
+    morderEnc <- mapM (\(a, b) -> encPair <$> encMethRefIn modName a
+                                            <*> encMethRefIn modName b) morder
+    portsEnc <- mapM (\(m, n) -> encPair <$> encMethRefIn modName m
                                          <*> pure (encW32 (fromIntegral n)))
                      (avi_iarray avi)
     return $ encStruct
@@ -1192,11 +1241,14 @@ data Siblings = Siblings { sibIfc :: S.Set String, sibDefs :: S.Set String }
 -- The sibling RDY method and WILL_FIRE def of a method, each named only
 -- when the module actually has one.  Only a method with actions has a
 -- WILL_FIRE def (cvtIFace wf_stmts).
-encSiblings :: Siblings -> Id -> Bool -> EncM (C.Encoding, C.Encoding)
-encSiblings sibs name hasActions = do
+encSiblings :: Siblings -> String -> Id -> Bool
+            -> EncM (C.Encoding, C.Encoding)
+encSiblings sibs modName name hasActions = do
     let present set i =
             if getIdBaseString i `S.member` set then Just i else Nothing
-    rdyEnc <- traverse idE (present (sibIfc sibs) (mkRdyId name))
+    -- the ready signal is a sibling METHOD, so it is named the way any
+    -- call on this module names one
+    rdyEnc <- traverse (encMethRefIn modName) (present (sibIfc sibs) (mkRdyId name))
     wfEnc <- traverse idE
                (if hasActions
                 then present (sibDefs sibs) (mkIdWillFire name)
@@ -1242,7 +1294,7 @@ encMethodStructAV :: Siblings -> SimPackage -> Id -> [AInput] -> Maybe APred
                   -> [AAction] -> ADef -> WireProps -> EncM C.Encoding
 encMethodStructAV sibs pkg name inputs mpred body retdef props = do
     nameId <- idE name
-    (rdyEnc, wfEnc) <- encSiblings sibs name True
+    (rdyEnc, wfEnc) <- encSiblings sibs (getIdBaseString (sp_name pkg)) name True
     enEnc <- encEnableId pkg name True
     argsEnc <- mapM (\it -> encPortOf it "MethodArg" (Just name)) inputs
     readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
@@ -1277,6 +1329,15 @@ encEnableId pkg name hasActions = do
                        else Nothing)
     return (encMaybe id e)
 
+-- | The interface faces that become methods, in the order encMethod
+-- emits them.  Clocks, resets and inouts yield nothing.
+isMethodIfc :: AIFace -> Bool
+isMethodIfc f = case f of
+    AIDef {}         -> True
+    AIAction {}      -> True
+    AIActionValue {} -> True
+    _                -> False
+
 -- | Whether a method is driven by an enable port: it takes actions, and
 -- is not always enabled -- bsc ties those high and emits no port.
 hasEnablePort :: SimPackage -> AIFace -> Bool
@@ -1291,7 +1352,8 @@ encMethodStruct :: Siblings -> SimPackage -> Id -> String -> [AInput]
                 -> WireProps -> EncM C.Encoding
 encMethodStruct sibs pkg name kind inputs mpred body mresult props = do
     nameId <- idE name
-    (rdyEnc, wfEnc) <- encSiblings sibs name (kind /= "Value")
+    (rdyEnc, wfEnc) <-
+        encSiblings sibs (getIdBaseString (sp_name pkg)) name (kind /= "Value")
     enEnc <- encEnableId pkg name (kind /= "Value")
     argsEnc <- mapM (\it -> encPortOf it "MethodArg" (Just name)) inputs
     readyEnc <- traverse (encExpr . resolveReady sibs name) mpred
@@ -1362,7 +1424,7 @@ encExpr (ASParam _ i) = encVariant "Param" <$> idE i
 encExpr (ASStr _ _ s) = encVariant "Str" <$> strE s
 encExpr (AMethCall t obj meth args) = do
     o <- idE obj
-    m <- idE meth
+    m <- encMethRef obj meth
     -- one value PER PORT, matching the callee's flattened (concat
     -- inputs) method-input defs: split-port args (ATuple / tuple-typed
     -- exprs) expand exactly as the C++ backend's call sites do
@@ -1376,7 +1438,7 @@ encExpr (AMethCall t obj meth args) = do
       ]
 encExpr (AMethValue t obj meth) = do
     o <- idE obj
-    m <- idE meth
+    m <- encMethRef obj meth
     return $ encVariant "MethValue" $ encStruct
       [ ("width", encW32 (aTypeWidth t))
       , ("instance", o)
@@ -1523,7 +1585,7 @@ primOpName op = internalError ("SimExportIR.primOpName: " ++ show op)
 encAction :: SignedOracle -> AAction -> EncM C.Encoding
 encAction _ (ACall obj meth (cond : args)) = do
     o <- idE obj
-    m <- idE meth
+    m <- encMethRef obj meth
     condEnc <- encExpr cond
     -- per-port arg expansion: see encExpr (AMethCall ...)
     argsEnc <- mapM encExpr (concatMap argInputPorts args)


### PR DESCRIPTION
Groundwork for per-module `.bir` export: make every identifier a
fragment writes mean something without a view of the design it links
into. Three commits, each building and passing the suites on its own.

**`trs: describe the fragment identifier model`** — a design note
covering the three scopes an identifier can live in, what a reference
carries when it leaves a fragment, how a generated name reaches its
consumers, and the invariants `content_hash` will rest on.

**`trs: give generated names ids at the point of generation`** — a name
bsc composes from a convention (`EN_<method>`, `<method>_<arg>`) was
recomposed by every consumer that wanted the thing it named, and
resolved by scanning the string table. The enable becomes a
`MethodEnable` input port with its id on `Method::en`, and an
argument's own name goes on `Port::base` with the qualifying prefix
already off. The last name-scan over the string table goes with them.

**`trs: scope fragment identifiers to the table that defines them`** —
`ModuleStrId` names something inside one module and travels with its
fragment; `GlobalStrId` names the vocabulary fragments share;
`DynStrId` names a string the arena makes at run time, and `StrRef` is
the tagged word a running program carries when it could be either.
References out of a fragment carry positions rather than names:
`MethRef::User` indexes the callee's method list, and only a
primitive's methods stay named, as `MethRef::Prim`.

One table still backs both `ModuleStrId` and `GlobalStrId`, so the
distinction is enforced by the compiler but not yet reflected in the
format. Splitting `Design::strings` is the next break, and it is what
`content_hash` waits on.

`BIR_VERSION` steps 5 -> 6 -> 7, each schema-breaking commit bumping
the Rust and Haskell sides together.

## Testing

Each of the two code commits was built (bsc + bluesim + trs) and run
standalone, as was the tip:

| suite | result |
| --- | --- |
| `tests/regress` | 35 pass, 0 fail |
| `tests/vcd` | 12 pass, 0 fail |
| `tests/interactive` | 35 pass, 0 fail |